### PR TITLE
perf: add composite indexes for product list/search queries

### DIFF
--- a/src/server/models/product.model.ts
+++ b/src/server/models/product.model.ts
@@ -162,6 +162,20 @@ const productSchema = new Schema<IProduct>(
   },
 );
 
+// getAllProductsService(category 지정) — deletedAt 등가 + category 등가 +
+// isFeatured/priority/createdAt 정렬을 index-only로 커버.
+productSchema.index(
+  { deletedAt: 1, category: 1, isFeatured: -1, priority: -1, createdAt: -1 },
+  { name: "deletedAt_category_isFeatured_priority_createdAt" },
+);
+
+// getAllProductsService(category 미지정)/searchProductsService의 deletedAt prefix —
+// category가 쿼리에 없을 때 위 인덱스는 category별 그룹이 섞여 정렬을 못 지켜준다.
+productSchema.index(
+  { deletedAt: 1, isFeatured: -1, priority: -1, createdAt: -1 },
+  { name: "deletedAt_isFeatured_priority_createdAt" },
+);
+
 export const ProductModel =
   (mongoose.models.Product as Model<IProduct>) ||
   model<IProduct>("Product", productSchema);

--- a/src/server/services/product.service.integration.test.ts
+++ b/src/server/services/product.service.integration.test.ts
@@ -4,6 +4,7 @@ import { dbConnect } from "@/server/lib/mongodb";
 import { buildProductInput, clearCollections } from "@testing/support";
 import { AppError } from "@/shared/types";
 import { ProductModel, InvitationProductModel } from "@/server/models";
