### PR TITLE
chore: 저장소 자동화 설정을 이관

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+/scripts/tdd-guard/ @rhsiddlsidhd
+/.claude/settings.json @rhsiddlsidhd
+/.codex/hooks.json @rhsiddlsidhd
+/tdd-exceptions.json @rhsiddlsidhd
+/.github/workflows/tdd.yml @rhsiddlsidhd
+/.github/workflows/portone-smoke.yml @rhsiddlsidhd

--- a/.github/workflows/full-mutation.yml
+++ b/.github/workflows/full-mutation.yml
@@ -1,0 +1,63 @@
+name: Weekly Full Mutation
+
+on:
+  schedule:
+    # Saturday 06:00 Asia/Seoul (Friday 21:00 UTC)
+    - cron: "0 21 * * 5"
+  workflow_dispatch:
+
+concurrency:
+  group: full-mutation-dev
+  cancel-in-progress: false
+
+jobs:
+  full-mutation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      JWT_SECRET: mutation-ci-jwt-secret-at-least-thirty-two-characters
+      ENTRY_JWT_SECRET: mutation-ci-entry-secret-at-least-thirty-two-characters
+      PORTONE_API_SECRET: test-secret
+      NEXT_PUBLIC_PORTONE_STORE_ID: store-ci
+      NEXT_PUBLIC_PORTONE_CHANNEL_KEY: channel-ci
+      MONGOMS_DOWNLOAD_DIR: ~/.cache/mongodb-binaries
+      STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+      STRYKER_REPORT_DIR: reports/mutation/full
+      STRYKER_INCREMENTAL_FILE: .mutation-state/incremental.json
+      STRYKER_DASHBOARD_VERSION: dev
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: dev
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-8.2.6-${{ runner.os }}
+      - uses: actions/cache/restore@v4
+        with:
+          path: .mutation-state/incremental.json
+          key: full-mutation-${{ runner.os }}-${{ hashFiles('package-lock.json', 'stryker.config.mjs') }}-${{ github.run_id }}
+          restore-keys: |
+            full-mutation-${{ runner.os }}-${{ hashFiles('package-lock.json', 'stryker.config.mjs') }}-
+      - run: npm ci
+      - name: Run full mutation
+        run: npm run test:mutation:full
+      - name: Save incremental baseline
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: .mutation-state/incremental.json
+          key: full-mutation-${{ runner.os }}-${{ hashFiles('package-lock.json', 'stryker.config.mjs') }}-${{ github.run_id }}
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: full-mutation-${{ github.run_id }}
+          path: reports/mutation/full
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/portone-smoke.yml
+++ b/.github/workflows/portone-smoke.yml
@@ -1,0 +1,29 @@
+name: PortOne KG Inicis Manual Smoke
+
+on:
+  workflow_dispatch:
+
+jobs:
+  portone-manual-smoke:
+    runs-on: [self-hosted, linux, x64, portone-smoke]
+    timeout-minutes: 25
+    environment: portone-test
+    env:
+      PORTONE_STORE_ID: ${{ secrets.PORTONE_STORE_ID }}
+      PORTONE_CHANNEL_KEY: ${{ secrets.PORTONE_INICIS_V2_CHANNEL_KEY }}
+      PORTONE_API_SECRET: ${{ secrets.PORTONE_V2_API_SECRET }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - name: Verify display and PortOne secrets
+        run: |
+          test -n "$DISPLAY"
+          test -n "$PORTONE_STORE_ID"
+          test -n "$PORTONE_CHANNEL_KEY"
+          test -n "$PORTONE_API_SECRET"
+      - run: npm run test:e2e:portone

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -1,0 +1,155 @@
+name: TDD Guard
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: tdd-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JWT_SECRET: tdd-ci-jwt-secret-at-least-thirty-two-characters
+  ENTRY_JWT_SECRET: tdd-ci-entry-secret-at-least-thirty-two-characters
+  PORTONE_API_SECRET: test-secret
+  NEXT_PUBLIC_PORTONE_STORE_ID: store-ci
+  NEXT_PUBLIC_PORTONE_CHANNEL_KEY: channel-ci
+  BASE_URL: http://127.0.0.1:3100
+  DEPLOYMENT_BASE_URL: http://127.0.0.1:3100
+
+jobs:
+  static:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      MONGOMS_DOWNLOAD_DIR: ~/.cache/mongodb-binaries
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-8.2.6-${{ runner.os }}
+      - run: npm run lint && npm run typecheck && node scripts/ci/build.mjs
+
+  unit-shard:
+    name: unit-${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [server, client-components, client-state, app-admin, app-main, app-api, shared]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - name: Run unit shard
+        run: |
+          echo '| Shard | Files | Tests | Duration |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| --- | ---: | ---: | ---: |' >> "$GITHUB_STEP_SUMMARY"
+          node scripts/test-scope/unit-shards.mjs run '${{ matrix.shard }}'
+
+  unit:
+    if: always()
+    needs: unit-shard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every unit shard
+        run: test '${{ needs.unit-shard.result }}' = 'success'
+
+  integration-client:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm run test:integration:client
+
+  integration-server:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      MONGOMS_DOWNLOAD_DIR: ~/.cache/mongodb-binaries
+      PORTONE_API_SECRET: test-secret
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-8.2.6-${{ runner.os }}
+      - run: npm ci
+      - run: npm run test:integration:server
+
+  e2e-core:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+
+  mutation-changed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MONGOMS_DOWNLOAD_DIR: ~/.cache/mongodb-binaries
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-8.2.6-${{ runner.os }}
+      - run: npm ci
+      - run: npm run test:mutation -- --base origin/dev
+
+  tdd-policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npx vitest run --project guard
+      - run: node scripts/test-scope/unit-shards.mjs verify
+      - run: node scripts/tdd-guard/bin/guard.mjs verify --ci


### PR DESCRIPTION
## Summary
- 모노레포 루트에 있던 tie-knot 전용 CI와 CODEOWNERS를 독립 저장소 구조에 맞게 이관합니다.
- 워크플로의 `tie-knot/` 경로 접두사를 제거해 새 저장소 루트에서 실행되도록 조정합니다.

## Test plan
- `git diff --cached --check` — 통과
- 워크플로 내 `tie-knot/` 경로 참조가 제거되었는지 검토 — 완료