### PR TITLE
fix(tdd-guard): claude 어댑터 차단 사유 미전달 수정

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -128,6 +128,8 @@
 - [ ] (2026-08-12, 위 항목 측정 중 파생) 요구 scope 판정이 import 전이 폐포를 쓰는 게 옳은지 재검토 필요 — 직접 import만 경계로 치면 69/410(17%)까지 떨어지지만, `src/server/actions/*`처럼 service를 경유해 DB에 닿는 파일이 unit만 요구하게 되어 과소 요구로 뒤집힌다. `docs/validation/testing-classification.md:16`의 "둘 이상의 실제 경계를 연결" 기준에 맞는 중간 규칙이 필요하다. 위 타입 import 정리 이후 수치를 다시 보고 판단한다.
 - [ ] (2026-08-12, guard 자체 수정 절차 확인 중 발견) `scripts/tdd-guard/core/run-vitest.mjs:6`의 `projectFor`가 scope `unit`이면 항상 project `unit`을 반환해 `scripts/**/*.test.mjs`(project `guard`)를 실행하지 못한다. guarded 범위가 `src/`로 좁혀져 당장 실害는 없으나, scripts 테스트를 Red/Green proof 흐름으로 돌릴 수단이 없다는 사실은 남는다.
 - [ ] (2026-08-12, AST 판정기 수정 중 관측) `scripts/test-scope/test-graph.mjs:41`의 `element.isTypeOnly`가 TypeScript deprecation 경고(TS6385) 대상 — 대체 API 확인 후 정리 필요.
+- [ ] (2026-08-12, `claude.mjs` 어댑터 사유 미전달 버그 수정 중 발견) `.claude/agents/backend-impl.md`, `frontend-impl.md`, `test-suite.md`가 존재하지 않는 pre-commit 게이트(lint/coverage80%/typecheck)를 계약으로 규정하고 TDD Guard·`test:red`·proof는 0건 언급 — `feature-team-orchestrator/SKILL.md:140`도 같은 유령 게이트를 표로 남김. 에이전트가 TDD Guard에 막혔을 때 복구 절차를 문서에서 못 찾는 문제로 이어짐.
+- [ ] (2026-08-12, 위와 같은 조사 중 보류) `codex.mjs`가 내보내는 `hookSpecificOutput`/`hookEventName: "PreToolUse"`/`permissionDecision`은 Claude Code 스키마 어휘라 Codex CLI가 실제로 이 형태를 소비하는지 미확인 — `.codex/hooks.json`도 Claude Code 구조(`matcher`/`statusMessage`)를 그대로 본떴다. 계약이 다르면 `exit 0`으로 나가 차단 자체가 안 걸릴 수 있음. Codex 문서 확인 + 실증 필요.
 
 ### 처리 완료 · 전제 소멸 (2026-08-12 전수 재검증)
 

