### PR TITLE
docs(todo): 항목 템플릿 적용 및 완료이력 정리

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,119 +24,119 @@
 
 ## 새 피처
 
-- [ ] **마켓플레이스 전환 (제3자 판매자 입점)** (2026-08-06 방향성만 논의, 착수 아님) — 현재 `UserRole`은 `"USER" | "ADMIN"` 둘뿐이고(`user.model.ts:2`) 상품 등록은 `createProduct.ts`의 `role !== "ADMIN"` 체크로 관리자 전용(자사 직접판매몰 구조, `authorId`는 "등록한 관리자"만 의미). `SELLER` role 추가해 제3자 판매자가 직접 상품을 입점시키는 구조로 전환하는 방향이 논의됨. 착수 시 파급 범위 큼 — 착수 전 별도로 팬아웃 설계 필요:
-  - 상품 등록/수정/삭제 권한 체크 전반에 `SELLER` 포함, 상품 소유권 개념 신설(자기 상품만 수정/삭제 가능하도록 인가 로직 추가 — `authorId`의 의미가 "등록한 관리자"에서 "소유 판매자"로 바뀜)
-  - 판매자 정산/수수료 체계, 판매자 프로필/스토어 페이지, 관리자의 판매자 상품 검수 플로우 등 마켓플레이스 특유 기능 신규 설계
-  - "상품 카테고리별 확장"과 별개 트랙 — 섞어서 진행하지 않는다.
+- [ ] **마켓플레이스 전환 (제3자 판매자 입점)** (2026-08-06 논의, 미착수)
+  할 일: 착수 전 팬아웃 설계 — `SELLER` role 추가, 상품 소유권 개념 신설(`authorId` 의미를 "등록한 관리자"→"소유 판매자"로 전환), 정산/수수료·판매자 스토어페이지·관리자 검수 플로우 신규 설계
+  위치: `user.model.ts:2`(`UserRole`), `createProduct.ts`(role 체크)
+  근거: 현재 상품등록은 `role !== "ADMIN"` 체크로 관리자 전용(자사 직접판매몰 구조) — 제3자 판매자 입점 구조로 전환 논의됨
+  상태: 미착수. "상품 카테고리별 확장"과 별개 트랙 — 섞어서 진행 금지
 
 ---
 
 ## 버그 수정
 
