### PR TITLE
refactor: 공유 도메인 타입을 shared로 추출하고 UI→서버 타입 의존 차단

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,8 @@ const eslintConfig = [...nextCoreWebVitals, ...nextTypescript, {
         { target: "./src/shared", from: "./src/app", message: "shared는 순수해야 한다" },
         { target: "./src/server", from: "./src/client", message: "서버는 클라이언트를 모른다" },
         { target: "./src/client", from: "./src/server/lib", message: "UI는 서버 lib을 직접 못 만진다" },
+        { target: "./src/client", from: "./src/server/services", message: "UI는 service 내부 타입을 직접 못 쓴다" },
+        { target: "./src/client", from: "./src/server/models", message: "UI는 DB 스키마를 직접 못 쓴다" },
       ],
     }],
   },

--- a/src/app/(admin)/admin/premium-features/_components/PremiumFeatureCardAction.tsx
+++ b/src/app/(admin)/admin/premium-features/_components/PremiumFeatureCardAction.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import { Button } from "@/client/components/atoms";
 import { Edit, Trash2 } from "lucide-react";
-import type { PremiumFeature } from "@/server/services";
+import type { PremiumFeature } from "@/shared/types";
 import { useAdminModalStore } from "@/client/store";
 const PremiumFeatureCardAction = ({
   premiumFeature,

--- a/src/app/(admin)/admin/premium-features/_components/PremiumFeatureDialog.tsx
+++ b/src/app/(admin)/admin/premium-features/_components/PremiumFeatureDialog.tsx
@@ -3,7 +3,7 @@
 import { useActionState, useEffect } from "react";
 import { toast } from "sonner";
 
-import type { PremiumFeature } from "@/server/services";
+import type { PremiumFeature } from "@/shared/types";
 import { updatePremiumFeature } from "@/server/actions";
 import type { APIResponse } from "@/shared/types";
 import { hasFieldErrors } from "@/shared/utils";

--- a/src/app/(admin)/admin/products/_components/AdminProductsTemplate.test.tsx
+++ b/src/app/(admin)/admin/products/_components/AdminProductsTemplate.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { ProductJSON } from "@/server/models";
+import type { ProductJSON } from "@/shared/types";
 
 vi.mock("./ProductTableRow", () => ({
   ProductTableRow: ({ product }: { product: { title: string } }) => (

--- a/src/app/(admin)/admin/products/_components/AdminProductsTemplate.tsx
+++ b/src/app/(admin)/admin/products/_components/AdminProductsTemplate.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { Plus } from "lucide-react";
 import { Button, TypographyH1, TypographyMuted } from "@/client/components/atoms";
-import type { ProductJSON } from "@/server/models";
+import type { ProductJSON } from "@/shared/types";
 import { routes } from "@/shared/constants";
 import { TABLE_COLUMNS } from "../_constants";
 import { ProductTableRow } from "./ProductTableRow";

--- a/src/app/(admin)/admin/products/_components/ProductEditDialog.quantityImages.test.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductEditDialog.quantityImages.test.tsx
@@ -44,7 +44,7 @@ vi.mock("@/shared/utils", async (importOriginal) => {
   };
 });
 
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { ProductEditDialog } from "./ProductEditDialog";
 
 const buildProduct = (overrides?: Partial<Product>): Product => ({

--- a/src/app/(admin)/admin/products/_components/ProductEditDialog.test.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductEditDialog.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@/client/hooks", () => ({
   }),
 }));
 
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { ProductEditDialog } from "./ProductEditDialog";
 
 const buildProduct = (overrides?: Partial<Product>): Product => ({

--- a/src/app/(admin)/admin/products/_components/ProductEditDialog.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductEditDialog.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 import { useActionState, useEffect, useState } from "react";
 import { UploadCloud, X } from "lucide-react";
 import { updateProduct } from "@/server/actions";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { Alert, ImageField, SelectField, Spinner, CloudImage } from "@/client/components/molecules";
 import { Input, Button, Textarea, Switch, Checkbox, Label, TypographyH4, TypographyMuted } from "@/client/components/atoms";
 

--- a/src/app/(admin)/admin/products/_components/ProductTableRow.test.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRow.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 
 vi.mock("./ProductTableRowAction", () => ({
   ProductTableRowAction: (): null => null,

--- a/src/app/(admin)/admin/products/_components/ProductTableRow.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRow.tsx
@@ -1,6 +1,6 @@
 import { Eye, Heart, ShoppingCart } from "lucide-react";
 import { Badge, TypographyMuted, TypographySmall } from "@/client/components/atoms";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { CloudImage } from "@/client/components/molecules";
 import { ProductTableRowAction } from "./ProductTableRowAction";
 import { ProductTableRowSelect } from "./ProductTableRowSelect";

--- a/src/app/(admin)/admin/products/_components/ProductTableRowSelect.test.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRowSelect.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/server/actions", () => ({
 }));
 
 import { updateProductStatus } from "@/server/actions";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { ProductTableRowSelect } from "./ProductTableRowSelect";
 
 const buildProduct = (overrides?: Partial<Product>): Product => ({

--- a/src/app/(admin)/admin/products/_components/ProductTableRowSelect.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRowSelect.tsx
@@ -5,7 +5,7 @@ import { isStatus, STATUS_ITEMS } from "../_types";
 import { updateProductStatus } from "@/server/actions";
 import { toast } from "sonner";
 import { StatusSelect } from "@/client/components/molecules";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 const ProductTableRowSelect = ({ product }: { product: Product }) => {
   const router = useRouter();
   const [status, setStatus] = useState<string>(product.status);

--- a/src/app/(admin)/admin/products/new/_components/ProductRegistrationForm.tsx
+++ b/src/app/(admin)/admin/products/new/_components/ProductRegistrationForm.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 
 import { createProduct } from "@/server/actions";
 import type { APIResponse } from "@/shared/types";
-import type { PremiumFeature } from "@/server/services";
+import type { PremiumFeature } from "@/shared/types";
 import { ProductRegistrationForm as PureProductRegistrationForm } from "@/client/components/organisms";
 import { routes } from "@/shared/constants";
 export function ProductRegistrationForm({

--- a/src/app/(main)/(checkout)/payment/_components/CheckoutSubmitBar.tsx
+++ b/src/app/(main)/(checkout)/payment/_components/CheckoutSubmitBar.tsx
@@ -3,7 +3,7 @@
 import { BottomActionBar } from "@/client/components/organisms";
 import { Spinner } from "@/client/components/molecules";
 import { Save } from "lucide-react";
-import type { PayStatus } from "@/server/models";
+import type { PayStatus } from "@/shared/types";
 interface CheckoutSubmitBarProps {
   disabled: boolean;
   pending: boolean;

--- a/src/app/(main)/(my-order)/my-orders/_constants/labels.ts
+++ b/src/app/(main)/(my-order)/my-orders/_constants/labels.ts
@@ -1,4 +1,4 @@
-import type { PayMethod } from "@/server/models";
+import type { PayMethod } from "@/shared/types";
 import type { OrderStatus } from "../_types";
 
 export const PAYMENT_STATUS: Record<OrderStatus, string> = {

--- a/src/app/(main)/(products)/products/[category]/[id]/_components/ProductDetailTemplate.test.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_components/ProductDetailTemplate.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { Product, PremiumFeature } from "@/server/services";
+import type { Product, PremiumFeature } from "@/shared/types";
 
 vi.mock("./ProductViewTracker", () => ({
   ProductViewTracker: (): null => null,

--- a/src/app/(main)/(products)/products/[category]/[id]/_components/ProductDetailTemplate.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_components/ProductDetailTemplate.tsx
@@ -1,5 +1,5 @@
 import { ProductFeatures } from "@/client/components/organisms";
-import type { Product, PremiumFeature } from "@/server/services";
+import type { Product, PremiumFeature } from "@/shared/types";
 import { ProductSummary } from "./ProductSummary";
 import { ProductViewTracker } from "./ProductViewTracker";
 

--- a/src/app/(main)/(products)/products/[category]/[id]/_components/ProductSummary.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_components/ProductSummary.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 
 import { useOrderStore } from "@/client/store";
-import type { Product, PremiumFeature } from "@/server/services";
+import type { Product, PremiumFeature } from "@/shared/types";
 
 import type { CheckoutItem } from "@/shared/types";
 import { ProductSummary as PureProductSummary } from "@/client/components/organisms";

--- a/src/app/(main)/(products)/products/_components/ProductCatalog.test.tsx
+++ b/src/app/(main)/(products)/products/_components/ProductCatalog.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 
 const { useProductsMock, usePremiumFeatureMock } = vi.hoisted(() => ({
   useProductsMock: vi.fn(),

--- a/src/app/(main)/(products)/products/_components/ProductCatalog.tsx
+++ b/src/app/(main)/(products)/products/_components/ProductCatalog.tsx
@@ -2,7 +2,7 @@
 
 import { useProducts, usePremiumFeature } from "@/client/hooks";
 import { ProductCatalog as ProductCatalogView } from "@/client/components/organisms";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import type { ProductCategory, SubCategory } from "@/shared/constants";
 
 export function ProductCatalog({

--- a/src/app/(main)/_components/HomeTemplate.test.tsx
+++ b/src/app/(main)/_components/HomeTemplate.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 
 vi.mock("@/client/components/organisms", () => ({
   EcommerceHero: () => <div>hero</div>,

--- a/src/app/(main)/_components/HomeTemplate.tsx
+++ b/src/app/(main)/_components/HomeTemplate.tsx
@@ -1,5 +1,5 @@
 import { StartActionCTA, EcommerceHero, LiveDemoSection, TemplateCarouselGroup } from "@/client/components/organisms";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { TypographyH2, TypographyP } from "@/client/components/atoms";
 import { SubCategoryNavSection } from "./SubCategoryNavSection";
 import { PopularProductsSection } from "./PopularProductsSection";

--- a/src/app/(main)/_components/PopularProductsSection.test.tsx
+++ b/src/app/(main)/_components/PopularProductsSection.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { PopularProductsSection } from "./PopularProductsSection";
 
 const buildProduct = (overrides?: Partial<Product>): Product =>

--- a/src/app/(main)/_components/PopularProductsSection.tsx
+++ b/src/app/(main)/_components/PopularProductsSection.tsx
@@ -10,7 +10,7 @@ import {
   CarouselNext,
 } from "@/client/components/atoms";
 import { ProductCard } from "@/client/components/organisms";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { POPULAR_PRODUCTS_MIN_ITEMS } from "@/shared/constants";
 
 interface PopularProductsSectionProps {

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,8 +1,7 @@
 export const revalidate = 3600;
 
 import { HomeTemplate } from "./_components";
-import type {
-  Product} from "@/server/services";
+import type { Product } from "@/shared/types";
 import {
   getFeaturedTemplatesService,
   getPopularProductsService,

--- a/src/app/(main)/search/_hooks/useProductSearch.integration.test.tsx
+++ b/src/app/(main)/search/_hooks/useProductSearch.integration.test.tsx
@@ -4,7 +4,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import type { Product } from "@/server/services/product.service";
+import type { Product } from "@/shared/types";
 import { useProductSearch } from "./useProductSearch";
 
 const product: Product = {

--- a/src/app/(main)/search/_hooks/useProductSearch.ts
+++ b/src/app/(main)/search/_hooks/useProductSearch.ts
@@ -2,7 +2,7 @@
 
 import useSWR from "swr";
 import { fetcher } from "@/client/fetcher";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import type { ErrorPayload } from "@/shared/types";
 
 // 런타임 shape은 응답 계약(ProductResponse[])과 동일하다 — Product 타입을 쓰는 이유는

--- a/src/app/(preview)/preview/[id]/_utils/accountSection.mapper.ts
+++ b/src/app/(preview)/preview/[id]/_utils/accountSection.mapper.ts
@@ -1,4 +1,4 @@
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 // AccountSection 컴포넌트가 받을 props 타입 정의
 export interface AccountInfo {
   relation: string;

--- a/src/app/(preview)/preview/[id]/_utils/gallerySection.mapper.ts
+++ b/src/app/(preview)/preview/[id]/_utils/gallerySection.mapper.ts
@@ -1,4 +1,4 @@
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 export interface GallerySectionProps {
   images: string[];
   lightboxEnabled: boolean;

--- a/src/app/(preview)/preview/[id]/_utils/heroSection.mapper.ts
+++ b/src/app/(preview)/preview/[id]/_utils/heroSection.mapper.ts
@@ -1,4 +1,4 @@
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 export interface HeroSectionProps {
   groomName: string;
   brideName: string;

--- a/src/app/(preview)/preview/[id]/_utils/invitationMessage.mapper.ts
+++ b/src/app/(preview)/preview/[id]/_utils/invitationMessage.mapper.ts
@@ -1,4 +1,4 @@
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 // 최종적으로 InvitationMessage 컴포넌트가 받을 props 타입
 interface Contact {
   relation: string;

--- a/src/app/(preview)/preview/[id]/_utils/locationSection.mapper.ts
+++ b/src/app/(preview)/preview/[id]/_utils/locationSection.mapper.ts
@@ -1,4 +1,4 @@
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 export interface LocationSectionProps {
   venueName: string;
   address: string;

--- a/src/app/(preview)/preview/[id]/_utils/thumbnails.mapper.ts
+++ b/src/app/(preview)/preview/[id]/_utils/thumbnails.mapper.ts
@@ -1,4 +1,4 @@
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 export interface ThumbnailsProps {
   divider: string;
   footer: string;

--- a/src/app/(preview)/preview/[id]/_utils/weddingMonthCalendar.mapper.ts
+++ b/src/app/(preview)/preview/[id]/_utils/weddingMonthCalendar.mapper.ts
@@ -1,4 +1,4 @@
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 export interface WeddingMonthCalendarProps {
   date: Date;
 }

--- a/src/app/api/couple-info/route.ts
+++ b/src/app/api/couple-info/route.ts
@@ -2,7 +2,7 @@ import type { APIRouteResponse} from "@/server/boundary";
 import { routeSuccess, routeError } from "@/server/boundary";
 import { AppError } from "@/shared/types";
 import { requireAuth, getCoupleInfoById } from "@/server/services";
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 import type { CoupleInfoResponse } from "@/shared/schemas";
 
 import type { NextRequest } from "next/server";

--- a/src/client/components/organisms/BasicInfoSection.tsx
+++ b/src/client/components/organisms/BasicInfoSection.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/client/components/at
 import { format } from "date-fns";
 import { TextField, AddressField, SwitchField, ComboboxField, DateField } from "@/client/components/molecules";
 
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 import type { SubwayStationsResponse } from "@/shared/schemas";
 
 type BasicInfoSectionProps = {

--- a/src/client/components/organisms/CheckoutForm.tsx
+++ b/src/client/components/organisms/CheckoutForm.tsx
@@ -1,6 +1,6 @@
 import { AlertCircle } from "lucide-react";
 
-import type { PayStatus } from "@/server/models";
+import type { PayStatus } from "@/shared/types";
 import type { BuyerInfo } from "@/shared/schemas";
 
 import { Spinner } from "@/client/components/molecules";

--- a/src/client/components/organisms/CoupleInfoSection.tsx
+++ b/src/client/components/organisms/CoupleInfoSection.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle, TypographyH3 } from "@/client
 
 import { BankField, TextField } from "@/client/components/molecules";
 
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 import type { BanksResponse } from "@/shared/schemas";
 
 type CoupleInfoSectionProps = {

--- a/src/client/components/organisms/LiveDemoSection.test.tsx
+++ b/src/client/components/organisms/LiveDemoSection.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { ProductJSON } from "@/server/models";
+import type { ProductJSON } from "@/shared/types";
 import { LiveDemoSection } from "./LiveDemoSection";
 
 const buildProduct = (): ProductJSON =>

--- a/src/client/components/organisms/LiveDemoSection.tsx
+++ b/src/client/components/organisms/LiveDemoSection.tsx
@@ -4,7 +4,7 @@ import { Eye, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import React from "react";
 import Image from "next/image";
-import type { ProductJSON } from "@/server/models";
+import type { ProductJSON } from "@/shared/types";
 import { routes } from "@/shared/constants";
 interface LiveDemoSectionProps {
   product: ProductJSON;

--- a/src/client/components/organisms/ParentsInfoSection.tsx
+++ b/src/client/components/organisms/ParentsInfoSection.tsx
@@ -6,7 +6,7 @@ import { BankField, TextField } from "@/client/components/molecules";
 
 import { ChevronDown } from "lucide-react";
 
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 import type { BanksResponse } from "@/shared/schemas";
 
 import { useState } from "react";

--- a/src/client/components/organisms/PaymentMethodSelector.tsx
+++ b/src/client/components/organisms/PaymentMethodSelector.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/client/components/atoms";
-import type { PayMethod } from "@/server/models";
+import type { PayMethod } from "@/shared/types";
 import { ArrowRightLeft, CreditCard, Landmark, Phone, Gift, Wallet } from "lucide-react";
 import React from "react";
 import type { RadioFieldOption} from "@/client/components/molecules";

--- a/src/client/components/organisms/PremiumFeatureDialog.tsx
+++ b/src/client/components/organisms/PremiumFeatureDialog.tsx
@@ -3,7 +3,7 @@ import { Button, DialogFooter, Input, TypographyMuted, Textarea, Label } from "@
 
 
 
-import type { PremiumFeature } from "@/server/services";
+import type { PremiumFeature } from "@/shared/types";
 import { Alert, TextField } from "@/client/components/molecules";
 import type { APIResponse } from "@/shared/types";
 import { getFieldError } from "@/shared/utils";

--- a/src/client/components/organisms/ProductCard.test.tsx
+++ b/src/client/components/organisms/ProductCard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { ProductCard } from "./ProductCard";
 
 const buildProduct = (overrides?: Partial<Product>): Product =>

--- a/src/client/components/organisms/ProductCard.tsx
+++ b/src/client/components/organisms/ProductCard.tsx
@@ -1,6 +1,6 @@
 import { Sparkles } from "lucide-react";
 import Link from "next/link";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { calculatePrice } from "@/shared/utils";
 import type { SubCategory} from "@/shared/constants";
 import { subCategoryLabels } from "@/shared/constants";

--- a/src/client/components/organisms/ProductCatalog.test.tsx
+++ b/src/client/components/organisms/ProductCatalog.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { ProductCatalog } from "./ProductCatalog";
 
 const buildProduct = (overrides?: Partial<Product>): Product =>

--- a/src/client/components/organisms/ProductCatalog.tsx
+++ b/src/client/components/organisms/ProductCatalog.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/client/context/productFilter";
 import React from "react";
 import { ProductFilters, ProductGrid } from "@/client/components/organisms";
-import type { Product, PremiumFeature } from "@/server/services";
+import type { Product, PremiumFeature } from "@/shared/types";
 
 import type { ProductCategory, SubCategory } from "@/shared/constants";
 

--- a/src/client/components/organisms/ProductFeatures.tsx
+++ b/src/client/components/organisms/ProductFeatures.tsx
@@ -1,5 +1,5 @@
 import { Card, TypographyH2, TypographyH3, TypographyMuted } from "@/client/components/atoms";
-import type { PremiumFeature } from "@/server/services";
+import type { PremiumFeature } from "@/shared/types";
 import clsx from "clsx";
 import { Check, Palette, Type, Settings, FileText } from "lucide-react";
 

--- a/src/client/components/organisms/ProductFilters.test.tsx
+++ b/src/client/components/organisms/ProductFilters.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { initialFilterState } from "@/client/context/productFilter";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { ProductFilters } from "./ProductFilters";
 
 const buildProduct = (overrides?: Partial<Product>): Product =>

--- a/src/client/components/organisms/ProductFilters.tsx
+++ b/src/client/components/organisms/ProductFilters.tsx
@@ -11,7 +11,7 @@ import type { Dispatch} from "react";
 import { useState } from "react";
 
 import type { ProductFilterState, ProductFilterAction } from "@/client/context/productFilter";
-import type { Product, PremiumFeature } from "@/server/services";
+import type { Product, PremiumFeature } from "@/shared/types";
 
 import { getSubCategoryOptions } from "@/shared/utils";
 

--- a/src/client/components/organisms/ProductGrid.test.tsx
+++ b/src/client/components/organisms/ProductGrid.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { initialFilterState } from "@/client/context/productFilter";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { ProductGrid } from "./ProductGrid";
 
 const buildProduct = (overrides?: Partial<Product>): Product =>

--- a/src/client/components/organisms/ProductGrid.tsx
+++ b/src/client/components/organisms/ProductGrid.tsx
@@ -4,7 +4,7 @@ import { ProductCard } from "@/client/components/organisms";
 
 import { useVisibleProducts } from "@/client/hooks";
 import type { ProductFilterState } from "@/client/context/productFilter";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { TypographyMuted, TypographyP } from "../atoms/typography";
 import { PackageOpen } from "lucide-react";
 

--- a/src/client/components/organisms/ProductOptions.test.tsx
+++ b/src/client/components/organisms/ProductOptions.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { Product, PremiumFeature } from "@/server/services";
+import type { Product, PremiumFeature } from "@/shared/types";
 import { ProductOptions } from "./ProductOptions";
 
 const buildOption = (overrides?: Partial<PremiumFeature>): PremiumFeature => ({

--- a/src/client/components/organisms/ProductOptions.tsx
+++ b/src/client/components/organisms/ProductOptions.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 import { Badge, Button } from "@/client/components/atoms";
 
 import { QuantityStepper, StatusSelect } from "@/client/components/molecules";
-import type { Product, PremiumFeature } from "@/server/services";
+import type { Product, PremiumFeature } from "@/shared/types";
 
 import type { CheckoutItem } from "@/shared/types";
 import type { SelectFeatureDto } from "@/shared/schemas";

--- a/src/client/components/organisms/ProductRegistrationForm.test.tsx
+++ b/src/client/components/organisms/ProductRegistrationForm.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ProductRegistrationForm } from "./ProductRegistrationForm";
-import type { PremiumFeature } from "@/server/services";
+import type { PremiumFeature } from "@/shared/types";
 
 const buildFeature = (overrides?: Partial<PremiumFeature>): PremiumFeature => ({
   _id: "feature-1",

--- a/src/client/components/organisms/ProductRegistrationForm.tsx
+++ b/src/client/components/organisms/ProductRegistrationForm.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 import { useState } from "react";
 import Image from "next/image";
 import { UploadCloud, X } from "lucide-react";
-import type { PremiumFeature } from "@/server/services";
+import type { PremiumFeature } from "@/shared/types";
 import { Alert, ImageField, SelectField } from "@/client/components/molecules";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Button, Textarea, Switch, Checkbox, Label, TypographyMuted, TypographyH4 } from "@/client/components/atoms";
 

--- a/src/client/components/organisms/ProductSummary.test.tsx
+++ b/src/client/components/organisms/ProductSummary.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 
 const { useAuthMock } = vi.hoisted(() => ({ useAuthMock: vi.fn() }));
 

--- a/src/client/components/organisms/ProductSummary.tsx
+++ b/src/client/components/organisms/ProductSummary.tsx
@@ -3,7 +3,7 @@
 import { Share2 } from "lucide-react";
 import { useMemo } from "react";
 import { Badge, TypographyH1, TypographyMuted } from "@/client/components/atoms";
-import type { Product, PremiumFeature } from "@/server/services";
+import type { Product, PremiumFeature } from "@/shared/types";
 import { isProductCategory, calculatePrice } from "@/shared/utils";
 import type { SubCategory } from "@/shared/constants";
 import { productCategoryLabels, subCategoryLabels } from "@/shared/constants";

--- a/src/client/components/organisms/TemplateCarouselGroup.test.tsx
+++ b/src/client/components/organisms/TemplateCarouselGroup.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import type * as AtomsModule from "@/client/components/atoms";
 
 vi.mock("@/client/components/atoms", async (importOriginal) => {

--- a/src/client/components/organisms/TemplateCarouselGroup.tsx
+++ b/src/client/components/organisms/TemplateCarouselGroup.tsx
@@ -2,7 +2,7 @@ import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious
 import React from "react";
 import { ProductCard } from "./ProductCard";
 
-import type { ProductJSON } from "@/server/models";
+import type { ProductJSON } from "@/shared/types";
 interface TemplateCarouselGroupProps {
   data: ProductJSON[];
   title: string;

--- a/src/client/hooks/useFetchCoupleInfo.ts
+++ b/src/client/hooks/useFetchCoupleInfo.ts
@@ -1,6 +1,6 @@
 "use client";
 import { fetcher } from "@/client/fetcher";
-import type { ICoupleInfo } from "@/server/models";
+import type { ICoupleInfo } from "@/shared/types";
 import { useSearchParams } from "next/navigation";
 import useSWR from "swr";
 

--- a/src/client/hooks/usePortOnePayment.ts
+++ b/src/client/hooks/usePortOnePayment.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { requestPayment } from "@/client/lib/portone/request-payment";
-import type { PayStatus } from "@/server/models";
+import type { PayStatus } from "@/shared/types";
 import type { CreateOrderResult } from "@/server/actions";
 import { completePayment } from "@/server/actions";
 import { useOrderStore } from "@/client/store";

--- a/src/client/hooks/usePremiumFeatures.ts
+++ b/src/client/hooks/usePremiumFeatures.ts
@@ -2,7 +2,7 @@
 
 import useSWR from "swr";
 import { fetcher } from "@/client/fetcher";
-import type { PremiumFeature } from "@/server/services";
+import type { PremiumFeature } from "@/shared/types";
 import { useEffect } from "react";
 import { toast } from "sonner";
 

--- a/src/client/hooks/useProducts.test.ts
+++ b/src/client/hooks/useProducts.test.ts
@@ -6,7 +6,7 @@ const { useSWRMock } = vi.hoisted(() => ({ useSWRMock: vi.fn() }));
 vi.mock("swr", () => ({ default: useSWRMock }));
 vi.mock("@/client/fetcher", () => ({ fetcher: vi.fn() }));
 
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import { useProducts } from "./useProducts";
 
 const buildProduct = (overrides?: Partial<Product>): Product =>

--- a/src/client/hooks/useProducts.ts
+++ b/src/client/hooks/useProducts.ts
@@ -2,7 +2,7 @@
 
 import useSWR from "swr";
 import { fetcher } from "@/client/fetcher";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import type { ProductCategory } from "@/shared/constants";
 
 export function useProducts(

--- a/src/client/hooks/useSuggestProducts.ts
+++ b/src/client/hooks/useSuggestProducts.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 const useSuggestProducts = ({
   data,
   keyword,

--- a/src/client/hooks/useVisibleProducts.ts
+++ b/src/client/hooks/useVisibleProducts.ts
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 
-import type { Product } from "@/server/services";
+import type { Product } from "@/shared/types";
 import type { ProductFilterState } from "@/client/context/productFilter";
 import { getChosung } from "@/shared/utils";
 

--- a/src/client/store/admin.modal.store.ts
+++ b/src/client/store/admin.modal.store.ts
@@ -1,4 +1,4 @@
-import type { PremiumFeature, Product } from "@/server/services";
+import type { PremiumFeature, Product } from "@/shared/types";
 
 import { create } from "zustand";
 

--- a/src/client/store/order.store.ts
+++ b/src/client/store/order.store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import type { CheckoutItem } from "@/shared/types";
-import type { PayStatus } from "@/server/models";
+import type { PayStatus } from "@/shared/types";
 
 interface OrderState {
   order: CheckoutItem | null;

--- a/src/server/actions/completePayment.ts
+++ b/src/server/actions/completePayment.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import type { APIResponse} from "@/shared/types";
 import { AppError } from "@/shared/types";
 import { syncPayment, requireAuth } from "@/server/services";
-import type { PayStatus } from "@/server/models";
+import type { PayStatus } from "@/shared/types";
 import { actionError } from "@/server/boundary";
 import { routes } from "@/shared/constants";
 

--- a/src/server/actions/createOrder.ts
+++ b/src/server/actions/createOrder.ts
@@ -9,7 +9,7 @@ import { actionError } from "@/server/boundary";
 
 import { validateAndFlatten } from "@/shared/utils";
 import { createOrderSchema } from "@/shared/schemas";
-import type { PayMethod } from "@/server/models";
+import type { PayMethod } from "@/shared/types";
 import { routes } from "@/shared/constants";
 export type CreateOrderResult = {
   merchantUid: string;

--- a/src/server/models/coupleInfo.model.ts
+++ b/src/server/models/coupleInfo.model.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type { Model, Types } from "mongoose";
 import mongoose, { Schema } from "mongoose";
+import type { ICoupleInfo } from "@/shared/types";
 
 // 공통 타입 정의
 interface Person {
@@ -20,21 +21,9 @@ interface CoupleSide extends Person {
   mother?: Parent;
 }
 
-export interface ICoupleInfo {
-  _id: string | Types.ObjectId;
-  userId: string | Types.ObjectId;
-  groom: CoupleSide;
-  bride: CoupleSide;
-  weddingDate: Date;
-  venue: string;
-  address: string;
-  addressDetail: string;
-  subwayStation?: string;
-  guestbookEnabled: boolean;
-  thumbnailImages: string[];
-  galleryImages: string[];
-  createdAt: Date;
-  updatedAt: Date;
+export interface CoupleInfoDB extends Omit<ICoupleInfo, "_id" | "userId"> {
+  _id: Types.ObjectId;
+  userId: Types.ObjectId;
 }
 
 const ParentSchema = new Schema<Parent>(
@@ -60,7 +49,7 @@ const CoupleSideSchema = new Schema<CoupleSide>(
 );
 
 
-const coupleInfoSchema = new Schema<ICoupleInfo>(
+const coupleInfoSchema = new Schema<CoupleInfoDB>(
   {
     userId: {
       type: Schema.Types.ObjectId,
@@ -99,5 +88,5 @@ const coupleInfoSchema = new Schema<ICoupleInfo>(
 );
 
 export const CoupleInfoModel =
-  (mongoose.models.CoupleInfo as Model<ICoupleInfo>) ||
-  mongoose.model<ICoupleInfo>("CoupleInfo", coupleInfoSchema);
+  (mongoose.models.CoupleInfo as Model<CoupleInfoDB>) ||
+  mongoose.model<CoupleInfoDB>("CoupleInfo", coupleInfoSchema);

--- a/src/server/models/order.model.ts
+++ b/src/server/models/order.model.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import type { Types, Model } from "mongoose";
 import mongoose, { Schema } from "mongoose";
-import type { PayMethod } from "./payment.model";
+import type { PayMethod } from "@/shared/types";
 import { PAY_METHOD } from "@/shared/constants";
 interface ProductPricing {
   originalPrice: number;

--- a/src/server/models/payment.model.ts
+++ b/src/server/models/payment.model.ts
@@ -1,21 +1,12 @@
 import "server-only";
-import type { PAY_METHOD } from "@/shared/constants";
+import type { PayMethod, PayStatus } from "@/shared/types";
 import type { Types, Model } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 
 // --- Enums --- TRANS 실시간 계좌이체 VBANK 가상 계좌
 
-export type PayMethod = (typeof PAY_METHOD)[number]; // 카드 , 계좌이체, 가상계좌, 휴대폰 소액결제
-
 // PortOne이 반환하는 PG사 식별자는 동적이므로 string으로 처리
 type PgProvider = string;
-export type PayStatus =
-  | "PENDING"
-  | "PAID"
-  | "FAILED"
-  | "CANCELLED"
-  | "PARTIAL_CANCELLED"
-  | "REFUNDED";
 
 // PortOne 결제수단 판별값(@portone/server-sdk PaymentMethod.type) + 미인식 폴백.
 export type PaymentMethodDetailType =

--- a/src/server/models/product.model.ts
+++ b/src/server/models/product.model.ts
@@ -9,6 +9,7 @@ import {
   SUB_CATEGORY_MAP,
   PRODUCT_CATEGORIES
 } from "@/shared/constants";
+import type { ProductJSON } from "@/shared/types";
 
 export type { ProductCategory, SubCategory };
 export { SUB_CATEGORY_MAP };
@@ -37,31 +38,24 @@ const discountSchema = new Schema(
   { _id: false },
 );
 
-export interface ProductDB {
-  authorId: string;
-  title: string;
-  description: string;
-  thumbnail: string;
-  price: number;
-  category: ProductCategory;
-  subCategory: SubCategory;
-  isPremium: boolean;
+export interface ProductDB
+  extends Omit<
+    ProductJSON,
+    | "_id"
+    | "likes"
+    | "featureIds"
+    | "previewUrl"
+    | "theme"
+    | "isLiked"
+    | "discountedPrice"
+    | "createdAt"
+    | "updatedAt"
+    | "deletedAt"
+  > {
   featureIds?: mongoose.Types.ObjectId[];
-  isFeatured: boolean;
-  priority: number;
   likes: mongoose.Types.ObjectId[];
-  views: number;
-  salesCount: number;
-  discount: {
-    discountType: "rate" | "amount";
-    value: number;
-  };
-  status: Status;
   // 스키마가 default: null이라 모든 문서에 항상 존재한다 — optional이 아니라 nullable.
   deletedAt: Date | null;
-  images: string[];
-  minQuantity: number;
-  maxQuantity: number;
 }
 
 export interface IProduct extends ProductDB {
@@ -74,19 +68,6 @@ export interface IProduct extends ProductDB {
 export interface IInvitationProduct extends IProduct {
   previewUrl?: string;
   theme?: InvitationTheme;
-}
-
-export interface ProductJSON extends Omit<ProductDB, "likes" | "featureIds" | "deletedAt"> {
-  _id: string;
-  likes: string[];
-  featureIds: string[];
-  previewUrl?: string;
-  theme?: InvitationTheme;
-  isLiked: boolean;
-  discountedPrice: number;
-  createdAt: string;
-  updatedAt: string;
-  deletedAt: string | null;
 }
 
 const productSchema = new Schema<IProduct>(

--- a/src/server/services/coupleInfo.service.ts
+++ b/src/server/services/coupleInfo.service.ts
@@ -1,11 +1,18 @@
 import "server-only";
-import type { ICoupleInfo } from "@/server/models";
+import type { CoupleInfoDB } from "@/server/models";
 import { CoupleInfoModel } from "@/server/models";
 import type { CoupleInfoSchemaDto } from "@/shared/schemas";
 import { dbConnect } from "@/server/lib/mongodb";
+import type { ICoupleInfo } from "@/shared/types";
 import { AppError } from "@/shared/types";
 
 import mongoose from "mongoose";
+
+const toCoupleInfo = (coupleInfo: CoupleInfoDB): ICoupleInfo => ({
+  ...coupleInfo,
+  _id: coupleInfo._id.toString(),
+  userId: coupleInfo.userId.toString(),
+});
 
 export const createCoupleInfoService = async (
   data: CoupleInfoSchemaDto & { userId: string },
@@ -37,7 +44,7 @@ export const createCoupleInfoService = async (
     },
   );
 
-  return newCoupleInfo.toJSON();
+  return toCoupleInfo(newCoupleInfo.toJSON());
 };
 
 export const getCoupleInfoById = async (
@@ -53,7 +60,7 @@ export const getCoupleInfoById = async (
     new mongoose.Types.ObjectId(coupleInfoId),
   ).lean();
 
-  return coupleInfo;
+  return coupleInfo ? toCoupleInfo(coupleInfo) : null;
 };
 
 export const updateCoupleInfoService = async (

--- a/src/server/services/payment.service.ts
+++ b/src/server/services/payment.service.ts
@@ -2,10 +2,9 @@ import "server-only";
 import mongoose from "mongoose";
 import * as PortOne from "@portone/server-sdk";
 import type {
-  PayStatus,
-  PayMethod,
   PaymentMethodDetail,
   IPayment} from "@/server/models";
+import type { PayMethod, PayStatus } from "@/shared/types";
 import {
   PaymentModel,
   OrderModel,

--- a/src/server/services/premiumFeature.service.ts
+++ b/src/server/services/premiumFeature.service.ts
@@ -2,20 +2,10 @@ import "server-only";
 import type { IFeature } from "@/server/models";
 import { FeatureModel } from "@/server/models";
 import type { PremiumFeatureDto } from "@/shared/schemas";
+import type { PremiumFeature } from "@/shared/types";
 import { dbConnect } from "@/server/lib/mongodb";
 
 import mongoose from "mongoose";
-// FeatureJSON을 재사용
-export type PremiumFeature = {
-  _id: string;
-  code: string;
-  label: string;
-  description: string;
-  additionalPrice: number;
-  isActive: boolean;
-  createdAt: string;
-};
-
 // Mapper 함수: DB 결과를 PremiumFeature로 변환
 const mapToPremiumFeature = (doc: IFeature): PremiumFeature => ({
   _id: String(doc._id),

--- a/src/server/services/product.service.ts
+++ b/src/server/services/product.service.ts
@@ -1,17 +1,15 @@
 import "server-only";
-import type { ProductJSON, ProductDB, IProduct } from "@/server/models";
+import type { ProductDB, IProduct } from "@/server/models";
 import { ProductModel, InvitationProductModel } from "@/server/models";
 import type { ProductDto } from "@/shared/schemas";
 import { dbConnect } from "@/server/lib/mongodb";
 import { calculatePrice, escapeRegExp, findProductCategoriesByTerm, findSubCategoriesByTerm } from "@/shared/utils";
+import type { ProductJSON } from "@/shared/types";
 import { AppError } from "@/shared/types";
 import type { InvitationTheme} from "@/shared/constants";
 import { POPULAR_PRODUCTS_LIMIT } from "@/shared/constants";
 import type { Model, Types } from "mongoose";
 import mongoose from "mongoose";
-
-// Product 타입을 export (다른 파일에서 사용)
-export type Product = ProductJSON;
 
 type LeanProduct = ProductDB & {
   _id: Types.ObjectId;

--- a/src/shared/types/couple-info.ts
+++ b/src/shared/types/couple-info.ts
@@ -1,0 +1,33 @@
+interface Person {
+  name: string;
+  phone: string;
+}
+
+interface Parent extends Person {
+  bankName?: string;
+  accountNumber?: string;
+}
+
+interface CoupleSide extends Person {
+  bankName?: string;
+  accountNumber?: string;
+  father?: Parent;
+  mother?: Parent;
+}
+
+export interface ICoupleInfo {
+  _id: string;
+  userId: string;
+  groom: CoupleSide;
+  bride: CoupleSide;
+  weddingDate: Date;
+  venue: string;
+  address: string;
+  addressDetail: string;
+  subwayStation?: string;
+  guestbookEnabled: boolean;
+  thumbnailImages: string[];
+  galleryImages: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,6 +1,9 @@
 export type * from "./alert";
 export type * from "./announcement";
 export type * from "./checkout";
+export type * from "./couple-info";
 export * from "./error";
 export type * from "./field";
 export type * from "./image";
+export type * from "./payment";
+export type * from "./product";

--- a/src/shared/types/payment.ts
+++ b/src/shared/types/payment.ts
@@ -1,0 +1,11 @@
+import type { PAY_METHOD } from "@/shared/constants";
+
+export type PayMethod = (typeof PAY_METHOD)[number];
+
+export type PayStatus =
+  | "PENDING"
+  | "PAID"
+  | "FAILED"
+  | "CANCELLED"
+  | "PARTIAL_CANCELLED"
+  | "REFUNDED";

--- a/src/shared/types/product.ts
+++ b/src/shared/types/product.ts
@@ -1,0 +1,52 @@
+import type {
+  InvitationTheme,
+  ProductCategory,
+  SubCategory,
+} from "@/shared/constants";
+
+export type ProductStatus = "active" | "inactive" | "soldOut" | "deleted";
+
+export interface ProductJSON {
+  _id: string;
+  authorId: string;
+  title: string;
+  description: string;
+  thumbnail: string;
+  price: number;
+  category: ProductCategory;
+  subCategory: SubCategory;
+  isPremium: boolean;
+  featureIds: string[];
+  isFeatured: boolean;
+  priority: number;
+  likes: string[];
+  views: number;
+  salesCount: number;
+  discount: {
+    discountType: "rate" | "amount";
+    value: number;
+  };
+  status: ProductStatus;
+  images: string[];
+  minQuantity: number;
+  maxQuantity: number;
+  previewUrl?: string;
+  theme?: InvitationTheme;
+  isLiked: boolean;
+  discountedPrice: number;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+export type Product = ProductJSON;
+
+export interface PremiumFeature {
+  _id: string;
+  code: string;
+  label: string;
+  description: string;
+  additionalPrice: number;
+  isActive: boolean;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

- `Product`, `PremiumFeature`, `PayStatus`, `PayMethod`, `ICoupleInfo`, `ProductJSON`을 `src/shared/types`로 옮기고 기존 69개 타입 참조를 공유 계약으로 전환했습니다.
- Mongoose 모델은 공유 직렬화 타입을 기반으로 DB 전용 ObjectId 타입을 구현하며, couple info service 경계에서 ObjectId를 문자열로 변환합니다.
- client에서 `server/services` 및 `server/models`를 직접 참조하지 못하도록 ESLint zone 두 개를 활성화했습니다.

## Test plan

- `npm run lint -- --quiet` — 통과
- `npm run typecheck` — 통과
- `npm run build` — 통과
- 전체 테스트 — Not run: 사용자 요청에 따라 PR CI에서 확인