### PR TITLE
ci(tdd): skip heavy job steps on docs-only PRs

### DIFF
--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -19,7 +19,24 @@ env:
   DEPLOYMENT_BASE_URL: http://127.0.0.1:3100
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          predicate-quantifier: some-with-excludes
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+
   static:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -36,10 +53,12 @@ jobs:
         with:
           path: ~/.cache/mongodb-binaries
           key: mongodb-8.2.6-${{ runner.os }}
-      - run: npm run lint && npm run typecheck && node scripts/ci/build.mjs
+      - if: needs.changes.outputs.code == 'true'
+        run: npm run lint && npm run typecheck && node scripts/ci/build.mjs
 
   unit-shard:
     name: unit-${{ matrix.shard }}
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -55,6 +74,7 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm ci
       - name: Run unit shard
+        if: needs.changes.outputs.code == 'true'
         run: |
           echo '| Shard | Files | Tests | Duration |' >> "$GITHUB_STEP_SUMMARY"
           echo '| --- | ---: | ---: | ---: |' >> "$GITHUB_STEP_SUMMARY"
@@ -62,7 +82,7 @@ jobs:
 
   unit:
     if: always()
-    needs: unit-shard
+    needs: [changes, unit-shard]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -70,6 +90,7 @@ jobs:
         run: test '${{ needs.unit-shard.result }}' = 'success'
 
   integration-client:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -80,9 +101,11 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - run: npm run test:integration:client
+      - if: needs.changes.outputs.code == 'true'
+        run: npm run test:integration:client
 
   integration-server:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -100,9 +123,11 @@ jobs:
           path: ~/.cache/mongodb-binaries
           key: mongodb-8.2.6-${{ runner.os }}
       - run: npm ci
-      - run: npm run test:integration:server
+      - if: needs.changes.outputs.code == 'true'
+        run: npm run test:integration:server
 
   e2e-core:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -113,10 +138,13 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - run: npx playwright install --with-deps chromium
-      - run: npm run test:e2e
+      - if: needs.changes.outputs.code == 'true'
+        run: npx playwright install --with-deps chromium
+      - if: needs.changes.outputs.code == 'true'
+        run: npm run test:e2e
 
   mutation-changed:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -135,9 +163,11 @@ jobs:
           path: ~/.cache/mongodb-binaries
           key: mongodb-8.2.6-${{ runner.os }}
       - run: npm ci
-      - run: npm run test:mutation -- --base origin/dev
+      - if: needs.changes.outputs.code == 'true'
+        run: npm run test:mutation -- --base origin/dev
 
   tdd-policy:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -150,6 +180,9 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - run: npx vitest run --project guard
-      - run: node scripts/test-scope/unit-shards.mjs verify
-      - run: node scripts/tdd-guard/bin/guard.mjs verify --ci
+      - if: needs.changes.outputs.code == 'true'
+        run: npx vitest run --project guard
+      - if: needs.changes.outputs.code == 'true'
+        run: node scripts/test-scope/unit-shards.mjs verify
+      - if: needs.changes.outputs.code == 'true'
+        run: node scripts/tdd-guard/bin/guard.mjs verify --ci


### PR DESCRIPTION
## Summary

- PR이 markdown 파일만 바꿔도 `dev` 브랜치 protection의 required check 14개가 전부 풀 실행됐다(예: PR #19가 TODO.md 1줄로 unit x7/integration x2/e2e/mutation 등 전량 트리거). `dorny/paths-filter`로 신규 `changes` job을 추가해 코드 변경 여부(`code`, `!**/*.md` 기준)를 boolean으로 산출하고, 기존 9개 job은 그 output에 `needs`로 연결해 실제 테스트/빌드/lint 실행 스텝만 조건부(`if: needs.changes.outputs.code == 'true'`)로 감쌌다.
- job 자체를 조건부 skip하지 않고 스텝만 감싼 이유: `unit-shard`는 matrix 전략으로 7개 named required context(`unit-server` 등)를 만드는데, job 레벨에서 skip하면 이번 run에서 matrix가 아예 확장되지 않아 해당 context가 생성되지 못하고 GitHub가 그 이름의 status를 영영 못 받아 required check가 "Expected" 상태로 고착된다(GitHub 공식 troubleshooting 문서 확인된 gotcha). 그래서 checkout/setup-node/npm ci는 그대로 두고 각 job의 마지막 실행 스텝만 조건부 처리했다.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tdd.yml'))"` — YAML 문법 OK
- Not run: 이 PR 자체는 `.github/workflows/tdd.yml`(비-md) 변경이라 `code=true`로 평가되어 기존과 동일하게 14개 job 풀 실행됨(회귀 확인 겸함) — docs-only PR에서 실제로 스킵되는지, 그리고 `unit-shard` matrix 7개 named context가 스킵 상태에서도 전부 생성되는지는 이 PR 머지 후 TODO.md류 문서 전용 PR로 별도 확인 필요(TODO.md #106 완료 기준)