-> **2026-08-12 전수 재검증 완료** — 코드 대조로 항목 유효성과 위치를 다시 확인했다. 이 날짜 이후 다시 낡을 수 있으므로 착수 전 해당 파일을 먼저 읽는다.
->
-> 처리 순서: **선행(가드레일)을 먼저** 끝낸 뒤 클러스터 1~3으로 간다. 클러스터 안에서는 위→아래 순서를 권장한다(파일·맥락 겹침 기준).
->
-> **2026-08-12 갱신**: 과거 선행 3건 중 "TDD Guard 요구 scope가 type-only import를 정규식으로 오판" 항목은 `c342ef9`(#14, AST 산정 전환)로 해소돼 처리 완료로 이관했다. 남은 2건의 권장 착수 순서는 나열 순서와 다르다 — **2 → 1**.
-> - **2번(커밋 규칙·리뷰 강제 복원)이 먼저**: 가장 싸고(unguarded라 proof 불필요) 이후 모든 커밋에 효과가 붙는다.
-> - **1번(하네스 문서)은 다음 기능 착수 전까지**: 이 문서가 발동하는 경로는 `feature-team-orchestrator`(`feat` 전용)뿐이라, 전부 `fix`/UI인 아래 클러스터 작업은 막지 않는다. 직접 작업 시의 TDD Guard 절차는 `docs/validation/tdd-guard.md`에 이미 정확히 있다.
-
-### 선행 — 가드레일 정합·복원 (아래 순서대로)
-
-- [ ] **하네스 문서가 존재하지 않는 pre-commit 게이트를 계약으로 명시 — 구현 에이전트가 TDD Guard를 모른 채 차단당함** (2026-08-12 발견 [발견: TODO 전수 재검증 중 가드레일 구조 감사], 2026-08-12 코드 대조로 여전히 유효 확인) — `.claude/agents/backend-impl.md`, `frontend-impl.md`, `test-suite.md` 세 파일에 TDD Guard·`test:red`·proof 언급이 **0건**이다. 대신 `backend-impl.md:44`와 `frontend-impl.md:44`가 "pre-commit 훅(lint/coverage80%/typecheck)에 막히면 원인 해결 후 재시도, 3회 실패 시 에스컬레이션"이라는 절차를 규정하는데 **그 훅은 존재하지 않는다**(`.git/hooks/`에 훅 0개, `.claude/settings.json`은 TDD Guard PreToolUse/PostToolUse만 등록).
-  - **실제 동작**: `guard.mjs pre-edit`가 유효 proof 없는 guarded 파일 편집을 `permissionDecision: "deny"`로 차단한다(`bin/guard.mjs:64`). 즉 구현 에이전트는 첫 `Edit`/`Write`에서 막히는데, 대응 절차(`npm run test:red -- --scope <scope>`)가 지침에 없어 복구 경로가 없다.
-  - **내부 모순**: `feature-team-orchestrator/SKILL.md:14`는 TDD Guard 계약으로 갱신됐는데 같은 파일 `:140`은 여전히 phantom pre-commit 게이트를 표로 남겨뒀다.
-  - **부수**: `.claude/agents/test-suite.md:27`이 지시하는 `npm run test`는 현재 실패하는 명령이다(아래 "단독" 섹션 항목 참고).
-  - **비용**: 대상 파일이 전부 unguarded(`docs/` 및 `.claude/`)라 Red proof 없이 수정 가능 — 착수 비용이 가장 낮다.
-  - **중복 제보**: 인박스에 같은 증상이 `claude.mjs` 어댑터 버그 수정(#15) 중 재발견돼 한 번 더 적혔다 — 새 정보 없이 이 항목과 동일해 병합, 인박스 쪽은 제거.
-
-- [ ] **저장소 분리 때 유실된 커밋 규칙·리뷰 강제 복원** (2026-08-12 발견 [발견: 훅 부재 확인 중 원본 저장소 대조]) — tie-knot은 `9d69d51 chore: tie-knot 저장소를 분리`로 agent-benchmark 모노레포에서 떨어져 나왔는데, 그때 추적 대상이 아니거나 삭제된 가드레일 자산이 재생성되지 않았다.
-  - **`commit-msg` 훅 이식**: 전역 `GIT.md`의 Naming 규칙을 검사하는 훅이 tie-knot에 없어, prefix 택소노미·`{prefix}({scope}): {message}` 형식·72자 상한을 강제하는 지점이 **로컬에도 CI에도 0개**다(`.github/workflows/`에 commitlint·PR 제목 검증 job 없음). 원본은 `/home/rhsiddlsidhd/agent-benchmark/.git/hooks/commit-msg`(2026-08-10)에 살아 있고 이미 고쳐진 버전이다 — 정규식 `^(feat|fix|docs|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9]+(-[a-z0-9]+)*\))?!?: ` 에 72자·소문자 시작·마침표 금지 검사까지 포함해 현행 `GIT.md`와 일치한다(과거형·명사구 판별만 미구현).
-    - **추적되는 위치로 승격할 것**: `.git/hooks/`는 Git 추적 대상이 아니라 clone·저장소 재구성마다 증발한다. 이번 유실이 정확히 그 경로였다. 저장소 내 스크립트 + `core.hooksPath`(또는 husky)로 두어야 재발하지 않는다.
-    - 검사 대상은 메시지 텍스트뿐이다. 코드 검사(`pre-commit` 계열)는 복원 대상이 아니다 — TDD Guard(에이전트 훅)와 PR CI가 그 책임을 나눠 갖는다.
-  - **`.github/CODEOWNERS` 재생성**: 분리 커밋이 지운 뒤 tie-knot에 다시 만들어지지 않았다. 원본은 `scripts/tdd-guard/`, `.claude/settings.json`, `.codex/hooks.json`, `tdd-exceptions.json`, `.github/workflows/tdd.yml`, `.github/workflows/portone-smoke.yml`을 소유자 리뷰 필수로 묶고 있었다(`git show 9d69d51^:.github/CODEOWNERS`, 경로는 모노레포 기준이라 tie-knot 기준으로 다시 써야 함). 지금은 가드레일 자체를 무력화하는 변경에 리뷰 강제가 없다.
-  - **PR 템플릿 부재**: 저장소에 템플릿이 없다. 전역 규칙상 `~/.codex/docs/references/pull_request_template.md`를 쓰거나 저장소 템플릿을 신설한다.
+> 현재 상태(2026-08-13): 선행 블로커 없음 — 클러스터 1→2→3 순서로 진행, 이후 "단독"은 순서 무관. 착수 전 각 항목의 `file:line`을 먼저 읽는다(라인은 드리프트될 수 있음).
 
 ### 클러스터 1 — 이미지 파이프라인 (아래 순서)
 
-- [ ] **상품 이미지 업로드가 Server Action 기본 body size limit(1MB)에 걸리는 잠복버그** (2026-08-07 발견, 목데이터 삽입 준비 중 논의 — 2026-08-12 재확인) — `createProduct`/`updateProduct`가 `thumbnail`/`images`를 File 객체 그대로 FormData에 실어 Server Action으로 보내는데, `next.config.ts`에 `experimental.serverActions.bodySizeLimit` 오버라이드가 없어 Next.js 16 기본값 1MB가 그대로 적용된다(`node_modules/next/dist/docs/01-app/02-guides/server-actions.md:83`). 실사진(수 MB급) 몇 장이면 걸린다 — vitest 목업 File이 작아서 지금까지 안 걸렸을 뿐. 청첩장(couple-info) 폼이 같은 문제로 클라이언트 직접업로드(signed, `src/app/api/upload/signature`)로 우회한 전례가 있다(2026-08-12 존재 확인).
-  - **참고**: `next-cloudinary`(v6.17.5)가 설치돼 있고 `CldUploadWidget`/`CldUploadButton`을 제공하는데 `src/` 어디서도 안 쓴다(2026-08-12 재확인, 사용 0건). 이걸로 전환하면 서버가 파일 바이트를 안 거쳐 body limit 문제가 구조적으로 사라진다. 단 `images` 요청 계약(`{existing: string[], newFiles: File[]}`)을 `string[]`로 바꿔야 하는 규모 있는 변경이라 별도 설계 필요.
-  - **비용**: `next.config.ts`는 guard 예외(`*.config.ts` 제외 규칙)라 임시 완화만 한다면 proof 없이 가능. 클라이언트 직접업로드 전환은 별개.
-  - 목데이터 삽입은 작은 플레이스홀더 이미지로 우회 가능 — 이 항목이 착수를 막지는 않는다.
-- [ ] **상품 상세 페이지가 `images`(상세 이미지 갤러리) 필드를 아예 렌더링하지 않음** (2026-08-07 발견, 목데이터 14건 실등록 검증 중 — 2026-08-12 재확인) — `src/client/components/organisms/ProductFeatures.tsx:47`의 "상세 정보" 섹션이 헤딩만 있고 본문이 0줄이다. `src/app/(main)/(products)/products/[category]/[id]/_components/ProductDetailTemplate.tsx:18`이 `ProductFeatures`에 `options`(premiumFeatures)만 넘기고 `product`/`product.images`를 전달하지 않는다 — 갤러리 소비 코드가 통째로 없다. 등록 폼은 non-invitation 카테고리에 `images`를 필수(최소 1장)로 강제하는데 정작 고객에게는 노출이 0인 상태 — 사진으로 구매를 설득해야 하는 답례품/웨딩소품에서 특히 치명적. `images: string[]`를 `ProductDetailTemplate`→`ProductFeatures`(또는 신규 갤러리 organism)로 내려서 렌더링을 추가한다.
+- [ ] **상품 이미지 업로드가 Server Action 기본 body size limit(1MB)에 걸림** (2026-08-07 발견, 2026-08-12 확인)
+  할 일: (임시) `next.config.ts`에 `experimental.serverActions.bodySizeLimit` 상향 — (근본) `next-cloudinary`(설치돼 있으나 미사용)로 클라이언트 직접업로드 전환 + `images` 요청 계약을 `string[]`로 변경(별도 설계 필요)
+  위치: `next.config.ts`, `createProduct`/`updateProduct`의 FormData 처리부
+  근거: Next16 기본 1MB, 실사진 몇 장이면 걸림(vitest mock File은 작아 지금까지 미발견). couple-info 폼은 이미 signed 직접업로드(`src/app/api/upload/signature`)로 우회한 전례
+  완료 기준: 수 MB급 실사진 다건 업로드 성공. 목데이터는 작은 이미지로 우회 가능 — 이 항목이 착수를 막지 않음
+- [ ] **상품 상세 페이지가 `images`(갤러리) 필드를 렌더링하지 않음** (2026-08-07 발견, 2026-08-12 확인)
+  할 일: `images: string[]`을 `ProductDetailTemplate`→`ProductFeatures`(또는 신규 갤러리 organism)로 전달·렌더
+  위치: `ProductFeatures.tsx:47`(빈 섹션), `ProductDetailTemplate.tsx:18`(images 미전달)
+  근거: 등록 폼은 non-invitation 카테고리에 images 최소 1장 강제하는데 고객 노출은 0 — 답례품/웨딩소품처럼 사진이 구매결정에 중요한 카테고리에 치명적
+  완료 기준: 5개 카테고리 상세페이지에서 등록 이미지 전부 노출
 
 ### 클러스터 2 — 카테고리별 하드코딩 문구 (같이 고칠 것)
 
-- [ ] **`OrderSummary.tsx` "청첩장 템플릿" 하드코딩** (2026-08-07 발견 — 2026-08-12 재확인) — `src/client/components/organisms/OrderSummary.tsx:57`이 주문서 상품명 아래에 카테고리 무관하게 `"청첩장 템플릿"`을 렌더한다. 카테고리 5종인 지금 답례품/방명록 주문서에도 그대로 뜬다. `CheckoutItem`에 카테고리 정보가 없어서 고치려면 `CheckoutItem` 계약 변경이 필요.
-- [ ] **상품 상세 페이지의 invitation 전용 안내 문구가 전 카테고리에 하드코딩 노출** (2026-08-07 발견, 목데이터 14건 실등록 검증 중 — 2026-08-12 재확인) — `src/client/components/organisms/ProductSummary.tsx:120,126,132`의 "구매 후 즉시 사용 가능하며, 무제한으로 수정할 수 있습니다" / "평생 호스팅이 포함되어 있어 별도의 유지비가 없습니다" / "모바일과 데스크톱 모두에서 완벽하게 작동합니다"가 캔들홀더 같은 실물 상품 상세페이지에도 카테고리 분기 없이 뜬다. 위 `OrderSummary` 항목과 동일 패턴 — 함께 고친다.
-  - 이 컴포넌트는 pure(organisms) 쪽이다. 컨테이너는 `src/app/(main)/(products)/products/[category]/[id]/_components/ProductSummary.tsx`로 분리돼 있으니 둘을 혼동하지 않는다.
+- [ ] **`OrderSummary.tsx` 카테고리 무관 "청첩장 템플릿" 하드코딩** (2026-08-07 발견, 2026-08-12 확인)
+  할 일: `CheckoutItem`에 카테고리 필드 추가 → `OrderSummary.tsx:57`을 카테고리별 상품유형명으로 분기
+  위치: `src/client/components/organisms/OrderSummary.tsx:57`, `CheckoutItem` 타입
+  근거: 카테고리 5종인데 답례품/방명록 주문서에도 "청첩장 템플릿" 고정 노출
+  완료 기준: 5개 카테고리 주문서 각각 올바른 상품유형명 렌더 + 회귀 테스트
+- [ ] **상품 상세 invitation 전용 안내 문구가 전 카테고리 노출** (2026-08-07 발견, 2026-08-12 확인)
+  할 일: `ProductSummary.tsx:121,127,133` 3개 문구를 카테고리 분기(invitation만 노출)
+  위치: `src/client/components/organisms/ProductSummary.tsx:121,127,133`(pure — 컨테이너는 `.../[id]/_components/ProductSummary.tsx`, 혼동 주의)
+  근거: "즉시사용/평생호스팅/모바일작동" 문구가 캔들홀더 등 실물상품에도 노출. `OrderSummary` 항목과 동일 패턴 — 함께 처리
+  완료 기준: 5개 카테고리 각각 올바른 문구 노출 + 회귀 테스트
 
 ### 클러스터 3 — 관리자 등록 폼 (`organisms/ProductRegistrationForm.tsx`, UI섹션 "연속 등록 워크플로우"와 같은 파일 — 함께 처리 권장)
 
-- [ ] **관리자 상품 등록 폼 가격 입력이 `step="1000"` 강제 + 실패 시 무피드백** (2026-08-07 발견, 목데이터 14건 실등록 검증 중 — 2026-08-12 재확인) — `src/client/components/organisms/ProductRegistrationForm.tsx:203`의 `price` input이 `step="1000"`이라 1000원 배수가 아닌 값(예: 4,500원)이 브라우저 네이티브 validation에 걸려 "상품 등록" 클릭이 조용히 씹힌다 — 화면에 에러가 전혀 안 떠서 관리자는 원인을 알 수 없다(재현: 4500원 입력 후 클릭 시 서버 액션 미호출, `element.validity.valid === false`). 답례품처럼 저가·비정형 가격이 흔한 카테고리에 특히 문제 — `step` 완화 또는 커스텀 에러 메시지 노출이 필요.
-  - 같은 파일 `:235,318,501,522`에도 `step`이 있다. 가격 외 필드는 의도된 제약일 수 있으니 함께 판단한다.
+- [ ] **상품 등록 폼 가격 input이 `step="1000"` 강제 + 실패 시 무피드백** (2026-08-07 발견, 2026-08-12 확인)
+  할 일: `price` input `step` 완화 또는 커스텀 에러 메시지 노출(1000원 배수 아닌 값 제출 시 조용히 씹히는 문제 해결)
+  위치: `ProductRegistrationForm.tsx:204`(price). `:236,319,502,523`은 다른 필드 step — 이번 스코프 아님, 별도 판단
+  근거: 4500원처럼 비정형 가격 입력 시 브라우저 native validation 실패로 클릭이 조용히 씹힘(`element.validity.valid===false`), 화면 에러 없음 — 답례품 등 저가·비정형 가격 카테고리에서 특히 문제
+  완료 기준: 비1000원배수 가격 제출 시 명확한 에러 표시 또는 정상 등록
 
 ### 단독 — 연관 항목 없음, 순서 무관
 
-- [ ] **사이드바가 최초 진입 시 관리자 계정도 "일반 계정"으로 잠깐 표시** (2026-08-07 발견 [발견: 목데이터 14건 실등록 워크스루], 2026-08-08 UI 수정 → 버그 수정으로 이동, 2026-08-12 범위 확대) — role 정보가 `/api/auth/me`로 비동기 도착하기 전 기본값이 "일반"이라 관리자에게 순간적으로 오탐 신호를 준다. 기본값을 로딩 스켈레톤이나 빈 상태로 바꾸는 게 안전.
-  - **위치 3곳** (TODO에 admin 1곳만 적혀 있었음): `src/app/(admin)/admin/layout.tsx:32`, `src/app/(main)/(my-order)/layout.tsx:25`, `src/app/(main)/(my-profile)/layout.tsx:25` — 전부 `{session?.role === "ADMIN" ? "관리자" : "일반"} 계정` 동일 패턴.
-  - **테스트 동반 수정 필요**: 세 layout의 테스트가 `"세션이 없으면 일반 계정으로 표시한다"`로 현재 동작을 스펙으로 못박고 있다(`layout.test.tsx` 각각). 고치려면 이 assertion부터 바꿔야 하고, 그게 곧 Red proof가 된다.
-  - **섹션 이동 근거**: 관리자에게 "일반 계정"을 보여주는 건 기존 스펙 위반이라 정답이 이미 있고 회귀 테스트로 못박을 수 있다 — 시각 확인으로 닫는 UI 수정 기준에 맞지 않는다.
+- [ ] **사이드바가 최초 진입 시 관리자도 "일반 계정"으로 순간 표시** (2026-08-07 발견, 2026-08-12 범위확대 확인)
+  할 일: role 로딩 전 기본값을 "일반" 대신 로딩 스켈레톤/빈 상태로 변경. 3곳 layout 테스트의 `"세션 없으면 일반 계정"` assertion부터 수정(Red proof)
+  위치: `admin/layout.tsx:32`, `(my-order)/layout.tsx:25`, `(my-profile)/layout.tsx:25` — 3곳 동일 패턴, 대응 `layout.test.tsx` 각각
+  근거: role이 `/api/auth/me` 비동기 도착 전 기본값 "일반" — 관리자에게 순간 오탐 신호. 기존 스펙 위반(정답 있음)이라 버그수정 분류
+  완료 기준: 3곳 전부 로딩 중 오탐 표시 없음 + 테스트 그린
 
-- [ ] **존재하지 않는 productId + non-invitation category로 `updateProduct` 호출 시 `NOT_FOUND` 아닌 `INTERNAL`(500) 반환** (2026-08-07 test-suite 발견 — 2026-08-12 원인 확정) — `product.model.ts:101`의 `subCategory` 비동기 validator가 `getQuery()` 폴백으로 기존 문서의 category를 읽는데, 문서가 없으면 `category`가 `undefined`가 되어 `allowed?.includes(value) ?? false`로 무조건 검증 실패한다. 그 ValidationError를 `src/server/services/product.service.ts:286`의 `.catch`가 전부 `AppError("INTERNAL")`로 뭉갠다.
-  - 카테고리가 discriminator 없는 4종(favor/accessory/guestbook/ceremony)으로 늘며 새로 열린 경로. 최소조치로는 안 되고 validator나 `.catch` 분기 재설계가 필요하다. 데이터 무결성 문제는 아니고 에러코드 오분류 수준이라 우선순위 낮음.
+- [ ] **존재하지 않는 productId+non-invitation category로 `updateProduct` 시 `NOT_FOUND` 아닌 `INTERNAL`(500)** (2026-08-07 발견, 2026-08-12 원인확정)
+  할 일: validator 또는 `.catch` 분기 재설계 — 문서 없음(category undefined)과 실제 검증실패를 구분해 `NOT_FOUND` 반환
+  위치: `product.model.ts:106`(validate),`:112`(getQuery 폴백),`:124`(includes 판정) / `product.service.ts:293`(.catch)
+  근거: discriminator 없는 4종 카테고리(favor/accessory/guestbook/ceremony) 도입으로 새로 열린 경로. 데이터 무결성 문제 아님, 에러코드 오분류 — 우선순위 낮음
+  완료 기준: 존재하지 않는 productId 요청 시 404 응답 + 회귀 테스트
 
-- [ ] **`npm run test`(bare Vitest 진입점)가 실행 즉시 실패** (2026-08-11 발견 — 2026-08-12 영향 범위 확정) — `Projects "guard" and "integration-client" have different 'maxWorkers' but same 'sequence.groupOrder'`로 테스트 시작 전에 죽는다(2026-08-12 재현). `vitest.config.ts`에서 `guard`는 `maxWorkers: 2`인데 `integration-client`는 미지정(기본값)이라 같은 그룹에서 충돌한다.
-  - **영향 범위는 좁다**(2026-08-12 확인): PR CI 7개 job은 전부 project별 명령 또는 `unit-shards.mjs run`을 쓰고, TDD Guard의 Red/Green proof도 `run-vitest.mjs:18`에서 항상 `--project`를 지정한다. mutation 게이트도 무사하다 — `vitest.mutation.config.ts`는 project별 `maxWorkers`가 다르지만 mongo 그룹이 `fileParallelism: false`라 별도 그룹으로 갈려 충돌하지 않는다(unit+server integration 동시 실행으로 실증, 2파일 35테스트 통과).
-  - **실사용처는 `.claude/agents/test-suite.md:27` 한 줄**("테스트는 실제로 실행해서(`npm run test`) 통과 확인 후 보고"). 즉 게이트 문제가 아니라 하네스 지침 정합 문제다 — 위 "선행" 첫 항목과 함께 처리하는 편이 낫다.
-  - **방향 판단 필요**: (A) project별 `sequence.groupOrder`를 부여해 bare 진입점을 되살릴지, (B) `test` 스크립트를 제거·재정의하고 `test-suite.md`를 실제 명령으로 교정할지. 지금 설정이 project를 쪼갠 이유(샤딩·직렬 mongod)를 보면 B가 설계와 일관된다.
-  - **주의**: `vitest.mutation.config.ts`의 무사고는 `fileParallelism` 차이에 기댄 우연이다. 그룹 구성이 바뀌면 같은 오류가 mutation 게이트에서 재발할 수 있다.
+- [ ] **오케스트레이터·구현자 문서가 제거된 pre-commit 게이트를 실패 트리거로 참조 — TDD Guard 실제 메커니즘과 불일치** (2026-08-12 발견, 2026-08-13 리팩터로 재정의)
+  할 일: 4곳 문구를 "pre-edit deny(reason에 복구 커맨드 포함) → 안내대로 재시도, 반복 실패 시 에스컬레이션"으로 통일 재작성
+    1. `SKILL.md:140` 에러표 — `:14`("pre-commit gate 제거됨")와 모순, 실제 실패(pre-edit deny)에 대응하는 행이 없음
+    2. `backend-impl.md:44-45`, `frontend-impl.md:44-45` — 동일 phantom pre-commit 문구 중복(실존 훅은 `commit-msg`뿐)
+  위치: 위 3개 파일 5개 앵커
+  근거: `guard.mjs` deny가 이미 복구커맨드를 실어 보냄(`guard.mjs:69`→`pre-edit-response.mjs:3-11`→`claude.mjs:24-26`) — 실행은 안 막힘, 문서 내부 모순만 남은 상태(착수 블로커 아님)
+  완료 기준: 3개 문서 5곳 전부 실제 메커니즘 반영, `SKILL.md:14`/`:140` 모순 해소
+  참고: `test-suite.md`의 `npm run test` 문제는 인박스 "test-suite.md 사실오류" 항목에 흡수(별개 근본원인)
 
 ---
 
 ## 성능 개선
 
-- [ ] **`Product` 복합 인덱스 추가 검토** (2026-08-07 — 2026-08-12 재확인: `_id` 외 인덱스 선언 0개) — 카테고리가 1종→5종으로 늘면서 `category` 필터에 실질적 선택도가 처음 생겼다. 제안: `{deletedAt:1, category:1, isFeatured:-1, priority:-1, createdAt:-1}`(ESR 순서). 이 인덱스는 `category` 지정 호출만 커버하고 전체 목록 경로(category 미지정)는 여전히 in-memory sort라, 두 경로를 다 커버하려면 인덱스 2개가 필요 — 실 데이터 규모를 보고 판단한다.
+- [ ] **`Product` 복합 인덱스 추가 검토** (2026-08-07 발견, 2026-08-12 확인: 인덱스 0개)
+  할 일: `{deletedAt:1, category:1, isFeatured:-1, priority:-1, createdAt:-1}`(ESR순) 인덱스 추가 검토 — category 미지정 전체목록 경로는 여전히 in-memory sort라 커버하려면 별도 인덱스 1개 더 필요
+  위치: `Product` 모델
+  근거: 카테고리 1→5종 확장으로 category 필터에 실질적 선택도 발생, 현재 `_id` 외 인덱스 없음
+  완료 기준: 실데이터 규모 확인 후 필요시 인덱스 추가 + 쿼리플랜 전후 대조(수치)
 
 ---
 
 ## UI 수정
 
-- [ ] **상품 등록 폼이 연속 등록 워크플로우를 지원하지 않음** (2026-08-07 발견 [발견: 목데이터 14건 실등록 워크스루], 버그수정 클러스터3과 같은 컴포넌트 — 함께 처리 권장, 2026-08-12 재확인) — 등록 성공 시 무조건 `/admin/products` 목록으로 리다이렉트한다(`src/app/(admin)/admin/products/new/_components/ProductRegistrationForm.tsx:27`). 여러 상품을 한 번에 등록하는 시나리오에서 매번 메뉴를 다시 눌러 폼을 처음부터 채워야 한다 — 카테고리/서브카테고리 등 직전 값을 유지한 채 "저장하고 계속 등록" 옵션이 있으면 대량 등록 비용이 크게 준다.
+- [ ] **상품 등록 폼이 연속 등록 워크플로우 미지원** (2026-08-07 발견, 2026-08-12 확인, 버그수정 클러스터3과 동일 컴포넌트 — 함께 처리 권장)
+  할 일: 등록 성공 시 카테고리/서브카테고리 값 유지한 채 "저장하고 계속 등록" 옵션 추가(현재 무조건 `/admin/products` 리다이렉트)
+  위치: `.../admin/products/new/_components/ProductRegistrationForm.tsx:27`
+  근거: 대량 등록 시나리오에서 매번 폼을 처음부터 채워야 함
+  완료 기준: 연속 등록 시 직전 카테고리값 유지(시각 확인)
 
 ---
 
 ## 미분류 인박스
 
-> 작업 브랜치는 **이 구역에만 append**한다. 정식 섹션으로의 분류·이동·완료 체크는 `docs/todo-section-taxonomy` 브랜치에서만 한다.
-> 항목 형식: `- [ ] (날짜, 발견 맥락) 증상 — 위치/근거`
+> 작업 브랜치는 **이 구역에만 append**한다(경량 포맷: `- [ ] (날짜, 발견 맥락) 증상 — 위치/근거`, 아래 서술형 대신 이 형식으로 추가). 정식 섹션으로의 분류·이동·완료 체크, 하위 그룹 재편은 `docs/todo-section-taxonomy` 브랜치에서만 한다. 완료 처리는 항목을 지우는 것으로 끝난다 — git log가 기록을 대신한다.
 
-- [ ] (2026-08-09, connect.ts 가드를 연결 시점으로 옮기며 발견 — 2026-08-12 재확인 `connect.ts:35`) `connect.ts`의 `testUri ?? srvUri`가 빈 문자열을 "값 있음"으로 취급 — `MONGO_TEST_URI=`처럼 키만 있고 값이 빈 경우 `??`가 폴백하지 않아 `uri`가 빈 문자열이 되고 연결이 원인 불명 에러로 실패한다. `||`로 바꾸면 해소되나 프로덕션 동작 변경이라 별도 판단 필요.
-- [ ] (2026-08-10, 변경 테스트 범위 실측 중 발견 — 2026-08-12 근거 갱신, 2026-08-12 재확인: 타입 import 정리(#16) 후에도 잔존) 배럴 강제 규칙의 누적 비용 — `src/` 전체의 `vi.mock("@/...")` 호출이 **112건**이고 그중 배럴 디렉터리를 그대로 mock하는 상위가 `@/server/services` 27, `@/server/actions` 14, `@/client/hooks` 14, `@/client/components/organisms` 8이며, 타입 하나를 배럴로 가져오는 것만으로 TDD Guard의 요구 scope가 `integration`으로 부풀어 오른다. `import type`/`export type` 강제(#16)로 타입 단독 참조 케이스는 줄었지만 배럴이 값도 함께 재수출하는 한 근본 해소는 아니다 — 아래 "요구 scope 판정" 재검토 항목과 직결. 규칙 재검토 필요.
-- [ ] (2026-08-10, Vitest 실행 로그 점검 중 발견 — 2026-08-12 재확인: 실행당 **6줄**) `vite-tsconfig-paths`가 Vite 네이티브 `resolve.tsconfigPaths: true`로 교체하라는 경고를 매 실행 출력 — 플러그인 제거와 네이티브 설정 전환 검토 필요.
-- [ ] (2026-08-11, 공통 TDD Guard 배포 전 검증 완료 후 보류) 배포 환경에 `.env.example`의 운영 필수 값과 `MAIN_PREVIEW_INFO_ID`, `MAIN_PREVIEW_PRODUCT_ID`, `CLOUDINARY_UPLOAD_PRESET`을 등록하고 실제 배포 URL로 Lighthouse 감사를 실행해야 함 — 현재 미배포 상태라 로컬·PR CI 검증 범위에서 제외함.
-- [ ] (2026-08-11, KG이니시스 `inicis_v2` 테스트 채널 확정 후 보류) 배포된 HTTPS 환경에서 PortOne 실제 결제 manual smoke를 수행해야 함 — GUI self-hosted runner(`self-hosted`, `linux`, `x64`, `portone-smoke`)와 사람의 카드사 인증으로 12,000원 결제, `PAID` 조회, store/TEST channel/payment ID 검증, 전액 취소 및 `CANCELLED` 재조회를 확인하고 실패 시에도 cleanup을 보장해야 함.
-- [ ] (2026-08-11, PortOne webhook 구현 후 배포 검증 보류) 배포 URL을 PortOne webhook으로 등록하고 운영 `PORTONE_WEBHOOK_SECRET`을 설정한 뒤 진위 검증, 멱등 처리 및 주문 상태 반영을 실제 webhook 전달로 확인해야 함 — `src/app/api/webhooks/portone/route.ts` 및 `src/server/services/payment.service.ts`.
-- [ ] (2026-08-12, 위 항목 측정 중 파생, 2026-08-12 실측치 갱신) 요구 scope 판정이 import 전이 폐포를 쓰는 게 옳은지 재검토 필요 — 직접 import만 경계로 치면 69/410(17%)까지 떨어지지만, `src/server/actions/*`처럼 service를 경유해 DB에 닿는 파일이 unit만 요구하게 되어 과소 요구로 뒤집힌다. `docs/validation/testing-classification.md:16`의 "둘 이상의 실제 경계를 연결" 기준에 맞는 중간 규칙이 필요하다. **타입 import 정리(#16) 완료 후 수치: 308/410(75.1%) → 262/410(63.9%)** — 나머지 262개는 실제 값 의존이라 이 규칙만으로는 안 줄어든다. 위 배럴 강제 규칙 누적비용 항목과 함께 이제 판단 시점.
-- [ ] (2026-08-12, guard 자체 수정 절차 확인 중 발견) `scripts/tdd-guard/core/run-vitest.mjs:6`의 `projectFor`가 scope `unit`이면 항상 project `unit`을 반환해 `scripts/**/*.test.mjs`(project `guard`)를 실행하지 못한다. guarded 범위가 `src/`로 좁혀져 당장 실害는 없으나, scripts 테스트를 Red/Green proof 흐름으로 돌릴 수단이 없다는 사실은 남는다.
-- [ ] (2026-08-12, AST 판정기 수정 중 관측) `scripts/test-scope/test-graph.mjs:41`의 `element.isTypeOnly`가 TypeScript deprecation 경고(TS6385) 대상 — 대체 API 확인 후 정리 필요.
-- [ ] (2026-08-12, 위와 같은 조사 중 보류) `codex.mjs`가 내보내는 `hookSpecificOutput`/`hookEventName: "PreToolUse"`/`permissionDecision`은 Claude Code 스키마 어휘라 Codex CLI가 실제로 이 형태를 소비하는지 미확인 — `.codex/hooks.json`도 Claude Code 구조(`matcher`/`statusMessage`)를 그대로 본떴다. 계약이 다르면 `exit 0`으로 나가 차단 자체가 안 걸릴 수 있음. Codex 문서 확인 + 실증 필요.
+### 배포 후 실행 (미배포 상태라 보류 — 배포되면 순서대로)
 
-### 처리 완료 · 전제 소멸 (2026-08-12 전수 재검증)
+- [ ] **배포 환경 변수 등록 + Lighthouse 감사** (2026-08-11) — `.env.example`의 운영 필수 값 + `MAIN_PREVIEW_INFO_ID`/`MAIN_PREVIEW_PRODUCT_ID`/`CLOUDINARY_UPLOAD_PRESET` 등록 후 실제 배포 URL로 Lighthouse 실행.
+- [ ] **PortOne 실결제 manual smoke** (2026-08-11, `inicis_v2` 테스트 채널 확정됨) — self-hosted runner(`self-hosted`,`linux`,`x64`,`portone-smoke`) + 사람 카드 인증으로 12,000원 결제→`PAID` 조회→store/channel/paymentId 검증→전액취소→`CANCELLED` 재조회. 실패해도 cleanup 보장.
+- [ ] **PortOne webhook 실전달 검증** (2026-08-11) — 배포 URL을 webhook으로 등록, 운영 `PORTONE_WEBHOOK_SECRET` 설정, 진위검증·멱등처리·주문상태반영을 실제 전달로 확인. 위치: `src/app/api/webhooks/portone/route.ts`, `payment.service.ts`.
 
-- [x] (2026-08-12 완료, `#14` `c342ef9`) TDD Guard 요구 scope 산정이 type-only import를 정규식으로 긁어 걸러내지 못하던 문제 — `classify-scope.mjs`가 `test-graph.mjs`의 TS AST(`runtimeSpecifiers`)로 판정하도록 전환. 원래 "선행" 2번 항목이었다.
-- [x] (2026-08-12 완료, `#16` `refactor/type-import-conventions`) 위 AST 전환 후에도 소스에 `import type` 표기 자체가 거의 없어 실효가 2개뿐이던 잔여 문제 — `@typescript-eslint/consistent-type-imports`(autofix 286건) + `consistent-type-exports`(배럴 재수출 정리, autofix 8건) + `tsconfig.json` `verbatimModuleSyntax: true`(잔여 TS1484 6건 수동)로 3층 규약을 강제. 결과: `src/**` integration 요구 308/410(75.1%) → 262/410(63.9%), 46개(11.2%p) 감소 — 극적이지 않은 이유와 남은 262개의 성격은 인박스 "요구 scope 판정" 재검토 항목·`docs/conventions/type-imports.md` 참고. `AGENTS.md` Cross-cutting References에 트리거 등록 완료.
-- [x] (2026-08-12 완료, `#17` `chore/remove-type-import-exception`) `#16` 작업에 쓰인 `tdd-exceptions.json`의 `type-import-convention-refactor-2026-08`(만료 2026-08-26) 예외를 작업 종료 즉시 삭제 — 만료까지 기다리지 않고 조기 처리.
-- [x] (2026-08-12 완료) `.claude/agents/backend-impl.md`/`frontend-impl.md`가 규정하는 phantom pre-commit 게이트 항목이 `claude.mjs` 어댑터 버그 수정(#15) 중 재발견돼 인박스에 중복 등록됐던 것 — 새 정보 없이 "선행" 1번 항목과 동일해 그쪽에 흡수, 인박스 사본은 제거.
-- [x] (2026-08-12 완료) `src/shared/AGENTS.md`의 근거 없는 server/client/shared 3분할 배경 문서 참조를 제거.
-- [x] (2026-08-12 완료) 소스→테스트 매핑을 `scripts/test-scope/test-graph.mjs`로 통합하고 `scripts/tdd-guard/core/resolve-tests.mjs`에서 사용하도록 정리.
-- [x] (2026-08-12 해소 확인) `updateProduct`의 `thumbnail` required 부채 — `src/shared/schemas/request/product.schema.ts:31`이 `File | URL string` union으로 바뀌었고 `updateProduct.ts:45,73`에 `currentThumbnail` 폴백이 있다. 수정 시 썸네일 재업로드 강제가 없다.
-- [x] (2026-08-12 해소 확인) `feature-team-orchestrator/SKILL.md:14`의 검증 안내 불일치 — 이미 TDD Guard 계약으로 갱신됨. 단 같은 파일 `:140`은 아직 낡아서 버그수정 "선행" 첫 항목으로 이관.
-- [x] (2026-08-12 해소 확인) `embla-carousel-wheel-gestures` 미설치 — 설치돼 있음(로컬 환경 드리프트였음).
-- [x] (2026-08-12 전제 소멸) `test:coverage:diff`가 괄호 경로(라우트 그룹)를 커버리지 게이트에서 누락하던 문제(#24) — 커버리지 게이트 자체가 제거됐다. `package.json`에 `test:coverage*` 스크립트가 없고 `vitest.config.ts`에 `coverage` 설정이 없으며, 게이트는 TDD Guard(Red/Green proof) + changed mutation으로 대체됐다.
-  - **결함 클래스 재발 없음 확인**: `vitest list --project unit "src/app/(admin)"`이 테스트를 정상 수집한다(위치인자는 substring 매칭이라 괄호가 문제되지 않음). 나아가 `scripts/test-scope/unit-shards.mjs`의 `verifyUnitShards`가 "모든 unit 테스트 파일이 정확히 1개 샤드에 속함"을 CI에서 강제해 침묵 누락 구멍이 구조적으로 막혀 있다.
-- [x] (2026-08-12 전제 소멸) 라우트 그룹 컴포넌트 4개의 line coverage 80% 미달 부채 — 커버리지 측정·게이트가 제거되어 기준 자체가 없다. 품질 부채를 다시 재려면 mutation 기준으로 재정의해야 한다.
-- [x] (2026-08-12 전제 소멸) Vitest `--coverage.changed`가 unstaged/untracked를 포함하던 관측 항목 — 커버리지 경로 자체가 없다.
-- [x] (2026-08-12 정식 섹션 이관) `.git/hooks/commit-msg` prefix 정규식이 전역 `GIT.md` 택소노미와 어긋나던 문제 — 정규식은 2026-08-10에 이미 고쳐졌고, 남은 문제는 그 훅이 저장소 분리 때 tie-knot으로 따라오지 못했다는 것이다. 버그수정 "선행" 항목(저장소 분리 유실물 복원)으로 옮김.
-- [x] (2026-08-12 불필요 판정) `.claude/hooks/pre-commit-check.sh`가 Git hook이 아니라는 항목 — 파일·디렉터리째 사라졌고 그것이 부르던 `npm run test:paired`도 `package.json`에 없다. 코드 검사 책임은 TDD Guard(에이전트 훅)와 PR CI가 나눠 가지므로 복원하지 않는다. 커밋 규칙 강제는 메시지 검사(`commit-msg`)로만 되살린다.
-- [x] (2026-08-12 전제 소멸) WSL 메모리 상한에 맞춘 `maxWorkers: "50%"` 제안 — 현재 `vitest.config.ts`는 project별로 `maxWorkers`를 명시(`guard`/`unit` 2, mongo 계열 1)하는 구조라 제안 내용이 그대로 적용되지 않는다.
+### TDD Guard 정책 재검토
+
+- [ ] **요구 scope 판정 규칙 — 배럴 재수출 + import 전이 경계** (2026-08-10 발견, 2026-08-12 수치 갱신) — `vi.mock("@/...")` 112건 중 배럴 디렉터리 통째 mock이 상위 4곳(`@/server/services` 27·`@/server/actions` 14·`@/client/hooks` 14·`@/client/components/organisms` 8). 타입 import 강제(#16) 후 integration 요구 308/410(75.1%)→262/410(63.9%)로 46개 줄었지만 나머지 262개는 실값 의존이라 그 규칙만으론 더 안 줄어듦. 직접 import만 경계로 좁히면 69/410(17%)까지 떨어지나 `src/server/actions/*`처럼 service 경유 DB접근 파일이 unit만 요구하게 돼 과소 요구로 뒤집힘 — `testing-classification.md:16`("둘 이상의 실제 경계 연결") 기준에 맞는 중간 규칙 필요. 위치: `classify-scope.mjs`.
+- [ ] **`run-vitest.mjs`가 `guard` project(scripts 테스트)를 실행 못함** (2026-08-12) — `projectFor`가 scope `unit`이면 항상 project `unit` 반환, `scripts/**/*.test.mjs`(project `guard`)는 대상 밖. guarded 범위가 `src/`뿐이라 당장 실해는 없으나 scripts 테스트를 Red/Green proof로 못 돌림. 위치: `run-vitest.mjs:6`.
+- [ ] **`codex.mjs` 훅 스키마가 Codex CLI 계약과 맞는지 미확인** (2026-08-12) — `hookSpecificOutput`/`permissionDecision` 등은 Claude Code 스키마 어휘. `.codex/hooks.json`도 Claude Code 구조(`matcher`/`statusMessage`)를 본떴다. 계약이 다르면 `exit 0`으로 나가 차단이 안 걸릴 수 있음 — Codex 문서 확인 + 실증 필요.
+- [ ] **test-suite agent 사실오류 + 역할 재설계** (2026-08-13) — `:11` "브라우저 E2E(Playwright) 없음"은 거짓(`testing/e2e/core.spec.ts`가 `npm run test:e2e`로 `tdd.yml:117` CI 게이트로 실행 중), `:19`는 같은 파일에서 Playwright를 인프라로 언급해 `:11`과 자기모순, `:27` `npm run test`(bare)는 항상 실패. 요구: agent 이름·역할·skill 재설계 — Phase4 골든패스를 unit/integration/E2E 중 어디에 반영할지 판단 기준이 없다, `boundary-verifier`+`boundary-verify` 패턴으로 전환. 실행은 `harness` 스킬.
+
+### 잡음 정리 (낮은 우선순위)
+
+- [ ] **`vite-tsconfig-paths` deprecation 경고** (2026-08-10) — 실행당 6줄 출력, Vite 네이티브 `resolve.tsconfigPaths:true`로 교체 검토.
+- [ ] **`test-graph.mjs`의 `element.isTypeOnly` deprecation(TS6385)** (2026-08-12) — 대체 API 확인 후 정리. 위치: `test-graph.mjs:41`.
+
+### 개별 판단 필요
+
+- [ ] **`connect.ts`의 `??`가 빈 문자열을 폴백 안 함** (2026-08-09) — `testUri ?? srvUri`는 `MONGO_TEST_URI=`처럼 값이 빈 문자열이면 폴백 안 해 연결이 원인불명 에러로 실패. `||`로 바꾸면 해소되나 프로덕션 동작 변경이라 판단 필요. 위치: `connect.ts:35`.

--- a/TODO.md
+++ b/TODO.md
@@ -103,6 +103,12 @@
   근거: 카테고리 1→5종 확장으로 category 필터에 실질적 선택도 발생, 현재 `_id` 외 인덱스 없음
   완료 기준: 실데이터 규모 확인 후 필요시 인덱스 추가 + 쿼리플랜 전후 대조(수치)
 
+- [ ] **PR CI가 변경 파일과 무관하게 14개 job 전량 실행** (2026-08-13 발견, PR #19가 TODO.md 1줄 변경으로 unit×7/integration×2/e2e/mutation 등 14개 전부 트리거됨)
+  할 일: `dorny/paths-filter`로 첫 job에서 changed-files boolean 산출 → 나머지 14개 job은 `needs: filter`로 받아 실제 테스트 실행 스텝만 `if:`로 감싼다. **워크플로우 레벨 `paths-ignore`나 job 자체 skip은 쓰지 않는다** — job이 안 돌면 required check가 "Pending"에 멈춰 PR이 영구 대기(GitHub 공식 문서 확인된 gotcha).
+  위치: `.github/workflows/tdd.yml`
+  근거: `dev` 브랜치 protection에 14개 전부 required_status_checks로 걸려있고 `enforce_admins:true`(`gh api repos/.../branches/dev/protection` 확인) — job은 유지한 채 내부 스텝만 조건부 skip해야 required 계약이 안 깨짐. 업계 표준(빠른 건 자주, 느린 건 조건부)과도 일치, `dorny/paths-filter`+`needs`/`if:` 패턴이 사실상 정석([GitHub 공식 트러블슈팅](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks), [Pantsbuild](https://www.pantsbuild.org/blog/2022/10/10/skipping-github-actions-jobs-without-breaking-branch-protection)).
+  완료 기준: docs-only PR에서 무거운 job(e2e/mutation/integration/unit)이 실제 테스트 없이 즉시 success 보고 + required check 14개 전부 정상 충족 확인, src/scripts 변경 PR에서는 기존과 동일하게 전부 실행되는 것도 대조 확인
+
 ---
 
 ## UI 수정


### PR DESCRIPTION
## Summary

- TODO.md 전 항목을 `할 일/위치/근거/완료 기준` 템플릿으로 재작성 — 증상 서술과 지시문이 뭉쳐 있어 "오늘 뭘 해야 하는지"가 산문 속에 묻히던 문제를 구조로 분리
- PR·src 이중검증으로 CODEOWNERS/PR템플릿(`#13`에서 이미 해소, 반영 누락 발견)·commit-msg 훅(데스크탑 clone에 재구성·테스트) 완료 이관, 인용 라인번호 5곳 드리프트 갱신
- "선행" 항목("하네스 문서가 phantom pre-commit 게이트 명시") 재검토 — TDD Guard deny 메시지가 이미 자기완결적(복구 커맨드 포함)이라 착수를 막지 않는다고 판단, 블로커 프레이밍을 버리고 "단독" 문서 리팩터 항목으로 재분류
- 처리완료 섹션 삭제 — git log/커밋메시지가 이미 더 정확한 기록을 갖고 있어 중복. 미분류 인박스는 주제별 4그룹(배포후실행/TDD Guard 정책 재검토/잡음정리/개별판단)으로 재구조화, 중복 항목(배럴규칙+요구scope 판정) 병합
- test-suite.md 사실오류(E2E 부정, 내부모순, `npm run test` 항상실패) + agent 역할 재설계 필요성을 인박스에 신규 등록

## Test plan

- `.git/hooks/commit-msg` — 정상/위반 케이스(prefix없음/마침표/wip/72자초과) 4패턴 전부 의도대로 거부, 과거 커밋 3건 통과 확인 후 이번 커밋도 그 훅 통과로 생성됨
- `npm run test` 재실행 — TODO가 인용한 에러(`maxWorkers`/`sequence.groupOrder` 충돌) 그대로 재현, 근본원인 서술 정확성 확인
- `grep`으로 CODEOWNERS/`.github/pull_request_template.md`/`testing/e2e/core.spec.ts`/`@playwright/test` 등 TODO 갱신에 인용한 파일·설정 실존 여부 전수 확인
- Not run: TODO.md 자체가 문서 전용 변경이라 앱 빌드/vitest 스위트는 대상 아님