### PR TITLE
fix: mutation target 경로의 glob 메타문자 escape

### DIFF
--- a/scripts/test-scope/changed-mutation.mjs
+++ b/scripts/test-scope/changed-mutation.mjs
@@ -16,8 +16,23 @@ function sha256(value) {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
+export function escapeGlobPath(target) {
+  const rangeIndex = target.lastIndexOf(":");
+  const file = target.slice(0, rangeIndex);
+  const range = target.slice(rangeIndex);
+  return file.replace(/[\[\]{}()*+?@!|]/g, "\\$&") + range;
+}
+
 function changedRanges(root, mergeBase) {
-  const output = git(root, ["diff", "--relative", "--unified=0", "--diff-filter=ACMR", mergeBase, "--", "src"]);
+  const output = git(root, [
+    "diff",
+    "--relative",
+    "--unified=0",
+    "--diff-filter=ACMR",
+    mergeBase,
+    "--",
+    "src",
+  ]);
   const ranges = new Map();
   let file;
   for (const line of output.split("\n")) {
@@ -48,10 +63,14 @@ export function mutationPlan(root = process.cwd(), base = "origin/dev") {
     for (const test of graph.testsFor(file)) tests.add(test);
   }
   targets.sort();
-  const sourceHash = sha256(targets.map((target) => {
-    const file = target.slice(0, target.lastIndexOf(":"));
-    return `${target}\0${fs.readFileSync(path.join(root, file))}`;
-  }).join("\0"));
+  const sourceHash = sha256(
+    targets
+      .map((target) => {
+        const file = target.slice(0, target.lastIndexOf(":"));
+        return `${target}\0${fs.readFileSync(path.join(root, file))}`;
+      })
+      .join("\0"),
+  );
   return {
     base,
     mergeBase,
@@ -66,13 +85,25 @@ function exceptions(root) {
   const file = path.join(root, "mutation-equivalents.json");
   if (!fs.existsSync(file)) return [];
   const entries = JSON.parse(fs.readFileSync(file, "utf8"));
-  if (!Array.isArray(entries)) throw new Error("mutation-equivalents.json must be an array");
+  if (!Array.isArray(entries))
+    throw new Error("mutation-equivalents.json must be an array");
   const now = new Date();
   for (const entry of entries) {
-    if (!entry.id || !entry.file || !entry.owner || !entry.reason || !entry.expiresAt) throw new Error("invalid mutation equivalent exception");
+    if (
+      !entry.id ||
+      !entry.file ||
+      !entry.owner ||
+      !entry.reason ||
+      !entry.expiresAt
+    )
+      throw new Error("invalid mutation equivalent exception");
     const expiresAt = new Date(entry.expiresAt);
-    if (Number.isNaN(expiresAt.valueOf()) || expiresAt <= now) throw new Error(`expired mutation equivalent exception: ${entry.id}`);
-    if (expiresAt.valueOf() - now.valueOf() > 30 * 24 * 60 * 60 * 1000) throw new Error(`mutation equivalent exception exceeds 30 days: ${entry.id}`);
+    if (Number.isNaN(expiresAt.valueOf()) || expiresAt <= now)
+      throw new Error(`expired mutation equivalent exception: ${entry.id}`);
+    if (expiresAt.valueOf() - now.valueOf() > 30 * 24 * 60 * 60 * 1000)
+      throw new Error(
+        `mutation equivalent exception exceeds 30 days: ${entry.id}`,
+      );
   }
   return entries;
 }
@@ -90,38 +121,69 @@ export function evaluateReport(report, equivalentExceptions = []) {
       total += 1;
       if (mutant.status === "Killed") killed += 1;
       if (mutant.status !== "Survived") continue;
-      const allowed = equivalentExceptions.some((entry) => entry.file === file && entry.mutant === mutantKey(mutant));
+      const allowed = equivalentExceptions.some(
+        (entry) => entry.file === file && entry.mutant === mutantKey(mutant),
+      );
       if (!allowed) surviving.push({ file, mutant: mutantKey(mutant) });
     }
   }
-  return { status: total === 0 ? "N/A" : surviving.length ? "FAILED" : "PASSED", total, killed, surviving };
+  return {
+    status: total === 0 ? "N/A" : surviving.length ? "FAILED" : "PASSED",
+    total,
+    killed,
+    surviving,
+  };
 }
 
 export function runChangedMutation(root = process.cwd(), base = "origin/dev") {
   const plan = mutationPlan(root, base);
   fs.mkdirSync(path.join(root, "reports", "mutation"), { recursive: true });
   if (!plan.targets.length) {
-    const result = { ...plan, status: "N/A", reason: "no changed tested source lines" };
+    const result = {
+      ...plan,
+      status: "N/A",
+      reason: "no changed tested source lines",
+    };
     fs.writeFileSync(path.join(root, PROOF), JSON.stringify(result, null, 2));
     return result;
   }
   const command = process.platform === "win32" ? "npx.cmd" : "npx";
-  const run = spawnSync(command, ["stryker", "run", "stryker.changed.config.mjs"], {
-    cwd: root,
-    stdio: "inherit",
-    env: { ...process.env, STRYKER_MUTATE_TARGETS: JSON.stringify(plan.targets), STRYKER_RELATED_TESTS: JSON.stringify(plan.tests) },
-  });
+  const run = spawnSync(
+    command,
+    ["stryker", "run", "stryker.changed.config.mjs"],
+    {
+      cwd: root,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        STRYKER_MUTATE_TARGETS: JSON.stringify(
+          plan.targets.map(escapeGlobPath),
+        ),
+        STRYKER_RELATED_TESTS: JSON.stringify(plan.tests),
+      },
+    },
+  );
   if (run.error) throw run.error;
   const reportFile = path.join(root, REPORT);
   if (!fs.existsSync(reportFile) && run.status === 0) {
-    const proof = { ...plan, status: "N/A", reason: "no mutants generated", createdAt: new Date().toISOString() };
+    const proof = {
+      ...plan,
+      status: "N/A",
+      reason: "no mutants generated",
+      createdAt: new Date().toISOString(),
+    };
     fs.writeFileSync(path.join(root, PROOF), JSON.stringify(proof, null, 2));
     return proof;
   }
   if (!fs.existsSync(reportFile)) throw new Error("mutation report missing");
   const reportText = fs.readFileSync(reportFile, "utf8");
   const result = evaluateReport(JSON.parse(reportText), exceptions(root));
-  const proof = { ...plan, ...result, reportHash: sha256(reportText), createdAt: new Date().toISOString() };
+  const proof = {
+    ...plan,
+    ...result,
+    reportHash: sha256(reportText),
+    createdAt: new Date().toISOString(),
+  };
   fs.writeFileSync(path.join(root, PROOF), JSON.stringify(proof, null, 2));
   if (run.status !== 0 || result.status === "FAILED") process.exitCode = 1;
   return proof;
@@ -129,12 +191,20 @@ export function runChangedMutation(root = process.cwd(), base = "origin/dev") {
 
 function baseArgument(argv) {
   const index = argv.indexOf("--base");
-  return index >= 0 ? argv[index + 1] : process.env.MUTATION_BASE ?? "origin/dev";
+  return index >= 0
+    ? argv[index + 1]
+    : (process.env.MUTATION_BASE ?? "origin/dev");
 }
 
-if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
   try {
-    const result = runChangedMutation(process.cwd(), baseArgument(process.argv.slice(2)));
+    const result = runChangedMutation(
+      process.cwd(),
+      baseArgument(process.argv.slice(2)),
+    );
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error(error.message);

--- a/scripts/test-scope/changed-mutation.test.mjs
+++ b/scripts/test-scope/changed-mutation.test.mjs
@@ -4,16 +4,31 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
-import { evaluateReport, mutationPlan } from "./changed-mutation.mjs";
+import {
+  escapeGlobPath,
+  evaluateReport,
+  mutationPlan,
+} from "./changed-mutation.mjs";
 
 function fixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "changed-mutation-"));
-  fs.writeFileSync(path.join(root, "tsconfig.json"), JSON.stringify({ compilerOptions: { moduleResolution: "Bundler" } }));
+  fs.writeFileSync(
+    path.join(root, "tsconfig.json"),
+    JSON.stringify({ compilerOptions: { moduleResolution: "Bundler" } }),
+  );
   fs.mkdirSync(path.join(root, "src"));
-  fs.writeFileSync(path.join(root, "src/value.ts"), "export const value = 1;\n");
-  fs.writeFileSync(path.join(root, "src/value.test.ts"), 'import { value } from "./value"; void value;\n');
+  fs.writeFileSync(
+    path.join(root, "src/value.ts"),
+    "export const value = 1;\n",
+  );
+  fs.writeFileSync(
+    path.join(root, "src/value.test.ts"),
+    'import { value } from "./value"; void value;\n',
+  );
   execFileSync("git", ["init", "-b", "dev"], { cwd: root });
-  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: root,
+  });
   execFileSync("git", ["config", "user.name", "Test"], { cwd: root });
   execFileSync("git", ["add", "."], { cwd: root });
   execFileSync("git", ["commit", "-m", "baseline"], { cwd: root });
