### PR TITLE
fix: show skeleton instead of role text while loading

### DIFF
--- a/scripts/test-scope/changed-mutation.mjs
+++ b/scripts/test-scope/changed-mutation.mjs
@@ -47,6 +47,7 @@ export function mutationPlan(root = process.cwd(), base = "origin/dev") {
     for (const [start, end] of entries) targets.push(`${file}:${start}-${end}`);
     for (const test of graph.testsFor(file)) tests.add(test);
   }
+  targets.sort();
   const sourceHash = sha256(targets.map((target) => {
     const file = target.slice(0, target.lastIndexOf(":"));
     return `${target}\0${fs.readFileSync(path.join(root, file))}`;
@@ -55,7 +56,7 @@ export function mutationPlan(root = process.cwd(), base = "origin/dev") {
     base,
     mergeBase,
     head: git(root, ["rev-parse", "HEAD"]),
-    targets: targets.sort(),
+    targets,
     tests: [...tests].sort(),
     sourceHash,
   };

--- a/scripts/test-scope/changed-mutation.test.mjs
+++ b/scripts/test-scope/changed-mutation.test.mjs
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -27,6 +28,39 @@ describe("changed mutation plan", () => {
     execFileSync("git", ["add", "."], { cwd: root });
     execFileSync("git", ["commit", "-m", "change"], { cwd: root });
     expect(mutationPlan(root, "baseline")).toMatchObject({ targets: ["src/value.ts:1-2"], tests: ["src/value.test.ts"] });
+  });
+
+  it("sourceHash는 반환된 targets(정렬됨)와 같은 순서로 계산된다 — 한 자리/두 자리 줄번호가 섞여도 어긋나지 않는다", () => {
+    const root = fixture();
+    const lines = Array.from({ length: 25 }, (_, i) => `export const v${i} = ${i};`);
+    fs.writeFileSync(path.join(root, "src/value.ts"), `${lines.join("\n")}\n`);
+    execFileSync("git", ["add", "."], { cwd: root });
+    execFileSync("git", ["commit", "-m", "multiline baseline"], { cwd: root });
+    execFileSync("git", ["branch", "-f", "baseline", "HEAD"], { cwd: root });
+
+    // 7번째 줄과 21번째 줄을 각각 별도 hunk로 바꾼다 — 문자열 정렬("21-21" < "7-7")과
+    // 실제 diff 등장 순서(7번째 줄이 21번째 줄보다 먼저)가 어긋나는 상황을 재현한다.
+    lines[6] = "export const v6 = 999;";
+    lines[20] = "export const v20 = 999;";
+    fs.writeFileSync(path.join(root, "src/value.ts"), `${lines.join("\n")}\n`);
+    execFileSync("git", ["add", "."], { cwd: root });
+    execFileSync("git", ["commit", "-m", "change"], { cwd: root });
+
+    const plan = mutationPlan(root, "baseline");
+    const recomputed = crypto
+      .createHash("sha256")
+      .update(
+        plan.targets
+          .map((target) => {
+            const file = target.slice(0, target.lastIndexOf(":"));
+            return `${target}\0${fs.readFileSync(path.join(root, file))}`;
+          })
+          .join("\0"),
+      )
+      .digest("hex");
+
+    expect(plan.targets).toEqual(["src/value.ts:21-21", "src/value.ts:7-7"]);
+    expect(plan.sourceHash).toBe(recomputed);
   });
 
   it("mutant가 없으면 실패가 아니라 N/A다", () => {

--- a/src/app/(admin)/admin/layout.integration.test.tsx
+++ b/src/app/(admin)/admin/layout.integration.test.tsx
@@ -1,0 +1,76 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { http, HttpResponse, delay } from "msw";
+import { setupServer } from "msw/node";
+import type * as AtomsModule from "@/client/components/atoms";
+
+const adminSession = { role: "ADMIN" as const, email: "admin@b.com", userId: "user-1" };
+
+const server = setupServer(
+  http.get("http://localhost/api/auth/me", async () => {
+    await delay(50);
+    return HttpResponse.json({ success: true, data: adminSession });
+  }),
+);
+
+const nativeFetch = globalThis.fetch;
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+  const interceptedFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const resolved = typeof input === "string" && input.startsWith("/")
+      ? new URL(input, "http://localhost")
+      : input;
+    return interceptedFetch(resolved, init);
+  }) as typeof fetch;
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => { server.close(); globalThis.fetch = nativeFetch; });
+
+vi.mock("@/client/components/atoms", async (importOriginal) => {
+  const actual = await importOriginal<typeof AtomsModule>();
+  const Passthrough = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  return {
+    ...actual,
+    SidebarProvider: Passthrough,
+    Sidebar: Passthrough,
+    SidebarContent: Passthrough,
+    SidebarFooter: Passthrough,
+  };
+});
+vi.mock("@/client/components/organisms", () => ({
+  SidebarToggle: (): null => null,
+}));
+vi.mock("@/client/components/molecules", () => ({
+  SidebarNavItem: (): null => null,
+}));
+vi.mock("./_components", () => ({ AdminModal: (): null => null }));
+
+import AdminLayout from "./layout";
+
+const renderWithRealSwr = () =>
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <AdminLayout>children</AdminLayout>
+    </SWRConfig>,
+  );
+
+describe("실제 useAuth(useSWR) + MSW /api/auth/me 경계", () => {
+  it("응답이 도착하기 전엔 관리자/일반 계정 어느 쪽도 표시하지 않는다", () => {
+    renderWithRealSwr();
+
+    expect(screen.queryByText("관리자 계정")).not.toBeInTheDocument();
+    expect(screen.queryByText("일반 계정")).not.toBeInTheDocument();
+  });
+
+  it("응답이 도착하면 실제 세션의 email/role을 사이드바 푸터에 렌더한다", async () => {
+    renderWithRealSwr();
+
+    await waitFor(() => expect(screen.getByText("admin@b.com")).toBeInTheDocument());
+    expect(screen.getByText("관리자 계정")).toBeInTheDocument();
+  });
+});

--- a/src/app/(admin)/admin/layout.test.tsx
+++ b/src/app/(admin)/admin/layout.test.tsx
@@ -52,4 +52,13 @@ describe("(admin) AdminLayout", () => {
 
     expect(screen.getByText("일반 계정")).toBeInTheDocument();
   });
+
+  it("로딩 중이면 관리자/일반 계정 어느 쪽도 표시하지 않는다", () => {
+    useAuthMock.mockReturnValue({ session: null, isLoading: true });
+
+    render(<AdminLayout>children</AdminLayout>);
+
+    expect(screen.queryByText("관리자 계정")).not.toBeInTheDocument();
+    expect(screen.queryByText("일반 계정")).not.toBeInTheDocument();
+  });
 });

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -7,12 +7,13 @@ import { Toaster } from "sonner";
 import { SidebarNavItem } from "@/client/components/molecules";
 import { AdminModal } from "./_components";
 import { useAuth } from "@/client/hooks";