+import { escapeRegExp, findProductCategoriesByTerm, findSubCategoriesByTerm } from "@/shared/utils";
 import {
   createProductService,
   getProductService,
@@ -739,6 +740,161 @@ describe("product.service", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].isLiked).toBe(true);
+    });
+  });
+
+  describe("Product 복합 인덱스 (explain)", () => {
+    interface ExplainPlanNode {
+      stage?: string;
+      indexName?: string;
+      inputStage?: ExplainPlanNode;
+      inputStages?: ExplainPlanNode[];
+      queryPlan?: ExplainPlanNode;
+    }
+
+    interface ExplainResult {
+      queryPlanner: { winningPlan: ExplainPlanNode };
+    }
+
+    // classic(`{stage, inputStage}` 체인)과 SBE(`{queryPlan:{...}, slotBasedPlan}`) 두 explain
+    // 출력 모양을 다 대응한다 — mongod 8.x는 쿼리에 따라 SBE 플래너를 쓸 수 있다.
+    const analyzeWinningPlan = (winningPlan: ExplainPlanNode) => {
+      const stages = new Set<string>();
+      const indexNames: string[] = [];
+
+      const walk = (node: ExplainPlanNode | undefined) => {
+        if (!node) return;
+        if (typeof node.stage === "string") {
+          stages.add(node.stage);
+          if (node.stage === "IXSCAN" && typeof node.indexName === "string") {
+            indexNames.push(node.indexName);
+          }
+        }
+        walk(node.inputStage);
+        node.inputStages?.forEach(walk);
+      };
+
+      walk(winningPlan.queryPlan ?? winningPlan);
+      return { stages, indexNames };
+    };
+
+    const buildIndexedProduct = (overrides: {
+      title: string;
+      category: string;
+      subCategory: string;
+      isFeatured: boolean;
+      priority: number;
+      createdAt: Date;
+      deletedAt?: Date | null;
+    }) => ({
+      authorId: "index-seed",
+      title: overrides.title,
+      description: "인덱스 검증용 시드 데이터",
+      thumbnail: "https://example.com/thumbnail.jpg",
+      price: 10000,
+      category: overrides.category,
+      subCategory: overrides.subCategory,
+      isPremium: false,
+      isFeatured: overrides.isFeatured,
+      priority: overrides.priority,
+      likes: [] as string[],
+      views: 0,
+      salesCount: 0,
+      discount: { discountType: "rate", value: 0 },
+      status: "active",
+      featureIds: [] as string[],
+      deletedAt: overrides.deletedAt ?? null,
+      images: [] as string[],
+      minQuantity: 1,
+      maxQuantity: 0,
+      createdAt: overrides.createdAt,
+      updatedAt: overrides.createdAt,
+    });
+
+    beforeEach(async () => {
+      // mongoose autoIndex는 모델 컴파일 시점에 비동기로 시작되고 앱 어디서도 await되지 않는다
+      // (`dbConnect()`는 연결만 기다린다) — explain/hint는 인덱스 빌드가 실제로 끝나야 그 인덱스를
+      // 후보로 인정하므로, 이 describe에서만 명시적으로 완료를 기다려 레이스를 없앤다.
+      await ProductModel.init();
+
+      // 옵티마이저가 IXSCAN/COLLSCAN을 무차별하게 고르지 않도록 충분한 문서 수 확보.
+      const now = Date.now();
+      const docs = Array.from({ length: 24 }, (_, i) =>
+        buildIndexedProduct({
+          title: `인덱스 시드 상품 ${i}`,
+          category: i % 2 === 0 ? "invitation" : "ceremony",
+          subCategory: i % 2 === 0 ? "wedding" : "program-book",
+          isFeatured: i % 3 === 0,
+          priority: i % 5,
+          createdAt: new Date(now - i * 60_000),
+          deletedAt: i % 8 === 7 ? new Date(now) : null,
+        }),
+      );
+      await ProductModel.collection.insertMany(docs as never[]);
+
+      // 이 파일의 다른 describe 블록들이 앞서 같은 query shape(예: {deletedAt:null} + 동일 sort)를
+      // 훨씬 적은 문서 수로 실행해 plan cache에 승자를 이미 남겨둘 수 있다 — 매 테스트가 지금 시드한
+      // 문서 분포로 실제 multi-plan competition을 다시 거치도록 강제로 비운다.
+      await mongoose.connection.db?.command({ planCacheClear: ProductModel.collection.collectionName });
+    });
+
+    it("getAllProductsService(category 지정, product.service.ts:164-171) 경로는 IXSCAN을 쓴다", async () => {
+      const explainResult = (await ProductModel.find({ deletedAt: null, category: "invitation" })
+        .sort({ isFeatured: -1, priority: -1, createdAt: -1 })
+        .explain("executionStats")) as unknown as ExplainResult;
+
+      const { stages, indexNames } = analyzeWinningPlan(explainResult.queryPlanner.winningPlan);
+
+      expect(stages.has("COLLSCAN")).toBe(false);
+      expect(indexNames).toContain("deletedAt_category_isFeatured_priority_createdAt");
+    });
+
+    it("getAllProductsService(category 미지정, product.service.ts:164-171) 경로는 IXSCAN을 쓴다", async () => {
+      const explainResult = (await ProductModel.find({ deletedAt: null })
+        .sort({ isFeatured: -1, priority: -1, createdAt: -1 })
+        .explain("executionStats")) as unknown as ExplainResult;
+
+      const { stages, indexNames } = analyzeWinningPlan(explainResult.queryPlanner.winningPlan);
+
+      expect(stages.has("COLLSCAN")).toBe(false);
+      expect(indexNames).toContain("deletedAt_isFeatured_priority_createdAt");
+    });
+
+    it("searchProductsService(product.service.ts:202-204)의 deletedAt prefix만으로도 IXSCAN을 쓴다", async () => {
+      const explainResult = (await ProductModel.find({ deletedAt: null })
+        .sort({ isFeatured: -1, priority: -1, createdAt: -1 })
+        .explain("executionStats")) as unknown as ExplainResult;
+
+      const { indexNames } = analyzeWinningPlan(explainResult.queryPlanner.winningPlan);
+
+      expect(indexNames).toContain("deletedAt_isFeatured_priority_createdAt");
+    });
+
+    it("searchProductsService(product.service.ts:186-204)의 $or 쿼리도 deletedAt prefix로 COLLSCAN 없이 처리된다", async () => {
+      const term = "예식";
+      const or: Record<string, unknown>[] = [
+        { title: { $regex: escapeRegExp(term), $options: "i" } },
+      ];
+
+      const categoryKeys = findProductCategoriesByTerm(term);
+      expect(categoryKeys).toContain("ceremony");
+      or.push({ category: { $in: categoryKeys } });
+
+      const subCategoryKeys = findSubCategoriesByTerm(term);
+      expect(subCategoryKeys).toContain("program-book");
+      or.push({ subCategory: { $in: subCategoryKeys } });
+
+      const explainResult = (await ProductModel.find({ deletedAt: null, $or: or })
+        .sort({ isFeatured: -1, priority: -1, createdAt: -1 })
+        .explain("executionStats")) as unknown as ExplainResult;
+
+      const { stages, indexNames } = analyzeWinningPlan(explainResult.queryPlanner.winningPlan);
+
+      // 실측 결과: title regex(anchor 없음)/subCategory 둘 다 전용 인덱스가 없지만, mongo는
+      // $or를 절별로 쪼개 COLLSCAN을 섞지 않는다 — deletedAt 등가만으로 Index B(IXSCAN) 하나를
+      // 골라 그 결과 집합에 $or 3절 전체를 FETCH 단계의 잔여 필터로 얹는다. COLLSCAN은 없다.
+      expect(stages.has("COLLSCAN")).toBe(false);
+      expect(indexNames).toContain("deletedAt_isFeatured_priority_createdAt");
     });
   });
 });