--- a/scripts/tdd-guard/adapters/__tests__/pre-edit-response.test.mjs
+++ b/scripts/tdd-guard/adapters/__tests__/pre-edit-response.test.mjs
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { afterAll, describe, expect, it } from "vitest";
+import { buildPreEditResponse } from "../pre-edit-response.mjs";
+
+const projectRoot = path.resolve(import.meta.dirname, "../../../..");
+const claudeAdapter = path.join(projectRoot, "scripts/tdd-guard/adapters/claude.mjs");
+const codexAdapter = path.join(projectRoot, "scripts/tdd-guard/adapters/codex.mjs");
+const roots = [];
+
+function write(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, value);
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tdd-adapter-fixture-"));
+  const state = fs.mkdtempSync(path.join(os.tmpdir(), "tdd-adapter-state-"));
+  roots.push(root, state);
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "guard@example.test"], { cwd: root });
+  execFileSync("git", ["config", "user.name", "TDD Guard"], { cwd: root });
+  write(path.join(root, "package.json"), "{}\n");
+  write(path.join(root, "package-lock.json"), "{}\n");
+  write(path.join(root, "stryker.config.mjs"), "export default {};\n");
+  write(path.join(root, "vitest.config.ts"), `
+    import { defineConfig } from "vitest/config";
+    export default defineConfig({ test: { projects: [{ test: { name: "unit", environment: "node", include: ["src/**/*.test.ts"] } }] } });
+  `);
+  write(path.join(root, "src/value.ts"), "export const value = 1;\n");
+  fs.symlinkSync(path.join(projectRoot, "node_modules"), path.join(root, "node_modules"), "dir");
+  execFileSync("git", ["add", "package.json", "package-lock.json", "stryker.config.mjs", "vitest.config.ts", "src/value.ts"], { cwd: root });
+  execFileSync("git", ["commit", "-qm", "baseline"], { cwd: root });
+  return { root, state };
+}
+
+function runAdapter(adapter, root, state, input) {
+  return spawnSync(process.execPath, [adapter, "pre-edit"], {
+    cwd: root,
+    input: JSON.stringify(input),
+    encoding: "utf8",
+    env: { ...process.env, TDD_GUARD_ROOT: root, TDD_GUARD_SESSION_ID: "fixture-session", XDG_STATE_HOME: state },
+  });
+}
+
+afterAll(() => roots.forEach((root) => fs.rmSync(root, { recursive: true, force: true })));
+
+describe("buildPreEditResponse", () => {
+  it("guard의 deny reason을 hookSpecificOutput.permissionDecisionReason에 그대로 담는다", () => {
+    const result = { status: 2, stdout: JSON.stringify({ permissionDecision: "deny", reason: "TDD Guard: src/value.ts 편집 전 테스트를 변경하세요." }) };
+    const { reason, hookSpecificOutput } = buildPreEditResponse(result, "pre-edit");
+
+    expect(reason).toBe("TDD Guard: src/value.ts 편집 전 테스트를 변경하세요.");
+    expect(hookSpecificOutput).toEqual({
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "TDD Guard: src/value.ts 편집 전 테스트를 변경하세요.",
+    });
+  });
+
+  it("guard stdout이 JSON이 아니거나 reason이 없으면 폴백 사유를 쓴다", () => {
+    const crashed = { status: 1, stdout: "ReferenceError: boom\n    at file.mjs:1:1" };
+    const { reason } = buildPreEditResponse(crashed, "pre-edit");
+
+    expect(reason).toBe("TDD Guard 실행 오류. 편집을 차단합니다. node scripts/tdd-guard/bin/guard.mjs pre-edit를 직접 실행하세요.");
+  });
+});
+
+describe("claude.mjs pre-edit 어댑터", () => {
+  it("deny를 구조화 stdout과 stderr 양쪽에 같은 reason으로 전달한다", () => {
+    const { root, state } = fixture();
+    const result = runAdapter(claudeAdapter, root, state, {
+      session_id: "fixture-session",
+      tool_name: "Write",
+      tool_input: { file_path: path.join(root, "src/value.ts") },
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    const stdout = JSON.parse(result.stdout);
+    expect(stdout).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "TDD Guard: src/value.ts 편집 전 테스트를 변경하고 npm run test:red -- --scope <scope>를 실행하세요.",
+      },
+    });
+    expect(result.stderr).toContain(stdout.hookSpecificOutput.permissionDecisionReason);
+  });
+
+  it("guard 크래시 시에도 같은 형태로 폴백 사유를 전달한다", () => {
+    const brokenRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tdd-adapter-broken-"));
+    roots.push(brokenRoot);
+    const state = fs.mkdtempSync(path.join(os.tmpdir(), "tdd-adapter-broken-state-"));
+    roots.push(state);
+
+    const result = runAdapter(claudeAdapter, brokenRoot, state, {
+      session_id: "fixture-session",
+      tool_name: "Write",
+      tool_input: { file_path: path.join(brokenRoot, "src/value.ts") },
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    const stdout = JSON.parse(result.stdout);
+    expect(stdout.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(stdout.hookSpecificOutput.permissionDecisionReason).toBe(
+      "TDD Guard 실행 오류. 편집을 차단합니다. node scripts/tdd-guard/bin/guard.mjs pre-edit를 직접 실행하세요.",
+    );
+    expect(result.stderr).toContain(stdout.hookSpecificOutput.permissionDecisionReason);
+  });
+
+  it("allow일 때는 차단하지 않는다", () => {
+    const { root, state } = fixture();
+    write(path.join(root, "src/value.test.ts"), `
+      import { describe, expect, it } from "vitest";
+      import { value } from "./value";
+      describe("value", () => { it("새 계약", () => { expect(value).toBe(2); }); });
+    `);
+    const red = spawnSync(process.execPath, [path.join(projectRoot, "scripts/tdd-guard/bin/guard.mjs"), "prove-red", "--scope", "unit"], {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, TDD_GUARD_ROOT: root, TDD_GUARD_SESSION_ID: "fixture-session", XDG_STATE_HOME: state },
+    });
+    expect(red.status, red.stderr || red.stdout).toBe(0);
+
+    const result = runAdapter(claudeAdapter, root, state, {
+      session_id: "fixture-session",
+      tool_name: "Write",
+      tool_input: { file_path: path.join(root, "src/value.ts") },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("{}\n");
+  });
+});
+
+describe("codex.mjs pre-edit 어댑터 (동작 불변 확인)", () => {
+  it("deny를 구조화 stdout으로 전달하고 stderr는 guard의 원본 그대로 둔다", () => {
+    const { root, state } = fixture();
+    const result = runAdapter(codexAdapter, root, state, {
+      session_id: "fixture-session",
+      tool_name: "apply_patch",
+      tool_input: { command: "*** Begin Patch\n*** Update File: src/value.ts\n*** End Patch" },
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "TDD Guard: src/value.ts 편집 전 테스트를 변경하고 npm run test:red -- --scope <scope>를 실행하세요.",
+      },
+    });
+    expect(result.stderr).toBe("");
+  });
+});

--- a/scripts/tdd-guard/adapters/claude.mjs
+++ b/scripts/tdd-guard/adapters/claude.mjs
@@ -2,18 +2,26 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildPreEditResponse } from "./pre-edit-response.mjs";
 
 const command = process.argv[2];
 let input = "";
 for await (const chunk of process.stdin) input += chunk;
 const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "../bin/guard.mjs");
 const result = spawnSync(process.execPath, [cli, command], { input, encoding: "utf8" });