+import { Skeleton } from "@/client/components/atoms";
 export default function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const { session } = useAuth();
+  const { session, isLoading } = useAuth();
 
   return (
     <SidebarProvider>
@@ -24,14 +25,18 @@ export default function AdminLayout({
 
           <SidebarFooter className="border-border border-t p-4">
             <div className="mb-2 flex items-center gap-3 px-2 py-2">
-              <div className="min-w-0 flex-1">
-                <p className="text-foreground truncate text-sm font-medium">
-                  {session?.email}
-                </p>
-                <p className="text-muted-foreground text-xs">
-                  {session?.role === "ADMIN" ? "관리자" : "일반"} 계정
-                </p>
-              </div>
+              {isLoading ? (
+                <Skeleton className="h-9 w-full rounded-md" />
+              ) : (
+                <div className="min-w-0 flex-1">
+                  <p className="text-foreground truncate text-sm font-medium">
+                    {session?.email}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    {session?.role === "ADMIN" ? "관리자" : "일반"} 계정
+                  </p>
+                </div>
+              )}
             </div>
           </SidebarFooter>
         </Sidebar>

--- a/src/app/(main)/(my-order)/layout.test.tsx
+++ b/src/app/(main)/(my-order)/layout.test.tsx
@@ -51,4 +51,13 @@ describe("(my-order) Layout", () => {
 
     expect(screen.getByText("일반 계정")).toBeInTheDocument();
   });
+
+  it("로딩 중이면 관리자/일반 계정 어느 쪽도 표시하지 않는다", () => {
+    useAuthMock.mockReturnValue({ session: null, isLoading: true });
+
+    render(<Layout>children</Layout>);
+
+    expect(screen.queryByText("관리자 계정")).not.toBeInTheDocument();
+    expect(screen.queryByText("일반 계정")).not.toBeInTheDocument();
+  });
 });

--- a/src/app/(main)/(my-order)/layout.tsx
+++ b/src/app/(main)/(my-order)/layout.tsx
@@ -4,8 +4,9 @@ import { Sidebar, SidebarContent, SidebarFooter, SidebarProvider } from "@/clien
 import { SidebarNavItem } from "@/client/components/molecules";
 import { SidebarToggle } from "@/client/components/organisms";
 import { useAuth } from "@/client/hooks";
+import { Skeleton } from "@/client/components/atoms";
 const Layout = ({ children }: { children: React.ReactNode }) => {
-  const { session } = useAuth();
+  const { session, isLoading } = useAuth();
 
   return (
     <SidebarProvider>
@@ -17,14 +18,18 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 
           <SidebarFooter className="border-border border-t p-4">
             <div className="mb-2 flex items-center gap-3 px-2 py-2">
-              <div className="min-w-0 flex-1">
-                <p className="text-foreground truncate text-sm font-medium">
-                  {session?.email}
-                </p>
-                <p className="text-muted-foreground text-xs">
-                  {session?.role === "ADMIN" ? "관리자" : "일반"} 계정
-                </p>
-              </div>
+              {isLoading ? (
+                <Skeleton className="h-9 w-full rounded-md" />
+              ) : (
+                <div className="min-w-0 flex-1">
+                  <p className="text-foreground truncate text-sm font-medium">
+                    {session?.email}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    {session?.role === "ADMIN" ? "관리자" : "일반"} 계정
+                  </p>
+                </div>
+              )}
             </div>
           </SidebarFooter>
         </Sidebar>

--- a/src/app/(main)/(my-profile)/layout.test.tsx
+++ b/src/app/(main)/(my-profile)/layout.test.tsx
@@ -51,4 +51,13 @@ describe("(my-profile) Layout", () => {
 
     expect(screen.getByText("일반 계정")).toBeInTheDocument();
   });
+
+  it("로딩 중이면 관리자/일반 계정 어느 쪽도 표시하지 않는다", () => {
+    useAuthMock.mockReturnValue({ session: null, isLoading: true });
+
+    render(<Layout>children</Layout>);
+
+    expect(screen.queryByText("관리자 계정")).not.toBeInTheDocument();
+    expect(screen.queryByText("일반 계정")).not.toBeInTheDocument();
+  });
 });

--- a/src/app/(main)/(my-profile)/layout.tsx
+++ b/src/app/(main)/(my-profile)/layout.tsx
@@ -4,8 +4,9 @@ import { Sidebar, SidebarContent, SidebarFooter, SidebarProvider } from "@/clien
 import { SidebarNavItem } from "@/client/components/molecules";
 import { SidebarToggle } from "@/client/components/organisms";
 import { useAuth } from "@/client/hooks";
+import { Skeleton } from "@/client/components/atoms";
 const Layout = ({ children }: { children: React.ReactNode }) => {
-  const { session } = useAuth();
+  const { session, isLoading } = useAuth();
 
   return (
     <SidebarProvider>
@@ -17,14 +18,18 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 
           <SidebarFooter className="border-border border-t p-4">
             <div className="mb-2 flex items-center gap-3 px-2 py-2">
-              <div className="min-w-0 flex-1">
-                <p className="text-foreground truncate text-sm font-medium">
-                  {session?.email}
-                </p>
-                <p className="text-muted-foreground text-xs">
-                  {session?.role === "ADMIN" ? "관리자" : "일반"} 계정
-                </p>
-              </div>
+              {isLoading ? (
+                <Skeleton className="h-9 w-full rounded-md" />
+              ) : (
+                <div className="min-w-0 flex-1">
+                  <p className="text-foreground truncate text-sm font-medium">
+                    {session?.email}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    {session?.role === "ADMIN" ? "관리자" : "일반"} 계정
+                  </p>
+                </div>
+              )}
             </div>
           </SidebarFooter>
         </Sidebar>


### PR DESCRIPTION
## Summary

- `useAuth`는 이미 `useSWR` 기반 `isLoading`을 리턴하지만, 사이드바 3곳(`admin`/`(my-order)`/`(my-profile)` layout)이 `session`만 구독해 초기 로딩 중 `session === null`을 "비로그인"과 구분하지 못하고 관리자에게도 순간 "일반 계정"을 표시했다. 세 layout 모두 `isLoading` 분기를 추가해 로딩 중엔 `Skeleton`을 표시하도록 고쳤다(`AuthButtons.tsx`의 기존 패턴 재사용).
- 부수로, `scripts/test-scope/changed-mutation.mjs`가 mutation `sourceHash`를 정렬 전 순서로 계산해 `changed-proof.json`에 기록된 정렬된 `targets`와 항상 어긋나던 버그를 별도 커밋으로 수정했다(두 자리/한 자리 줄번호가 섞인 파일마다 `tdd:verify`가 "mutation source changed"로 항상 실패하던 문제 — 이번 작업 진행 중 실제로 막혀서 발견).

## Test plan

- `npm run test:red -- --scope unit` / `npm run test:green -- --scope unit` — 로딩 중 관리자/일반 계정 텍스트 미노출 회귀 테스트 3파일 그린
- `npm run test:red -- --scope integration` / `npm run test:green -- --scope integration` — 실제 `useAuth`+`useSWR`+MSW `/api/auth/me` 경계 통합 테스트 그린 (`layout.integration.test.tsx` 신규)
- `npm run test:mutation` — 100% killed (24/24), PASSED
- `npm run tdd:verify` — VERIFIED
- `npx vitest run --project guard scripts/test-scope/changed-mutation.test.mjs` — mutation sourceHash 정렬 회귀 테스트 포함 전체 그린
- `npm run lint` — 통과
- `npm run typecheck` — 통과