### PR DESCRIPTION
## Summary

- `Product`에 자동 `_id` 외 인덱스가 없어 `getAllProductsService`/`searchProductsService`가 전부 COLLSCAN + in-memory sort로 돌던 문제를 고친다. 카테고리가 1종→5종으로 늘면서 `category` 필터가 실질 선택도를 갖게 됐다(TODO.md 성능 개선 섹션).
- `product.model.ts`에 복합 인덱스 2개 추가: `{deletedAt,category,isFeatured,priority,createdAt}`(category 지정 목록), `{deletedAt,isFeatured,priority,createdAt}`(category 미지정 목록/검색 — category가 쿼리에 없으면 첫 인덱스는 정렬 순서를 못 지켜줘 별도 인덱스 필요). base 스키마에 걸어 invitation discriminator에도 자동 적용된다.
- `getFeaturedTemplatesService`(status 필터 미포함)와 `getPopularProductsService`(좋아요 배열 길이 정렬, 구조적으로 인덱스 불가)는 의도적으로 스코프 밖 — TODO 미분류 인박스로 별도 이관 필요(아래 참고).
- `TODO.md`는 이 브랜치에서 건드리지 않는다(`docs/todo-section-taxonomy` 브랜치 전용, AGENTS.md Git 규칙). 이 PR 머지 후 taxonomy 브랜치에서: (1) 기존 성능 항목을 "구조 완성, 실데이터 규모 재검토는 배포 후"로 갱신, (2) "배포 후 실행" 인박스에 재검토 항목 추가, (3) 위 2건(status 필터/배열 정렬)을 개별 판단 인박스로 append.

## Test plan

- `npx vitest run --project integration-server src/server/services/product.service.integration.test.ts` — 61/61 통과. `explain("executionStats")` 기반 신규 4개 케이스로 IXSCAN 사용·COLLSCAN 없음을 검증(category 지정/미지정, searchProductsService의 deletedAt prefix, $or 쿼리).
- `npx vitest run --project unit --project integration-server` — 766/766 통과, 회귀 없음.
- `npm run typecheck` — 통과.
- `npx eslint src/server/models/product.model.ts src/server/services/product.service.integration.test.ts` — 통과.
- Not run: 실데이터 규모 기준 검증 — 프로젝트가 아직 미배포라 실데이터가 없다(TODO.md:128). 완료기준의 그 부분은 배포 후 별도 재검토 대상.