### PR TITLE
docs: 해결된 문서 참조 항목을 정리

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## 진행 방식
 
-- 작업 항목 1개 = worktree 1개 = branch 1개 (`docs/GIT.md` worktree 규칙)
+- 작업 항목 1개 = worktree 1개 = branch 1개 (`~/.codex/docs/GIT.md` worktree 규칙)
 - 완료 → PR → `dev` merge → 로컬/원격 branch 삭제 → worktree remove
 - 클러스터(파일·주제 겹침)는 같은 worktree에서 순차 처리한다 — 의존성이 없어도 같은 파일이면 병렬로 나누지 않는다
 - TODO.md 갱신은 `docs/todo-section-taxonomy` 브랜치에서만 한다. 작업 브랜치는 "미분류 인박스"에만 append (`AGENTS.md` Git 규칙)
@@ -84,7 +84,7 @@
 
 - [ ] (2026-08-08, TODO 운영 규칙 정립 중 발견) `.git/hooks/commit-msg`의 prefix 검사가 전역 `GIT.md` 택소노미와 어긋남 — 정규식이 `^(feat|fix|docs|refactor|chore|test): ` 라서 ① `docs(agents):` 같은 scope 표기가 거부되고(전역 규칙은 `{prefix}({scope}): {message}`를 허용) ② `perf`/`build`/`ci`/`revert` 4개 prefix가 아예 막힌다. 성능 개선 항목을 커밋하려면 규칙과 훅 중 하나를 반드시 어겨야 하는 상태.
 - [ ] (2026-08-08, 위 커밋 진행 중 발견) `node_modules`에 `embla-carousel-wheel-gestures`가 설치돼 있지 않아 pre-commit 훅의 typecheck가 실패, 모든 커밋이 차단됨 — `package.json:46`에는 선언돼 있어 `npm install`로 해소됨(로컬 환경 드리프트). 재발하면 훅이 "설치 누락"과 "타입 에러"를 구분해 안내할 필요 있음.
-- [ ] (2026-08-09, src/test 구조 정리 중 발견) `src/shared/AGENTS.md` 마지막 줄이 존재하지 않는 파일을 참조 — "server/client/shared 3분할 배경: `docs/ARCHITECTURE.md`"인데 그 파일이 레포에 없다. 문서를 쓰거나 참조를 지우거나 둘 중 하나 필요.
+- [x] (2026-08-12 완료) `src/shared/AGENTS.md`의 server/client/shared 3분할 배경 참조를 현재 문서인 `docs/architecture/README.md`로 수정.
 - [ ] (2026-08-09, #24 수정 후 드러남) 라우트 그룹 경로 컴포넌트 4개가 line coverage 80% 미달 — `ProductEditDialog.tsx`(57.7%), `UpdatePasswordForm.tsx`(61.1%), `CheckoutForm.tsx`(69.0%), `ProductRegistrationForm.tsx`(admin, 72.7%). #24의 tinyglobby 순회 버그가 이 파일들을 커버리지 집계에서 통째로 빼고 있어 그동안 안 보이던 기존 부채다(신규 회귀 아님). CI가 없고 pre-commit은 `test:coverage:diff`(변경 파일 한정)라 당장 막히진 않으며, 해당 파일을 건드리는 커밋에서 걸린다.
 - [ ] (2026-08-09, connect.ts 가드를 연결 시점으로 옮기며 발견) `connect.ts`의 `testUri ?? srvUri`가 빈 문자열을 "값 있음"으로 취급 — `MONGO_TEST_URI=`처럼 키만 있고 값이 빈 경우 `??`가 폴백하지 않아 `uri`가 빈 문자열이 되고, 연결이 원인 불명 에러로 실패한다. `.env`에 키만 써두고 값을 비우는 실수에서 나올 수 있는 경로다. `||`로 바꾸면 해소되나 프로덕션 동작 변경이라 별도 판단 필요.
 - [ ] (2026-08-10, 테스트 게이트 재배치 중 발견) `.claude/hooks/pre-commit-check.sh`는 실제 Git hook이 아니라 Claude PreToolUse 훅이라 터미널에서 직접 커밋하면 검사가 전혀 실행되지 않음 — 사람과 에이전트 양쪽에 적용하려면 `.git/hooks/pre-commit` 또는 husky로 이전 필요.


### PR DESCRIPTION
## Summary
- TODO.md의 이동 전 GIT.md 경로를 현재 전역 문서 경로로 수정했습니다.
- 이미 해결된 아키텍처 문서 참조 항목을 완료 상태로 갱신했습니다.

## Test plan
- git diff --check — 통과
- TODO 문서 참조 확인 — 통과