### PR TITLE
build: 서버 전용 모듈 경계 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-day-picker": "^9.13.0",
         "react-dom": "19.1.0",
         "react-kakao-maps-sdk": "^1.2.0",
+        "server-only": "^0.0.1",
         "sonner": "^2.0.7",
         "swr": "^2.3.8",
         "tailwind-merge": "^3.4.0",
@@ -1686,6 +1687,7 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1707,6 +1709,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2867,6 +2870,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6464,6 +6468,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13257,6 +13262,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-cookie-parser": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-day-picker": "^9.13.0",
     "react-dom": "19.1.0",
     "react-kakao-maps-sdk": "^1.2.0",
+    "server-only": "^0.0.1",
     "sonner": "^2.0.7",
     "swr": "^2.3.8",
     "tailwind-merge": "^3.4.0",

--- a/src/server/lib/bcrypt/hash.ts
+++ b/src/server/lib/bcrypt/hash.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import bcrypt from "bcryptjs";
 
 export const hashPassword = async (password: string) => {

--- a/src/server/lib/bcrypt/index.ts
+++ b/src/server/lib/bcrypt/index.ts
@@ -1,1 +1,2 @@
+import "server-only";
 export * from "./hash";

--- a/src/server/lib/cloudinary/cleanup.ts
+++ b/src/server/lib/cloudinary/cleanup.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { v2 as cloudinary } from "cloudinary";
 import { AppError } from "@/shared/types";
 

--- a/src/server/lib/cloudinary/index.ts
+++ b/src/server/lib/cloudinary/index.ts
@@ -1,3 +1,4 @@
+import "server-only";
 export * from "./upload";
 export * from "./sign";
 export * from "./cleanup";

--- a/src/server/lib/cloudinary/sign.ts
+++ b/src/server/lib/cloudinary/sign.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { v2 as cloudinary } from "cloudinary";
 
 export type UploadSignature = {

--- a/src/server/lib/cloudinary/type.ts
+++ b/src/server/lib/cloudinary/type.ts
@@ -1,3 +1,4 @@
+import "server-only";
 export type CloudinaryResource = {
   asset_folder: string;
   asset_id: string;

--- a/src/server/lib/cloudinary/upload.ts
+++ b/src/server/lib/cloudinary/upload.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { AppError } from "@/shared/types";
 import type { CloudinaryResource, UploadedCloudinaryAsset } from "./type";
 

--- a/src/server/lib/cookies/delete.ts
+++ b/src/server/lib/cookies/delete.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cookies } from "next/headers";
 import type { CookieName } from "./type";
 

--- a/src/server/lib/cookies/get.ts
+++ b/src/server/lib/cookies/get.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { RequestCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import { cookies } from "next/headers";
 import type { CookieName } from "./type";

--- a/src/server/lib/cookies/index.ts
+++ b/src/server/lib/cookies/index.ts
@@ -1,3 +1,4 @@
+import "server-only";
 export * from "./get";
 export * from "./set";
 export * from "./delete";

--- a/src/server/lib/cookies/set.ts
+++ b/src/server/lib/cookies/set.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { ResponseCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import { cookies } from "next/headers";
 import type { CookieName } from "./type";

--- a/src/server/lib/cookies/type.ts
+++ b/src/server/lib/cookies/type.ts
@@ -1,1 +1,2 @@
+import "server-only";
 export type CookieName = "token" | "entry" | "userEmail";

--- a/src/server/lib/jose/config.ts
+++ b/src/server/lib/jose/config.ts
@@ -1,3 +1,4 @@
+import "server-only";
 function requireEnv(key: string): string {
   const value = process.env[key];
   if (!value) {

--- a/src/server/lib/jose/decrypt.ts
+++ b/src/server/lib/jose/decrypt.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { JWTPayload, JWTVerifyResult } from "jose";
 import { jwtVerify } from "jose";
 import type { DecryptProps, EncryptProps } from "./type";

--- a/src/server/lib/jose/encrypt.ts
+++ b/src/server/lib/jose/encrypt.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { SignJWT } from "jose";
 import type { EncryptProps } from "./type";
 import { ENTRY_ENCODED_KEY, JWT_ENCODED_KEY } from "./config";

--- a/src/server/lib/jose/index.ts
+++ b/src/server/lib/jose/index.ts
@@ -1,2 +1,3 @@
+import "server-only";
 export * from "./encrypt";
 export * from "./decrypt";

--- a/src/server/lib/jose/type.ts
+++ b/src/server/lib/jose/type.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { UserRole } from "@/server/models";
 type JWTType = "REFRESH" | "ENTRY";
 

--- a/src/server/lib/mongodb/connect.ts
+++ b/src/server/lib/mongodb/connect.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import mongoose from "mongoose";
 
 // 1. 캐시 객체의 타입을 정의합니다.

--- a/src/server/lib/mongodb/index.ts
+++ b/src/server/lib/mongodb/index.ts
@@ -1,1 +1,2 @@
+import "server-only";
 export * from "./connect";

--- a/src/server/lib/nodemailer/index.ts
+++ b/src/server/lib/nodemailer/index.ts
@@ -1,1 +1,2 @@
+import "server-only";
 export * from "./send";

--- a/src/server/lib/nodemailer/send.ts
+++ b/src/server/lib/nodemailer/send.ts
@@ -1,4 +1,5 @@
 "use server";
+import "server-only";
 
 import * as nodemailer from "nodemailer";
 

--- a/src/server/models/coupleInfo.model.ts
+++ b/src/server/models/coupleInfo.model.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { Model, Types } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 

--- a/src/server/models/feature.model.ts
+++ b/src/server/models/feature.model.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { Types, Model } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 

--- a/src/server/models/guestbook.model.ts
+++ b/src/server/models/guestbook.model.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { Model, Types } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -1,3 +1,4 @@
+import "server-only";
 export * from "./coupleInfo.model";
 export * from "./feature.model";
 export * from "./guestbook.model";

--- a/src/server/models/order.model.ts
+++ b/src/server/models/order.model.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { Types, Model } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 import type { PayMethod } from "./payment.model";

--- a/src/server/models/payment.model.ts
+++ b/src/server/models/payment.model.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { PAY_METHOD } from "@/shared/constants";
 import type { Types, Model } from "mongoose";
 import mongoose, { Schema } from "mongoose";

--- a/src/server/models/product.model.ts
+++ b/src/server/models/product.model.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { Model } from "mongoose";
 import mongoose, { model, Schema } from "mongoose";
 import type {

--- a/src/server/models/user.model.ts
+++ b/src/server/models/user.model.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { Types, Model } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 export type UserRole = "USER" | "ADMIN";

--- a/src/server/services/auth.service.ts
+++ b/src/server/services/auth.service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { UserRole } from "@/server/models";
 import { UserModel } from "@/server/models";
 import { dbConnect } from "@/server/lib/mongodb";

--- a/src/server/services/coupleInfo.service.ts
+++ b/src/server/services/coupleInfo.service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { ICoupleInfo } from "@/server/models";
 import { CoupleInfoModel } from "@/server/models";
 import type { CoupleInfoSchemaDto } from "@/shared/schemas";

--- a/src/server/services/guestbook.service.ts
+++ b/src/server/services/guestbook.service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { IGuestbook } from "@/server/models";
 import { GuestbookModel } from "@/server/models";
 import type { GuestbookType } from "@/shared/schemas";

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -1,3 +1,4 @@
+import "server-only";
 export * from "./auth.service";
 export * from "./coupleInfo.service";
 export * from "./guestbook.service";

--- a/src/server/services/order.service.ts
+++ b/src/server/services/order.service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import mongoose from "mongoose";
 import type { IOrder, OrderJSON} from "@/server/models";
 import { OrderModel } from "@/server/models";

--- a/src/server/services/payment.service.ts
+++ b/src/server/services/payment.service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import mongoose from "mongoose";
 import * as PortOne from "@portone/server-sdk";
 import type {

--- a/src/server/services/premiumFeature.service.ts
+++ b/src/server/services/premiumFeature.service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { IFeature } from "@/server/models";
 import { FeatureModel } from "@/server/models";
 import type { PremiumFeatureDto } from "@/shared/schemas";

--- a/src/server/services/product.service.ts
+++ b/src/server/services/product.service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { ProductJSON, ProductDB, IProduct } from "@/server/models";
 import { ProductModel, InvitationProductModel } from "@/server/models";
 import type { ProductDto } from "@/shared/schemas";

--- a/src/server/services/subway.service.ts
+++ b/src/server/services/subway.service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { AppError } from "@/shared/types";
 import { parseSeoulOpenApiResponse } from "@/shared/utils";
 

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { AppError } from "@/shared/types";
 import type { BaseUser, IUser } from "@/server/models";
 import { UserModel } from "@/server/models";

--- a/testing/support/setup/jsdom-polyfill.ts
+++ b/testing/support/setup/jsdom-polyfill.ts
@@ -1,4 +1,6 @@
-import { afterEach } from "vitest";
+import { afterEach, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
 
 // services/actions 등 DOM 없는 파일(`// @vitest-environment node`)은 이 아래
 // jsdom 전용 폴리필을 전부 건너뛴다 — jsdom 환경에서만 Element/window가 존재한다.

--- a/testing/support/setup/node-polyfill.ts
+++ b/testing/support/setup/node-polyfill.ts
@@ -1,4 +1,7 @@
 import { File } from "node:buffer";
+import { vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
 
 if (!("File" in globalThis)) {
   Object.defineProperty(globalThis, "File", { value: File, configurable: true });


### PR DESCRIPTION
## Summary

- `server-only` 의존성을 추가해 models, services, 서버 전용 adapters 후보 모듈의 클라이언트 번들 유입을 컴파일 단계에서 차단합니다.
- Client Component가 호출하는 정상 Server Action 경계를 보존하기 위해 `src/server/actions/`는 적용 대상에서 제외합니다.
- Vitest에서는 `server-only` marker를 공통 setup에서 mock해 Next.js 컴파일러 없이 실행되는 테스트가 제품 경계 표식 때문에 중단되지 않도록 합니다.

## Test plan

- `npm run build` — 로컬 통과
- TDD Guard CI 전체 체크 — 통과 (`static`, unit 전체 shard, integration, E2E, mutation, TDD policy)