### PR TITLE
ci: main PR에 TDD Guard를 실행한다

### DIFF
--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -1,0 +1,155 @@
+name: TDD Guard
+
+on:
+  pull_request:
+    branches: [dev, main]
+  workflow_dispatch:
+
+concurrency:
+  group: tdd-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JWT_SECRET: tdd-ci-jwt-secret-at-least-thirty-two-characters
+  ENTRY_JWT_SECRET: tdd-ci-entry-secret-at-least-thirty-two-characters
+  PORTONE_API_SECRET: test-secret
+  NEXT_PUBLIC_PORTONE_STORE_ID: store-ci
+  NEXT_PUBLIC_PORTONE_CHANNEL_KEY: channel-ci
+  BASE_URL: http://127.0.0.1:3100
+  DEPLOYMENT_BASE_URL: http://127.0.0.1:3100
+
+jobs:
+  static:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      MONGOMS_DOWNLOAD_DIR: ~/.cache/mongodb-binaries
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-8.2.6-${{ runner.os }}
+      - run: npm run lint && npm run typecheck && node scripts/ci/build.mjs
+
+  unit-shard:
+    name: unit-${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [server, client-components, client-state, app-admin, app-main, app-api, shared]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - name: Run unit shard
+        run: |
+          echo '| Shard | Files | Tests | Duration |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| --- | ---: | ---: | ---: |' >> "$GITHUB_STEP_SUMMARY"
+          node scripts/test-scope/unit-shards.mjs run '${{ matrix.shard }}'
+
+  unit:
+    if: always()
+    needs: unit-shard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every unit shard
+        run: test '${{ needs.unit-shard.result }}' = 'success'
+
+  integration-client:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm run test:integration:client
+
+  integration-server:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      MONGOMS_DOWNLOAD_DIR: ~/.cache/mongodb-binaries
+      PORTONE_API_SECRET: test-secret
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-8.2.6-${{ runner.os }}
+      - run: npm ci
+      - run: npm run test:integration:server
+
+  e2e-core:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+
+  mutation-changed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MONGOMS_DOWNLOAD_DIR: ~/.cache/mongodb-binaries
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-8.2.6-${{ runner.os }}
+      - run: npm ci
+      - run: npm run test:mutation -- --base origin/dev
+
+  tdd-policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npx vitest run --project guard
+      - run: node scripts/test-scope/unit-shards.mjs verify
+      - run: node scripts/tdd-guard/bin/guard.mjs verify --ci


### PR DESCRIPTION
## Summary

- main 대상 PR에서도 TDD Guard가 실행되도록 워크플로를 추가합니다.
- dev와 main 병합 경로가 동일한 CI 검증을 사용하도록 트리거를 구성합니다.

## Test plan

- `git diff --check`
- dev에서 실행된 최근 TDD Guard의 14개 체크 이름 확인
- dev 브랜치 보호 규칙에 14개 체크가 필수로 등록됐는지 GitHub API로 확인

## Notes

- main 보호 규칙의 필수 체크 연결은 이 워크플로가 main에 반영된 뒤 진행합니다.