### PR TITLE
fix(tdd-guard): 요구 scope를 런타임 import AST로 산정한다

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -124,6 +124,10 @@
 - [ ] (2026-08-11, 공통 TDD Guard 배포 전 검증 완료 후 보류) 배포 환경에 `.env.example`의 운영 필수 값과 `MAIN_PREVIEW_INFO_ID`, `MAIN_PREVIEW_PRODUCT_ID`, `CLOUDINARY_UPLOAD_PRESET`을 등록하고 실제 배포 URL로 Lighthouse 감사를 실행해야 함 — 현재 미배포 상태라 로컬·PR CI 검증 범위에서 제외함.
 - [ ] (2026-08-11, KG이니시스 `inicis_v2` 테스트 채널 확정 후 보류) 배포된 HTTPS 환경에서 PortOne 실제 결제 manual smoke를 수행해야 함 — GUI self-hosted runner(`self-hosted`, `linux`, `x64`, `portone-smoke`)와 사람의 카드사 인증으로 12,000원 결제, `PAID` 조회, store/TEST channel/payment ID 검증, 전액 취소 및 `CANCELLED` 재조회를 확인하고 실패 시에도 cleanup을 보장해야 함.
 - [ ] (2026-08-11, PortOne webhook 구현 후 배포 검증 보류) 배포 URL을 PortOne webhook으로 등록하고 운영 `PORTONE_WEBHOOK_SECRET`을 설정한 뒤 진위 검증, 멱등 처리 및 주문 상태 반영을 실제 webhook 전달로 확인해야 함 — `src/app/api/webhooks/portone/route.ts` 및 `src/server/services/payment.service.ts`.
+- [ ] (2026-08-12, 요구 scope 산정 수정 중 실측) 타입을 값 구문으로 import하는 표기가 요구 scope를 부풀린다 — `src/**` 비테스트 410개 중 **310개(76%)** 가 integration 요구. 판정기를 TS AST로 바꿔도 308개로, `import type` 표기가 소스에 거의 없어 실효가 2개뿐이다(대표: `src/client/components/organisms/ProductFeatures.tsx:2` — `import { PremiumFeature } from "@/server/services"`, `PremiumFeature`는 타입). `@typescript-eslint/consistent-type-imports` 위반이 **210파일 / 286건**이고 전부 autofix 가능. 해법은 3층(eslint autofix → 배럴 `consistent-type-exports` → tsconfig `verbatimModuleSyntax`)이며 별도 `refactor` 브랜치로 진행한다. 인박스의 배럴 강제 규칙 항목과 같은 뿌리다.
+- [ ] (2026-08-12, 위 항목 측정 중 파생) 요구 scope 판정이 import 전이 폐포를 쓰는 게 옳은지 재검토 필요 — 직접 import만 경계로 치면 69/410(17%)까지 떨어지지만, `src/server/actions/*`처럼 service를 경유해 DB에 닿는 파일이 unit만 요구하게 되어 과소 요구로 뒤집힌다. `docs/validation/testing-classification.md:16`의 "둘 이상의 실제 경계를 연결" 기준에 맞는 중간 규칙이 필요하다. 위 타입 import 정리 이후 수치를 다시 보고 판단한다.
+- [ ] (2026-08-12, guard 자체 수정 절차 확인 중 발견) `scripts/tdd-guard/core/run-vitest.mjs:6`의 `projectFor`가 scope `unit`이면 항상 project `unit`을 반환해 `scripts/**/*.test.mjs`(project `guard`)를 실행하지 못한다. guarded 범위가 `src/`로 좁혀져 당장 실害는 없으나, scripts 테스트를 Red/Green proof 흐름으로 돌릴 수단이 없다는 사실은 남는다.
+- [ ] (2026-08-12, AST 판정기 수정 중 관측) `scripts/test-scope/test-graph.mjs:41`의 `element.isTypeOnly`가 TypeScript deprecation 경고(TS6385) 대상 — 대체 API 확인 후 정리 필요.
 
 ### 처리 완료 · 전제 소멸 (2026-08-12 전수 재검증)
 