-if (result.status !== 0 && result.status !== 2) {
-  process.stdout.write(JSON.stringify({
-    permissionDecision: "deny",
-    reason: `TDD Guard 실행 오류. 편집을 차단합니다. node scripts/tdd-guard/bin/guard.mjs ${command}를 직접 실행하세요.`,
-  }));
+
+if (command !== "pre-edit") {
+  process.stdout.write(result.stdout || "");
   process.stderr.write(result.stderr || "");
-  process.exit(2);
+  process.exit(result.status ?? 2);
 }
-process.stdout.write(result.stdout || ""); process.stderr.write(result.stderr || ""); process.exit(result.status ?? 2);
+
+if (result.status === 0) {
+  process.stdout.write("{}\n");
+  process.exit(0);
+}
+
+const { reason, hookSpecificOutput } = buildPreEditResponse(result, command);
+process.stdout.write(`${JSON.stringify({ hookSpecificOutput }, null, 2)}\n`);
+process.stderr.write(result.stderr ? `${reason}\n${result.stderr}` : `${reason}\n`);
+process.exit(0);

--- a/scripts/tdd-guard/adapters/codex.mjs
+++ b/scripts/tdd-guard/adapters/codex.mjs
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildPreEditResponse } from "./pre-edit-response.mjs";
 
 const command = process.argv[2];
 let input = "";
@@ -21,16 +22,8 @@ if (result.status === 0) {
   process.exit(0);
 }
 
-let reason;
-try { reason = JSON.parse(result.stdout).reason; } catch {}
-reason ||= `TDD Guard 실행 오류. 편집을 차단합니다. node scripts/tdd-guard/bin/guard.mjs ${command}를 직접 실행하세요.`;
+const { hookSpecificOutput } = buildPreEditResponse(result, command);
 
-process.stdout.write(`${JSON.stringify({
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "deny",
-    permissionDecisionReason: reason,
-  },
-}, null, 2)}\n`);
+process.stdout.write(`${JSON.stringify({ hookSpecificOutput }, null, 2)}\n`);
 process.stderr.write(result.stderr || "");
 process.exit(0);

--- a/scripts/tdd-guard/adapters/pre-edit-response.mjs
+++ b/scripts/tdd-guard/adapters/pre-edit-response.mjs
@@ -1,0 +1,14 @@
+export function buildPreEditResponse(result, command) {
+  let reason;
+  try { reason = JSON.parse(result.stdout).reason; } catch {}
+  reason ||= `TDD Guard 실행 오류. 편집을 차단합니다. node scripts/tdd-guard/bin/guard.mjs ${command}를 직접 실행하세요.`;
+
+  return {
+    reason,
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- `claude.mjs`가 guard.mjs의 평평한 deny JSON을 그대로 stdout에 흘려보내 Claude Code의 `hookSpecificOutput` 스키마로 인식되지 못했다. exit 2 경로에서 모델이 읽는 stderr는 항상 비어 있어 편집 차단 사유가 0줄로 사라졌다(원인: `claude.mjs`, `codex.mjs`가 같은 커밋 `2759f0b`에서 서로 다른 변환 로직으로 도입됨).
- `codex.mjs`의 올바른 변환 로직을 `scripts/tdd-guard/adapters/pre-edit-response.mjs`로 공유해 `claude.mjs`에 적용했다. 스키마 해석이 실패해도 사유가 전달되도록 stderr에도 reason을 함께 쓴다(belt-and-braces).
- `codex.mjs`는 같은 공유 함수를 쓰도록 리팩터링했지만 stdout/stderr 출력은 바이트 단위로 동일하게 유지했다 — Codex CLI가 이 스키마를 실제로 소비하는지 미확인이라 동작 변경은 범위 밖(TODO 인박스에 별도 기록).
- 목적 밖 발견 두 건(존재하지 않는 pre-commit 게이트를 규정한 에이전트 문서, codex 계약 미확인)을 TODO.md 미분류 인박스에 기록.

## Test plan

- `npx vitest run --project guard` — 68 passed (신규 회귀 테스트 5건 포함: deny reason 전달, stdout이 JSON이 아니거나 reason 없을 때 폴백, guard 실제 크래시 시 폴백, allow 시 미차단, codex 동작 불변)
- 수동 확인: `echo '{"tool_input":{"file_path":"src/foo.ts"},"session_id":"x"}' | node scripts/tdd-guard/adapters/claude.mjs pre-edit` — stdout에 `hookSpecificOutput.permissionDecisionReason`, stderr에 같은 reason 모두 출력 확인, exit 0