### PR TITLE
refactor: 현재 통과하는 레이어 경계를 eslint로 강제

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,15 @@ const eslintConfig = [...nextCoreWebVitals, ...nextTypescript, {
   },
   rules: {
     "@typescript-eslint/consistent-type-exports": "error",
+    "import/no-restricted-paths": ["error", {
+      zones: [
+        { target: "./src/shared", from: "./src/server", message: "shared는 순수해야 한다" },
+        { target: "./src/shared", from: "./src/client", message: "shared는 순수해야 한다" },
+        { target: "./src/shared", from: "./src/app", message: "shared는 순수해야 한다" },
+        { target: "./src/server", from: "./src/client", message: "서버는 클라이언트를 모른다" },
+        { target: "./src/client", from: "./src/server/lib", message: "UI는 서버 lib을 직접 못 만진다" },
+      ],
+    }],
   },
 }, {
   ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "next-env.d.ts", "scripts/**", ".claude/hooks/**", "coverage/**"]

--- a/src/app/(preview)/preview/[id]/_components/Navigation.tsx
+++ b/src/app/(preview)/preview/[id]/_components/Navigation.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Button } from "@/client/components/atoms";
-import { navigationButtons } from "@/shared/constants";
+import { navigationButtons } from "@/client/constants/navigation";
 import type { NavigationGeo } from "@/client/hooks";
 import Image from "next/image";
 import React from "react";

--- a/src/client/constants/navigation.ts
+++ b/src/client/constants/navigation.ts
@@ -1,0 +1,44 @@
+import { openApp } from "@/client/utils";
+
+export const navigationButtons = [
+  {
+    name: "네이버지도",
+    path: "navermap.webp",
+    onClick: ({
+      current,
+      target,
+      address,
+    }: {
+      current: { lng: number | null; lat: number | null };
+      target: { lng: number | null; lat: number | null };
+      address: string;
+    }) =>
+      current &&
+      target &&
+      address &&
+      openApp.openNaverMap({ current, target, address }),
+  },
+  {
+    name: "티맵",
+    path: "tmap.webp",
+    onClick: ({ address }: { address: string }) =>
+      address && openApp.openTmap(address),
+  },
+  {
+    name: "카카오내비",
+    path: "kakaonavi.webp",
+    onClick: ({
+      current,
+      target,
+      address,
+    }: {
+      current: { lng: number | null; lat: number | null };
+      target: { lng: number | null; lat: number | null };
+      address: string;
+    }) =>
+      current &&
+      target &&
+      address &&
+      openApp.openKakaoMap({ current, target, address }),
+  },
+] as const;

--- a/src/shared/constants/navigation.ts
+++ b/src/shared/constants/navigation.ts
@@ -1,50 +1,6 @@
-import { openApp } from "@/client/utils";
 import { LayoutDashboard, User, ShoppingBag } from "lucide-react";
 
 import { routes } from "./routes";
-
-export const navigationButtons = [
-  {
-    name: "네이버지도",
-    path: "navermap.webp",
-    onClick: ({
-      current,
-      target,
-      address,
-    }: {
-      current: { lng: number | null; lat: number | null };
-      target: { lng: number | null; lat: number | null };
-      address: string;
-    }) =>
-      current &&
-      target &&
-      address &&
-      openApp.openNaverMap({ current, target, address }),
-  },
-  {
-    name: "티맵",
-    path: "tmap.webp",
-    onClick: ({ address }: { address: string }) =>
-      address && openApp.openTmap(address),
-  },
-  {
-    name: "카카오내비",
-    path: "kakaonavi.webp",
-    onClick: ({
-      current,
-      target,
-      address,
-    }: {
-      current: { lng: number | null; lat: number | null };
-      target: { lng: number | null; lat: number | null };
-      address: string;
-    }) =>
-      current &&
-      target &&
-      address &&
-      openApp.openKakaoMap({ current, target, address }),
-  },
-] as const;
 
 export const MAIN_NAV_ITEMS = [
   {


### PR DESCRIPTION
## Summary

- 현재 구조에서 위반 없이 적용 가능한 `import/no-restricted-paths` zone 다섯 개를 활성화해 shared·server·client의 의존 방향을 강제합니다.
- 브라우저 API를 호출하는 `navigationButtons`를 `src/client/constants/navigation.ts`로 옮겨 shared 배럴의 런타임 누수를 제거합니다.
- 남은 34건은 `client → server/services·models`의 `import type` 의존입니다. 2b에서 도메인 타입 6종을 `src/shared/types/`로 추출한 뒤 두 zone을 추가합니다.

## Test plan

- `npm run lint` — 통과
- `npx eslint src/shared/utils/price.ts` — 임시 `@/server/models` import를 추가했을 때 `import/no-restricted-paths` 오류를 확인하고 즉시 원복
- `npm run build` — 통과
- 전체 테스트 — 로컬 미실행, CI에서 확인