### PR TITLE
chore(github): 유실된 CODEOWNERS를 복원하고 PR 템플릿을 신설한다

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# 가드레일 자체를 무력화할 수 있는 경로는 소유자 리뷰를 거친다.
+
+/scripts/tdd-guard/ @rhsiddlsidhd
+/.claude/settings.json @rhsiddlsidhd
+/.codex/hooks.json @rhsiddlsidhd
+/tdd-exceptions.json @rhsiddlsidhd
+/.github/ @rhsiddlsidhd

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+- {이 변경이 필요한 이유와 달성한 결과}
+
+## Test plan
+
+- `{실행한 명령 또는 점검}` — {결과}
+
+<!--
+- 본문은 한국어로 쓰되 섹션 제목(Summary, Test plan)과 명령·경로·식별자는 그대로 둔다.
+- Test plan에는 실제로 실행한 것만 적는다. 검증하지 않았다면 `Not run: {사유}`로 명시한다.
+- breaking change는 PR 제목에 `!`를 붙이고 Summary에 무엇이 깨지는지와 마이그레이션 방법을 적는다.
+- 전문: ~/.codex/docs/GIT.md, ~/.codex/docs/references/pull_request_template.md
+-->


### PR DESCRIPTION
## Summary

- 저장소 분리(`9d69d51`) 때 유실된 가드레일 중 추적 대상 자산 2건을 복원한다. `.github/CODEOWNERS`는 원본(모노레포 기준)을 tie-knot 경로로 다시 쓴 것으로, 가드레일 자체를 무력화할 수 있는 경로(`scripts/tdd-guard/`, `.claude/settings.json`, `.codex/hooks.json`, `tdd-exceptions.json`, `.github/`)를 소유자 리뷰에 묶는다.
- `.github/pull_request_template.md`는 전역 `~/.codex/docs/references/pull_request_template.md` 형식을 저장소 템플릿으로 신설한다. 지금까지 저장소에 템플릿이 없었다.
- `commit-msg` 훅은 이번 PR에 포함되지 않는다. 로컬 `.git/hooks/commit-msg`에 직접 설치했고(추적 대상 아님), 저장소 추적 사본을 두지 않기로 결정했다. dev에 실제로 남는 커밋 제목은 squash merge 특성상 PR 제목이며 이는 여전히 어떤 게이트도 검사하지 않는다 — PR 제목 검증 CI는 후속 판단 대상이다.

## Test plan

- `.git/hooks/commit-msg` 직접 호출 6건 — 통과 2건(`chore: restore commit guardrails`, `chore(git-hooks): restore commit msg validation`), 거부 4건(prefix 누락 / 대문자 시작 / 마침표 종료 / 72자 초과) 전부 의도대로 판정
- `git commit -m "chore(github): restore codeowners and add pr template"` — 훅이 실제 커밋 경로에서 발동해 통과
- Not run: 코드 변경이 없어 `test:unit` 등 테스트 스위트는 실행하지 않음