--- a/scripts/tdd-guard/__tests__/guard.test.mjs
+++ b/scripts/tdd-guard/__tests__/guard.test.mjs
@@ -85,6 +85,11 @@ describe("scope, proof hash and adapters", () => {
     }
   });
   it("unit/integration/e2e를 분류한다", () => { expect(classifyScope("src/a.test.ts")).toBe("unit"); expect(classifyScope("src/a.integration.test.ts")).toBe("integration"); expect(classifyScope("testing/e2e/a.spec.ts")).toBe("e2e"); });
+  it("상태 전이로 지키는 대상은 src 제품 코드이고 scripts 도구는 아니다", () => {
+    expect(classifyFile("src/server/services/product.service.ts")).toEqual({ kind: "product", guarded: true });
+    expect(classifyFile("scripts/tdd-guard/core/policy.mjs")).toEqual({ kind: "excluded", guarded: false });
+    expect(classifyFile("scripts/test-scope/test-graph.mjs")).toEqual({ kind: "excluded", guarded: false });
+  });
   it("testing/support는 제품 코드와 테스트 파일 양쪽에서 제외한다", () => {
     expect(classifyFile("testing/support/db.ts")).toEqual({ kind: "excluded", guarded: false });
     expect(classifyFile("testing/support/setup/mongo-server.ts")).toEqual({ kind: "excluded", guarded: false });
@@ -109,6 +114,36 @@ describe("scope, proof hash and adapters", () => {
     write(path.join(dir, "src/features/save.ts"), `import { Product } from "./product"; export const save = Product.create;\n`);
     write(path.join(dir, "src/features/product.ts"), `import mongoose from "mongoose"; export const Product = mongoose.model("Product", new mongoose.Schema({}));\n`);
     expect(requiredScopes(["src/features/save.ts"], dir)).toEqual(["integration", "unit"]);
+  });
+  it("type-only import는 런타임 의존이 아니므로 경계를 타고 넘지 않는다", () => {
+    const dir = temp();
+    write(path.join(dir, "src/ui/Badge.tsx"), `import type { Product } from "./product"; export const Badge = (product: Product) => null;\n`);
+    write(path.join(dir, "src/ui/product.ts"), `import mongoose from "mongoose"; export const Product = mongoose.model("Product", new mongoose.Schema({}));\n`);
+    expect(requiredScopes(["src/ui/Badge.tsx"], dir)).toEqual(["unit"]);
+  });
+  it("named import이 전부 type-only여도 런타임 의존이 아니다", () => {
+    const dir = temp();
+    write(path.join(dir, "src/ui/Card.tsx"), `import { type Product, type Option } from "./product"; export const Card = (product: Product) => null;\n`);
+    write(path.join(dir, "src/ui/product.ts"), `import mongoose from "mongoose"; export const Product = mongoose.model("Product", new mongoose.Schema({}));\n`);
+    expect(requiredScopes(["src/ui/Card.tsx"], dir)).toEqual(["unit"]);
+  });
+  it("값을 하나라도 함께 가져오면 런타임 의존으로 남는다", () => {
+    const dir = temp();
+    write(path.join(dir, "src/ui/Form.tsx"), `import { type Product, save } from "./product"; export const Form = () => save;\n`);
+    write(path.join(dir, "src/ui/product.ts"), `import mongoose from "mongoose"; export const save = mongoose.model("Product", new mongoose.Schema({})).create;\n`);
+    expect(requiredScopes(["src/ui/Form.tsx"], dir)).toEqual(["integration", "unit"]);
+  });
+  it("주석·문자열·정규식에 등장한 모듈명은 경계가 아니다", () => {
+    const dir = temp();
+    write(path.join(dir, "src/features/text.ts"), `// import mongoose from "mongoose"\nexport const pattern = /mongodb-memory-server/;\nexport const label = 'import "cloudinary"';\n`);
+    expect(requiredScopes(["src/features/text.ts"], dir)).toEqual(["unit"]);
+  });
+  it("require와 동적 import도 런타임 경계로 잡는다", () => {
+    const dir = temp();
+    write(path.join(dir, "src/features/lazy.ts"), `export const load = () => import("cloudinary");\n`);
+    write(path.join(dir, "src/features/legacy.ts"), `const mongoose = require("mongoose"); export const model = mongoose.model;\n`);
+    expect(requiredScopes(["src/features/lazy.ts"], dir)).toEqual(["integration", "unit"]);
+    expect(requiredScopes(["src/features/legacy.ts"], dir)).toEqual(["integration", "unit"]);
   });
   it("integration 실행 프로젝트는 테스트 소유 경계로 선택한다", () => {
     const dir = temp();
@@ -144,15 +179,15 @@ describe("필수 Guard 상태 전이", () => {
   });
   it("이동으로 삭제된 tracked 테스트는 건너뛰고 새 경로를 연결한다", () => {
     const dir = repo();
-    write(path.join(dir, "scripts/old.mjs"), "export const value = 1;\n");
-    write(path.join(dir, "scripts/old.test.mjs"), `import { value } from "./old.mjs";\n`);
-    execFileSync("git", ["add", "scripts/old.mjs", "scripts/old.test.mjs"], { cwd: dir });
-    execFileSync("git", ["commit", "-qm", "add scripts"], { cwd: dir });
-    fs.renameSync(path.join(dir, "scripts/old.mjs"), path.join(dir, "scripts/new.mjs"));
-    fs.renameSync(path.join(dir, "scripts/old.test.mjs"), path.join(dir, "scripts/new.test.mjs"));
-    write(path.join(dir, "scripts/new.test.mjs"), `import { value } from "./new.mjs";\n`);
+    write(path.join(dir, "src/features/old.ts"), "export const value = 1;\n");
+    write(path.join(dir, "src/features/old.test.ts"), `import { value } from "./old";\n`);
+    execFileSync("git", ["add", "src/features/old.ts", "src/features/old.test.ts"], { cwd: dir });
+    execFileSync("git", ["commit", "-qm", "add feature"], { cwd: dir });
+    fs.renameSync(path.join(dir, "src/features/old.ts"), path.join(dir, "src/features/new.ts"));
+    fs.renameSync(path.join(dir, "src/features/old.test.ts"), path.join(dir, "src/features/new.test.ts"));
+    write(path.join(dir, "src/features/new.test.ts"), `import { value } from "./new";\n`);
 
-    expect(resolveTests(dir, "scripts/new.mjs")).toEqual(["scripts/new.test.mjs"]);
+    expect(resolveTests(dir, "src/features/new.ts")).toEqual(["src/features/new.test.ts"]);
   });
   it("신규 assertion 실패만 Red로 인정한다", () => {
     expect(newRedFailures(

--- a/scripts/tdd-guard/core/classify-file.mjs
+++ b/scripts/tdd-guard/core/classify-file.mjs
@@ -30,7 +30,9 @@ export function classifyFile(file) {
   if (DEFAULT_EXCLUDES.some((pattern) => pattern.test(normalized))) {
     return { kind: "excluded", guarded: false };
   }
-  if (/\.[cm]?[jt]sx?$/.test(normalized) && (normalized.startsWith("src/") || normalized.startsWith("scripts/"))) {
+  // Guard가 상태 전이로 증명하는 대상은 제품 코드다. scripts는 그 증명을 수행하는 도구라
+  // 같은 절차로 자기 자신을 통과시킬 수 없다 — 테스트는 `guard` project와 CI가 강제한다.
+  if (/\.[cm]?[jt]sx?$/.test(normalized) && normalized.startsWith("src/")) {
     return { kind: "product", guarded: true };
   }
   return { kind: "excluded", guarded: false };

--- a/scripts/tdd-guard/core/classify-scope.mjs
+++ b/scripts/tdd-guard/core/classify-scope.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { normalizePath } from "./classify-file.mjs";
+import { runtimeSpecifiers } from "../../test-scope/test-graph.mjs";
 
 export function classifyScope(file) {
   const normalized = normalizePath(file);
@@ -11,20 +12,31 @@ export function classifyScope(file) {
   return "unit";
 }
 
+// 경계는 실제 런타임 import로 판정한다. 소스 텍스트 검사는 import로 표현되지 않는
+// 두 경우(`use server` 지시문, 직접 fetch 호출)에만 남긴다.
 const INTEGRATION_BOUNDARIES = [
-  { pattern: /(?:from\s+|import\s*)["'](?:mongoose|mongodb)["']|mongodb-memory-server/, reason: "Mongoose/MongoDB 실행 경계 변경" },
-  { pattern: /["']use server["']|(?:from\s+|import\s*)["']next\/server["']/, reason: "Server Action 또는 Route Handler 실행 경계 변경" },
-  { pattern: /(?:from\s+|import\s*)["'](?:swr|msw)["']|\bfetch\s*\(/, reason: "실제 client HTTP 경계 변경" },
-  { pattern: /(?:from\s+|import\s*)["'](?:cloudinary|@portone\/)[^"']*["']/, reason: "외부 서비스 adapter 경계 변경" },
+  { modules: /^(?:mongoose|mongodb|mongodb-memory-server)$/, reason: "Mongoose/MongoDB 실행 경계 변경" },
+  { modules: /^next\/server$/, source: /^\s*["']use server["']\s*;?\s*$/m, reason: "Server Action 또는 Route Handler 실행 경계 변경" },
+  { modules: /^(?:swr|msw)$/, source: /\bfetch\s*\(/, reason: "실제 client HTTP 경계 변경" },
+  { modules: /^(?:cloudinary(?:\/|$)|@portone\/)/, reason: "외부 서비스 adapter 경계 변경" },
 ];
 
-function localDependencies(root, file) {
+// type-only import는 런타임에 남지 않으므로 의존으로 세지 않는다. 정규식으로 import를
+// 긁으면 그 구분이 불가능해 요구 scope가 부풀어 오른다.
+function moduleFacts(root, file) {
   const absolute = path.join(root, file);
-  if (!fs.existsSync(absolute)) return [];
+  if (!fs.existsSync(absolute) || !fs.statSync(absolute).isFile()) return null;
   const source = fs.readFileSync(absolute, "utf8");
+  try {
+    return { source, specifiers: runtimeSpecifiers(source, file) };
+  } catch {
+    return { source, specifiers: [] };
+  }
+}
+
+function localDependencies(root, file, specifiers) {
   const dependencies = [];
-  for (const match of source.matchAll(/(?:from\s+|import\s*)["']([^"']+)["']/g)) {
-    const specifier = match[1];
+  for (const specifier of specifiers) {
     let candidate;
     if (specifier.startsWith("@/")) candidate = `src/${specifier.slice(2)}`;
     else if (specifier.startsWith(".")) candidate = normalizePath(path.join(path.dirname(file), specifier));
@@ -53,15 +65,15 @@ export function requiredScopePolicy(files, root = process.cwd()) {
     const file = pending.pop();
     if (!file || seen.has(file)) continue;
     seen.add(file);
-    const absolute = path.join(root, file);
-    if (!fs.existsSync(absolute) || !fs.statSync(absolute).isFile()) continue;
-    const source = fs.readFileSync(absolute, "utf8");
-    const boundary = INTEGRATION_BOUNDARIES.find(({ pattern }) => pattern.test(source));
+    const facts = moduleFacts(root, file);
+    if (!facts) continue;
+    const boundary = INTEGRATION_BOUNDARIES.find(({ modules, source }) =>
+      facts.specifiers.some((specifier) => modules.test(specifier)) || (source ? source.test(facts.source) : false));
     if (boundary) {
       scopes.add("integration");
       reasons.integration ??= boundary.reason;
     }
-    pending.push(...localDependencies(root, file));
+    pending.push(...localDependencies(root, file, facts.specifiers));
   }
   return { requiredScopes: [...scopes].sort(), reasons };
 }

--- a/scripts/test-scope/test-graph.mjs
+++ b/scripts/test-scope/test-graph.mjs
@@ -26,7 +26,7 @@ function compilerOptions(root) {
   };
 }
 
-function runtimeSpecifiers(source, file) {
+export function runtimeSpecifiers(source, file) {
   const kind = file.endsWith("x") ? ts.ScriptKind.TSX : file.endsWith(".mjs") ? ts.ScriptKind.JS : ts.ScriptKind.TS;
   const tree = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, kind);
   const specifiers = [];


### PR DESCRIPTION
## Summary

- 요구 scope 산정이 import를 정규식으로 긁어 `import type`을 런타임 의존으로 셌다. 타입 하나만 참조해도 사슬 끝의 mongoose 경계가 걸려 `integration` proof가 강제됐다. `scripts/test-scope/test-graph.mjs`의 `runtimeSpecifiers`(TS AST, type-only import를 정확히 배제)를 재사용하도록 정합을 맞췄다. 같은 이유로 경계 판정도 소스 텍스트 대신 해석된 module specifier를 대상으로 바꿨다 — 텍스트 스캔은 이 파일 안에 적힌 경계 패턴 문자열까지 경계로 오인했고(`mongodb-memory-server`), 반대로 `require`와 동적 `import`는 놓쳤다.
- guarded 제품 파일 범위를 `src/`로 좁혔다. TDD Guard는 제품 코드의 Red → Green → mutation 상태 전이를 증명하는 장치이고, `scripts/`는 그 증명을 **수행하는 도구**라 같은 절차로 자기 자신을 통과시킬 수 없다. 실제로 `run-vitest.mjs`의 `projectFor`가 scope `unit`을 항상 vitest `unit` project로 보내 `scripts/**/*.test.mjs`를 한 건도 실행하지 못하므로, scripts 파일은 원리적으로 Red proof를 만들 수 없었다. 도구의 테스트는 `guard` project와 CI(`npx vitest run --project guard`)가 계속 강제한다.
- **효과는 제한적이다**: `src/**` 비테스트 410개 중 integration 요구가 310개 → 308개로만 줄었다. 실제 원인은 타입을 값 구문으로 import하는 소스 표기이며(`ProductFeatures.tsx:2`의 `import { PremiumFeature } from "@/server/services"`), 이 수정은 그 표기를 고쳤을 때 판정기가 제대로 반응하도록 만드는 선행 조건이다. 후속 리팩토링(eslint `consistent-type-imports` 210파일/286건 → 배럴 `consistent-type-exports` → `verbatimModuleSyntax`)은 TODO 인박스에 기록했다.

## Test plan

- `npx vitest run --project guard` — 62 passed (5 files). 회귀 테스트 6건 추가: type-only import 차단, named import 전부 type-only, 값 혼합 시 경계 유지, 주석·문자열·정규식 텍스트 무시, `require`·동적 `import` 포착, guarded 범위가 `src`이고 `scripts`가 아님
- 위 6건은 구현 전 실행해 5건이 assertion failure로 실패함을 먼저 확인(48 passed / 5 failed). 환경·import 오류가 아님
- `npm run lint` — 통과
- `npm run typecheck` — 통과
- `node scripts/tdd-guard/bin/guard.mjs verify --ci --base dev` — `valid: true`
- `node scripts/test-scope/unit-shards.mjs verify` — `valid: true`, 124 files, missing·duplicated 0
- Not run: `npm run test:unit` 등 src 스위트 — 워크트리에 `.env`가 없어(gitignore) `JWT_SECRET` 미정의로 로드가 실패한다. 제품 코드 변경이 없어 CI 검증으로 넘긴다