@@ -22,17 +37,78 @@ function fixture() {
 }
 
 describe("changed mutation plan", () => {
+  it.each([
+    [
+      "라우트 그룹",
+      "src/app/(main)/page.tsx:1-1",
+      "src/app/\\(main\\)/page.tsx:1-1",
+    ],
+    [
+      "동적 세그먼트",
+      "src/app/[id]/page.tsx:3-3",
+      "src/app/\\[id\\]/page.tsx:3-3",
+    ],
+    [
+      "라우트 그룹과 동적 세그먼트",
+      "src/app/(preview)/preview/[id]/_components/Navigation.tsx:3-3",
+      "src/app/\\(preview\\)/preview/\\[id\\]/_components/Navigation.tsx:3-3",
+    ],
+  ])(
+    "Stryker에 전달할 %s 경로만 glob escape한다",
+    (_name, target, expected) => {
+      expect(escapeGlobPath(target)).toBe(expected);
+    },
+  );
+
+  it("라우트 경로의 plan.targets와 sourceHash는 escape되지 않은 원본을 유지한다", () => {
+    const root = fixture();
+    const source = "src/app/(preview)/preview/[id]/_components/Navigation.tsx";
+    const test =
+      "src/app/(preview)/preview/[id]/_components/Navigation.test.tsx";
+    fs.mkdirSync(path.dirname(path.join(root, source)), { recursive: true });
+    fs.writeFileSync(path.join(root, source), "export const navigation = 1;\n");
+    fs.writeFileSync(
+      path.join(root, test),
+      'import { navigation } from "./Navigation"; void navigation;\n',
+    );
+    execFileSync("git", ["add", "."], { cwd: root });
+    execFileSync("git", ["commit", "-m", "route baseline"], { cwd: root });
+    execFileSync("git", ["branch", "-f", "baseline", "HEAD"], { cwd: root });
+    fs.writeFileSync(path.join(root, source), "export const navigation = 2;\n");
+    execFileSync("git", ["add", "."], { cwd: root });
+    execFileSync("git", ["commit", "-m", "change route"], { cwd: root });
+
+    const plan = mutationPlan(root, "baseline");
+    const target = `${source}:1-1`;
+    const expectedHash = crypto
+      .createHash("sha256")
+      .update(`${target}\0${fs.readFileSync(path.join(root, source))}`)
+      .digest("hex");
+
+    expect(plan.targets).toEqual([target]);
+    expect(plan.sourceHash).toBe(expectedHash);
+  });
+
   it("merge-base 이후 바뀐 제품 줄과 관련 테스트만 선택한다", () => {
     const root = fixture();
-    fs.writeFileSync(path.join(root, "src/value.ts"), "export const value = 2;\nexport const next = 3;\n");
+    fs.writeFileSync(
+      path.join(root, "src/value.ts"),
+      "export const value = 2;\nexport const next = 3;\n",
+    );
     execFileSync("git", ["add", "."], { cwd: root });
     execFileSync("git", ["commit", "-m", "change"], { cwd: root });
-    expect(mutationPlan(root, "baseline")).toMatchObject({ targets: ["src/value.ts:1-2"], tests: ["src/value.test.ts"] });
+    expect(mutationPlan(root, "baseline")).toMatchObject({
+      targets: ["src/value.ts:1-2"],
+      tests: ["src/value.test.ts"],
+    });
   });
 
   it("sourceHash는 반환된 targets(정렬됨)와 같은 순서로 계산된다 — 한 자리/두 자리 줄번호가 섞여도 어긋나지 않는다", () => {
     const root = fixture();
-    const lines = Array.from({ length: 25 }, (_, i) => `export const v${i} = ${i};`);
+    const lines = Array.from(
+      { length: 25 },
+      (_, i) => `export const v${i} = ${i};`,
+    );
     fs.writeFileSync(path.join(root, "src/value.ts"), `${lines.join("\n")}\n`);
     execFileSync("git", ["add", "."], { cwd: root });
     execFileSync("git", ["commit", "-m", "multiline baseline"], { cwd: root });
@@ -64,12 +140,31 @@ describe("changed mutation plan", () => {
   });
 
   it("mutant가 없으면 실패가 아니라 N/A다", () => {
-    expect(evaluateReport({ files: {} })).toMatchObject({ status: "N/A", total: 0 });
+    expect(evaluateReport({ files: {} })).toMatchObject({
+      status: "N/A",
+      total: 0,
+    });
   });
 
   it("명시한 동등 mutant만 survived 예외로 인정한다", () => {
-    const report = { files: { "src/value.ts": { mutants: [{ status: "Survived", mutatorName: "BooleanLiteral", location: { start: { line: 4 } } }] } } };
+    const report = {
+      files: {
+        "src/value.ts": {
+          mutants: [
+            {
+              status: "Survived",
+              mutatorName: "BooleanLiteral",
+              location: { start: { line: 4 } },
+            },
+          ],
+        },
+      },
+    };
     expect(evaluateReport(report).status).toBe("FAILED");
-    expect(evaluateReport(report, [{ file: "src/value.ts", mutant: "4:BooleanLiteral" }]).status).toBe("PASSED");
+    expect(
+      evaluateReport(report, [
+        { file: "src/value.ts", mutant: "4:BooleanLiteral" },
+      ]).status,
+    ).toBe("PASSED");
   });
 });


### PR DESCRIPTION
## Summary

- Stryker가 mutation range와 glob 표현식을 함께 받았다고 오인하던 Next.js 라우트 그룹·동적 세그먼트 경로를 실행 경계에서만 escape합니다.
- `plan.targets`, `sourceHash`, `changed-proof.json`에는 재현 가능한 원본 경로가 유지됩니다.
- 라우트 그룹, 동적 세그먼트, 결합 경로와 원본 target·hash 보존을 회귀 테스트로 추가했습니다.

## Test plan

- `npx vitest run --project guard scripts/test-scope/changed-mutation.test.mjs` — 8개 테스트 통과
- `npm run lint -- --quiet` — 통과
- `npm run test:mutation -- --base origin/dev` — Not run: 사용자 요청에 따라 CI의 `mutation-changed`에서 실제 Stryker 수용 여부 확인
- 전체 테스트 — Not run: 사용자 요청에 따라 PR CI에서 확인