### PR TITLE
docs: verify CI paths-filter docs-only skip (no merge)

### DIFF
--- a/docs/_ci-skip-probe.md
+++ b/docs/_ci-skip-probe.md
@@ -1,0 +1,4 @@
+# CI skip probe (throwaway)
+
+이 파일은 `dorny/paths-filter` docs-only skip 동작 실증용 임시 파일이다.
+PR #20 검증 목적으로만 존재하며 merge 없이 close 후 삭제된다.


### PR DESCRIPTION
## Summary

- PR #20에서 추가한 `dorny/paths-filter` docs-only skip 경로 실증용 테스트 PR. 검증 후 merge 없이 close.

## Test plan

- `Not run: 이 PR 자체가 검증 대상`