### PR TITLE
refactor: slim server actions

### DIFF
--- a/docs/proposals/directory-restructure.md
+++ b/docs/proposals/directory-restructure.md
@@ -439,6 +439,7 @@ HTTP status·응답 형태를 여기서 정하지 않는다 — `AppError`를 th
 | 5. UI층 통합 | 완료 | `client/**`와 `app/**/_hooks`→`ui/` | components/hooks/stores 경계가 적용되고 UI가 models/services/db를 직접 import하지 않는다 |
 | 6. 문서·규칙 동기화 | 완료 | AGENTS.md와 architecture/convention/validation 문서 경로 갱신 | 삭제된 경로 참조가 없고 실제 디렉토리와 일치한다 |
 | 7. 최종 통합 검증 | 완료 | 정적 검증·잔여 import 조사 | lint·tsc·build가 통과하고 기존 최상위 구조의 import가 0건이다 |
+| 7.5. Actions 완전 슬림화 | 완료 | 인증·외부 Adapter·업무 흐름 조합을 services로 이동 | action은 파싱·응답·캐시 갱신만 담당하고 models/db/adapters 직접 import가 0건이다 |
 | 8. 테스트 체계 전면 개선 | 승인 대기 | 테스트 분류·배치·Vitest project·공용 인프라 재설계 | 별도 승인 후 범위와 완료 조건을 확정한다 |
 
 Phase 1~7은 각 Phase에서 `git diff --check`, 삭제 경로 import 검색, lint·tsc·build를 통과한 뒤에만 병합한다. 테스트 명령은 실행하지 않으며 Phase 8 승인 전까지 테스트 인프라를 변경하지 않는다.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,7 @@ const eslintConfig = [...nextCoreWebVitals, ...nextTypescript, {
         { target: "./src/ui", from: "./src/db", message: "UI는 DB를 직접 못 만진다" },
         { target: "./src/actions", from: "./src/models", message: "action은 model을 직접 못 만진다" },
         { target: "./src/actions", from: "./src/db", message: "action은 DB를 직접 못 만진다" },
+        { target: "./src/actions", from: "./src/adapters", message: "action은 adapter를 직접 못 만진다" },
         { target: "./src/services", from: "./src/actions", message: "서비스는 action을 모른다" },
       ],
     }],

--- a/src/actions/AGENTS.md
+++ b/src/actions/AGENTS.md
@@ -23,6 +23,7 @@ src/actions/
   - 서비스 레이어가 던진 `AppError`를 액션이 다시 throw해서 `boundary.ts`의 `actionError`가 캐치·번역(`{ success:false, error }`)하는 것도 이 규칙 위반 아님 — 액션 "자신의" 검증 실패가 아니라 더 아래 레이어에서 이미 난 예외를 리턴값으로 옮기는 것뿐이다. 상세 규칙은 `docs/architecture/error-handling.md` §채널 A 참고.
 - 클라이언트가 넘긴 값을 소유권 판단 없이 그대로 DB 조회/수정 조건으로 쓰지 않는다 — 리소스 참조(ID)와 변경 내용만 클라이언트에서 받고, 소유자/권한은 세션에서 다시 조회해 대조한다. zod 등 스키마 검증은 값의 "형태"만 보장할 뿐 소유권을 보장하지 않는다.
 - DB 레코드를 그대로 반환값으로 넘기지 않는다 — Server Action의 리턴값은 클라이언트로 직렬화되므로, UI가 실제로 쓰는 필드만 추려 반환한다.
+- `models/`, `db/`, `adapters/`를 직접 import하지 않는다. 인증·외부 SDK·보상 로직과 업무 흐름 조합은 `services/`의 유스케이스 함수가 담당한다.
 - mutation 이후 관련 캐시를 갱신하지 않고 끝내지 않는다 — Server Action 안에서는 즉시 반영(read-your-own-writes)이 필요하면 `updateTag`를, 오리진이 Route Handler 등 Server Action 바깥이면 `revalidateTag`/`revalidatePath`를 쓴다(`updateTag`는 Server Action 밖에서 호출하면 에러가 던져진다).
 - Client Component에서 직접 호출할 Server Action을 컴포넌트 파일 안에 인라인으로 정의하지 않는다 — Client Component는 `"use server"`가 선언된 별도 파일의 export만 import해 호출할 수 있다(인라인 함수 레벨 `"use server"`는 Server Component 전용).
 - `useActionState`로 연결되는 액션의 인자 순서를 `(prevState, formData)` 밖으로 바꾸지 않는다 — 이 훅의 계약이 이 순서를 요구한다.

--- a/src/actions/clearUserEmailCookie.ts
+++ b/src/actions/clearUserEmailCookie.ts
@@ -1,12 +1,12 @@
 "use server";
 
-import { deleteCookie } from "@/adapters/cookies";
+import { clearUserEmailCookieService } from "@/services";
 import { actionError } from "@/boundary";
 import type { APIResponse } from "@/core/domain";
 
 export const clearUserEmailCookie = async (): Promise<APIResponse<null>> => {
   try {
-    await deleteCookie("userEmail");
+    await clearUserEmailCookieService();
     return { success: true, data: null };
   } catch (e) {
     return actionError(e);

--- a/src/actions/completePayment.ts
+++ b/src/actions/completePayment.ts
@@ -2,8 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import type { APIResponse} from "@/core/domain";
-import { AppError } from "@/core/domain";
-import { syncPayment, requireAuth } from "@/services";
+import { completePaymentService } from "@/services";
 import type { PayStatus } from "@/core/domain";
 import { actionError } from "@/boundary";
 import { routes } from "@/core/domain";
@@ -12,21 +11,11 @@ export const completePayment = async (
   paymentId: string,
 ): Promise<APIResponse<{ status: PayStatus }>> => {
   try {
-    await requireAuth();
-
-    if (typeof paymentId !== "string" || !paymentId) {
-      throw new AppError("VALIDATION", "올바르지 않은 요청입니다.");
-    }
-
-    const payment = await syncPayment(paymentId);
-
-    if (!payment) {
-      throw new AppError("INTERNAL", "결제 동기화에 실패했습니다.");
-    }
+    const status = await completePaymentService(paymentId);
 
     revalidatePath(routes.myOrders.root);
 
-    return { success: true, data: { status: payment.status } };
+    return { success: true, data: { status } };
   } catch (e) {
     return actionError(e);
   }

--- a/src/actions/createCoupleInfo.ts
+++ b/src/actions/createCoupleInfo.ts
@@ -1,12 +1,7 @@
 "use server";
 
 import type { APIResponse } from "@/core/domain";
-import {
-  requireAuth,
-  createCoupleInfoService,
-  isValidSubwayStationName,
-  attachCoupleInfoToOrder,
-} from "@/services";
+import { createCoupleInfoWorkflow } from "@/services";
 import { actionError } from "@/boundary";
 import { validateAndFlatten } from "@/core/utils";
 import { coupleInfoSchema } from "@/core/schemas";
@@ -74,57 +69,15 @@ export const createCoupleInfo = async (
     };
   }
 
-  if (
-    parsed.data.subwayStation &&
-    !(await isValidSubwayStationName(parsed.data.subwayStation))
-  ) {
-    return {
-      success: false,
-      error: {
-        category: "VALIDATION",
-        message: "입력값을 확인해주세요",
-        fieldErrors: { subwayStation: ["존재하지 않는 지하철역입니다."] },
-      },
-    };
-  }
-
   try {
-    const { userId } = await requireAuth();
-
-    const coupleInfo = await createCoupleInfoService({
-      userId,
-      groom: parsed.data.groom,
-      bride: parsed.data.bride,
-      weddingDate: parsed.data.weddingDate,
-      weddingTime: parsed.data.weddingTime,
-      venue: parsed.data.venue,
-      address: parsed.data.address,
-      addressDetail: parsed.data.addressDetail,
-      subwayStation: parsed.data.subwayStation,
-      guestbookEnabled: parsed.data.guestbookEnabled,
-      thumbnailImages: parsed.data.thumbnailImages,
-      galleryImages: parsed.data.galleryImages,
-    });
-
-    if (!coupleInfo) {
-      return {
-        success: false,
-        error: { category: "INTERNAL", message: "커플 정보 등록에 실패하였습니다." },
-      };
-    }
-
-    // 결제 이후 my-orders 흐름(orderId 전달)에서는 생성한 커플 정보를 해당
-    // 주문에 연결한다 — orderId가 없으면(기존 흐름) 연결을 건너뛴다.
     const orderId = formData.get("orderId") as string | null;
-    if (orderId) {
-      await attachCoupleInfoToOrder(orderId, coupleInfo._id.toString(), userId);
-    }
+    const coupleInfoId = await createCoupleInfoWorkflow(parsed.data, orderId ?? undefined);
 
     return {
       success: true,
       data: {
         message: "커플 정보가 성공적으로 등록되었습니다.",
-        _id: coupleInfo._id.toString(),
+        _id: coupleInfoId,
       },
     };
   } catch (e) {

--- a/src/actions/createGuestbook.ts
+++ b/src/actions/createGuestbook.ts
@@ -1,10 +1,8 @@
 "use server";
 
 import type { APIResponse } from "@/core/domain";
-import { hashPassword } from "@/adapters/bcrypt";
-
 import { GuestbookSchema } from "@/core/schemas";
-import { createGuestbookService } from "@/services";
+import { createGuestbookWithPasswordService } from "@/services";
 import { actionError } from "@/boundary";
 import { validateAndFlatten } from "@/core/utils";
 import { routes } from "@/core/domain";
@@ -31,10 +29,7 @@ export const createGuestbook = async (
   }
 
   try {
-    const hashedPassword = await hashPassword(parsed.data.password);
-    await createGuestbookService({
-      data: { ...parsed.data, password: hashedPassword },
-    });
+    await createGuestbookWithPasswordService(parsed.data);
 
     revalidatePath(routes.preview.detail(parsed.data.coupleInfoId));
 

--- a/src/actions/createOrder.ts
+++ b/src/actions/createOrder.ts
@@ -3,8 +3,7 @@
 import type { APIResponse } from "@/core/domain";
 import { redirect } from "next/navigation";
 
-import { getCookie } from "@/adapters/cookies";
-import { requireAuth, createOrderService } from "@/services";
+import { getAuth, createOrderForCurrentUserService } from "@/services";
 import { actionError } from "@/boundary";
 
 import { validateAndFlatten } from "@/core/utils";
@@ -29,8 +28,7 @@ export async function createOrder(
   formData: FormData,
 ): Promise<APIResponse<CreateOrderResult>> {
   // 로그인 안 된 상태면 로그인 페이지로(리다이렉트는 try/catch 밖에서)
-  const cookie = await getCookie("token");
-  if (!cookie?.value) {
+  if (!(await getAuth())) {
     redirect(routes.login);
   }
 
@@ -67,12 +65,7 @@ export async function createOrder(
   }
 
   try {
-    const { userId } = await requireAuth();
-
-    const order = await createOrderService({
-      ...parsed.data,
-      userId,
-    });
+    const order = await createOrderForCurrentUserService(parsed.data);
 
     return {
       success: true,

--- a/src/actions/createPremiumFeature.ts
+++ b/src/actions/createPremiumFeature.ts
@@ -1,7 +1,7 @@
 "use server";
 import type { APIResponse } from "@/core/domain";
 import { premiumFeatureSchema } from "@/core/schemas";
-import { createPremiumFeatureService, requireAuth } from "@/services";
+import { createPremiumFeatureAsAdminService } from "@/services";
 import { actionError } from "@/boundary";
 import { validateAndFlatten } from "@/core/utils";
 import { routes } from "@/core/domain";
@@ -27,15 +27,7 @@ export const createPremiumFeature = async (
   }
 
   try {
-    const { role } = await requireAuth();
-    if (role !== "ADMIN") {
-      return {
-        success: false,
-        error: { category: "FORBIDDEN", message: "관리자 권한이 필요합니다." },
-      };
-    }
-
-    await createPremiumFeatureService(parsed.data);
+    await createPremiumFeatureAsAdminService(parsed.data);
     revalidatePath(routes.admin.premiumFeatures.root);
     return { success: true, data: { message: "프리미엄 기능을 등록하였습니다." } };
   } catch (e) {

--- a/src/actions/createProduct.ts
+++ b/src/actions/createProduct.ts
@@ -1,9 +1,7 @@
 "use server";
 
 import type { APIResponse } from "@/core/domain";
-import { deleteProductAsset } from "@/adapters/cloudinary/cleanup";
-import { uploadProductImage } from "@/adapters/cloudinary/upload-from-url";
-import { requireAuth, createProductService } from "@/services";
+import { createProductWorkflow } from "@/services";
 import { actionError } from "@/boundary";
 import { productSchema } from "@/core/schemas";
 import { routes } from "@/core/domain";
@@ -20,8 +18,6 @@ export const createProduct = async (
   _prev: unknown,
   formData: FormData,
 ): Promise<APIResponse<{ message: string }>> => {
-  const uploadedPublicIds: string[] = [];
-  const recordUpload = ({ publicId }: { publicId: string }) => uploadedPublicIds.push(publicId);
   const thumbnailFile = formData.get("thumbnail") as File;
   const previewFile = formData.get("previewUrl") as File;
 
@@ -60,34 +56,9 @@ export const createProduct = async (
   }
 
   try {
-    const { role, userId } = await requireAuth();
-    if (role !== "ADMIN") {
-      return {
-        success: false,
-        error: { category: "FORBIDDEN", message: "관리자 권한이 필요합니다." },
-      };
-    }
-
-    const thumbnailUrl = await uploadProductImage(thumbnailFile, "thumbnail", recordUpload);
-
-    let previewUrl: string | undefined;
-    if (previewFile && previewFile.size > 0) {
-      previewUrl = await uploadProductImage(previewFile, "preview", recordUpload);
-    }
-
-    const uploadedImageUrls = (
-      await Promise.all(
-        parsed.data.images.newFiles.map((file) => uploadProductImage(file, "images", recordUpload)),
-      )
-    ).filter((url): url is string => Boolean(url));
-    const images = [...parsed.data.images.existing, ...uploadedImageUrls];
-
-    await createProductService({
+    await createProductWorkflow({
       ...parsed.data,
-      images,
-      authorId: userId,
-      thumbnail: thumbnailUrl,
-      previewUrl,
+      previewFile,
     });
 
     revalidatePath(routes.admin.products.root);
@@ -98,7 +69,6 @@ export const createProduct = async (
       data: { message: "상품이 성공적으로 등록되었습니다." },
     };
   } catch (e) {
-    await Promise.allSettled(uploadedPublicIds.map((publicId) => deleteProductAsset(publicId)));
     return actionError(e);
   }
 };

--- a/src/actions/deleteGuestbook.ts
+++ b/src/actions/deleteGuestbook.ts
@@ -1,10 +1,9 @@
 "use server";
 
 import type { APIResponse } from "@/core/domain";
-import { comparePasswords } from "@/adapters/bcrypt";
 import { validateAndFlatten } from "@/core/utils";
 import { GuestbookSchema } from "@/core/schemas";
-import { getPrivateGuestbookService, deleteGuestbookService } from "@/services";
+import { deleteGuestbookWithPasswordService } from "@/services";
 import { actionError } from "@/boundary";
 import { routes } from "@/core/domain";
 import * as z from "zod";
@@ -39,33 +38,7 @@ export const deleteGuestbook = async (
   }
 
   try {
-    const guestbook = await getPrivateGuestbookService(parsed.data.guestbookId);
-    if (!guestbook) {
-      return {
-        success: false,
-        error: { category: "NOT_FOUND", message: "해당 게시글을 찾을 수 없습니다." },
-      };
-    }
-
-    const isPasswordValid = await comparePasswords(
-      parsed.data.password,
-      guestbook.password,
-    );
-    if (!isPasswordValid) {
-      return {
-        success: false,
-        error: { category: "UNAUTHENTICATED", message: "비밀번호가 일치하지 않습니다." },
-      };
-    }
-
-    const deleteResult = await deleteGuestbookService(parsed.data.guestbookId);
-
-    if (!deleteResult.acknowledged || deleteResult.deletedCount === 0) {
-      return {
-        success: false,
-        error: { category: "INTERNAL", message: "게시글 삭제에 실패했습니다." },
-      };
-    }
+    await deleteGuestbookWithPasswordService(parsed.data);
 
     revalidatePath(routes.preview.detail(parsed.data.coupleInfoId));
 

--- a/src/actions/deleteProduct.ts
+++ b/src/actions/deleteProduct.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import type { APIResponse } from "@/core/domain";
-import { requireAuth, deleteProductService } from "@/services";
+import { deleteProductAsAdminService } from "@/services";
 import { actionError } from "@/boundary";
 import { routes } from "@/core/domain";
 
@@ -11,15 +11,7 @@ export const deleteProduct = async (
   productId: string,
 ): Promise<APIResponse<{ message: string }>> => {
   try {
-    const { role } = await requireAuth();
-    if (role !== "ADMIN") {
-      return {
-        success: false,
-        error: { category: "FORBIDDEN", message: "관리자 권한이 필요합니다." },
-      };
-    }
-
-    await deleteProductService(productId);
+    await deleteProductAsAdminService(productId);
 
     revalidatePath(routes.admin.products.root);
     revalidatePath(routes.products.root);

--- a/src/actions/loginUser.ts
+++ b/src/actions/loginUser.ts
@@ -4,11 +4,8 @@ import type { APIResponse } from "@/core/domain";
 
 import { validateAndFlatten } from "@/core/utils";
 import { LoginSchema } from "@/core/schemas";
-import { encrypt } from "@/adapters/jose";
-import { setCookie } from "@/adapters/cookies";
-import { getUser } from "@/services";
+import { loginUserService } from "@/services";
 import type { UserRole } from "@/core/domain";
-import { comparePasswords } from "@/adapters/bcrypt";
 import { actionError } from "@/boundary";
 
 export const loginUser = async (
@@ -41,40 +38,8 @@ export const loginUser = async (
     };
   }
 
-  const { email, password, remember } = parsed.data;
-
-  // 이메일를 바탕으로 사용자 조회
-  const user = await getUser({ email });
-
-  if (!user) {
-    return {
-      success: false,
-      error: { category: "UNAUTHENTICATED", message: "이메일 또는 비밀번호가 일치하지 않습니다." },
-    };
-  }
-
-  const isPasswordValid = await comparePasswords(password, user.password);
-
-  if (!isPasswordValid) {
-    return {
-      success: false,
-      error: { category: "UNAUTHENTICATED", message: "이메일 또는 비밀번호가 일치하지 않습니다." },
-    };
-  }
-
   try {
-    const refreshJWT = await encrypt({
-      id: user._id.toString(),
-      role: user.role,
-      type: "REFRESH",
-    });
-
-    await setCookie({ name: "token", value: refreshJWT, remember });
-
-    return {
-      success: true,
-      data: { role: user.role, email: user.email, userId: user._id.toString() },
-    };
+    return { success: true, data: await loginUserService(parsed.data) };
   } catch (e) {
     return actionError(e);
   }

--- a/src/actions/requestPasswordReset.ts
+++ b/src/actions/requestPasswordReset.ts
@@ -1,18 +1,10 @@
 "use server";
 
-import { encrypt } from "@/adapters/jose";
 import { validateAndFlatten } from "@/core/utils";
-import { sendEmail } from "@/adapters/nodemailer";
 import { emailSchema } from "@/core/schemas";
 import type { APIResponse } from "@/core/domain";
-import { checkEmailDuplicate } from "@/services";
+import { requestPasswordResetService } from "@/services";
 import { actionError } from "@/boundary";
-import { routes } from "@/core/domain";
-const createChangePWDomain = (token: string): string => {
-  return process.env.NODE_ENV === "development"
-    ? `http://localhost:3000${routes.changePw}?t=${encodeURIComponent(token)}`
-    : "";
-};
 
 export const requestPasswordReset = async (
   prev: unknown,
@@ -39,23 +31,8 @@ export const requestPasswordReset = async (
   }
   const { email } = parsed.data;
 
-  const isEmail = await checkEmailDuplicate(email);
-
-  if (!isEmail) {
-    return {
-      success: false,
-      error: { category: "VALIDATION", message: "등록되지 않은 이메일입니다." },
-    };
-  }
-
   try {
-    // entry token 발행 && createDomatin
-    const entryToken = await encrypt({ id: email, type: "ENTRY" });
-
-    // 도메인을 생성
-    const path = createChangePWDomain(entryToken);
-
-    await sendEmail({ email, path });
+    await requestPasswordResetService(email);
 
     return {
       success: true,

--- a/src/actions/signupUser.ts
+++ b/src/actions/signupUser.ts
@@ -2,11 +2,9 @@
 
 import type { APIResponse } from "@/core/domain";
 
-import { hashPassword } from "@/adapters/bcrypt";
-
 import { validateAndFlatten } from "@/core/utils";
 import { RegisterSchema } from "@/core/schemas";
-import { checkEmailDuplicate, createUser } from "@/services";
+import { signupUserService } from "@/services";
 import { actionError } from "@/boundary";
 export async function signupUser(
   prev: unknown,
@@ -33,27 +31,8 @@ export async function signupUser(
     };
   }
 
-  const { email, name, phone, password } = parsed.data;
-
-  const isEmail = await checkEmailDuplicate(email);
-
-  if (isEmail) {
-    return {
-      success: false,
-      // 409 Conflict는 taxonomy(src/AGENTS.md)에 없음 — 입력값(이메일) 자체의 문제라 VALIDATION으로 분류(400)
-      error: { category: "VALIDATION", message: "이미 존재하는 이메일 입니다." },
-    };
-  }
-
   try {
-    const hashedPassword = await hashPassword(password);
-
-    await createUser({
-      password: hashedPassword,
-      email,
-      name,
-      phone,
-    });
+    await signupUserService(parsed.data);
 
     return {
       success: true,

--- a/src/actions/toggleProductLike.ts
+++ b/src/actions/toggleProductLike.ts
@@ -2,8 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import type { APIResponse} from "@/core/domain";
-import { AppError } from "@/core/domain";
-import { requireAuth, updateProductLikeService } from "@/services";
+import { toggleProductLikeForCurrentUserService } from "@/services";
 import { actionError } from "@/boundary";
 import { routes } from "@/core/domain";
 
@@ -11,15 +10,7 @@ export const toggleProductLike = async (
   productId: string,
 ): Promise<APIResponse<{ message: string }>> => {
   try {
-    const { userId } = await requireAuth();
-
-    const updated = await updateProductLikeService(productId, userId);
-    if (!updated) {
-      throw new AppError(
-        "NOT_FOUND",
-        "상품을 찾을 수 없거나 좋아요 업데이트에 실패했습니다.",
-      );
-    }
+    await toggleProductLikeForCurrentUserService(productId);
 
     revalidatePath(routes.products.root);
 

--- a/src/actions/updateCoupleInfo.ts
+++ b/src/actions/updateCoupleInfo.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import type { APIResponse } from "@/core/domain";
-import { requireAuth, updateCoupleInfoService, isValidSubwayStationName } from "@/services";
+import { updateCoupleInfoWorkflow } from "@/services";
 import { actionError } from "@/boundary";
 import { validateAndFlatten } from "@/core/utils";
 import { coupleInfoSchema } from "@/core/schemas";
@@ -75,31 +75,8 @@ export const updateCoupleInfo = async (
     };
   }
 
-  if (
-    parsed.data.subwayStation &&
-    !(await isValidSubwayStationName(parsed.data.subwayStation))
-  ) {
-    return {
-      success: false,
-      error: {
-        category: "VALIDATION",
-        message: "입력값을 확인해주세요",
-        fieldErrors: { subwayStation: ["존재하지 않는 지하철역입니다."] },
-      },
-    };
-  }
-
   try {
-    const { userId } = await requireAuth();
-
-    const updated = await updateCoupleInfoService(coupleInfoId, userId, parsed.data);
-
-    if (!updated) {
-      return {
-        success: false,
-        error: { category: "INTERNAL", message: "커플 정보 업데이트에 실패하였습니다." },
-      };
-    }
+    await updateCoupleInfoWorkflow(coupleInfoId, parsed.data);
 
     return {
       success: true,

--- a/src/actions/updatePremiumFeature.ts
+++ b/src/actions/updatePremiumFeature.ts
@@ -3,7 +3,7 @@
 import type { APIResponse } from "@/core/domain";
 import { validateAndFlatten } from "@/core/utils";
 import { premiumFeatureSchema } from "@/core/schemas";
-import { updatePremiumFeatureService, requireAuth } from "@/services";
+import { updatePremiumFeatureAsAdminService } from "@/services";
 import { actionError } from "@/boundary";
 import { routes } from "@/core/domain";
 import { revalidatePath } from "next/cache";
@@ -38,15 +38,7 @@ export const updatePremiumFeature = async (
   }
 
   try {
-    const { role } = await requireAuth();
-    if (role !== "ADMIN") {
-      return {
-        success: false,
-        error: { category: "FORBIDDEN", message: "관리자 권한이 필요합니다." },
-      };
-    }
-
-    await updatePremiumFeatureService(featureId, parsed.data);
+    await updatePremiumFeatureAsAdminService(featureId, parsed.data);
 
     revalidatePath(routes.admin.premiumFeatures.root);
 

--- a/src/actions/updateProduct.ts
+++ b/src/actions/updateProduct.ts
@@ -1,15 +1,12 @@
 "use server";
 
 import type { APIResponse } from "@/core/domain";
-import { deleteProductAsset } from "@/adapters/cloudinary/cleanup";
-import { uploadProductImage } from "@/adapters/cloudinary/upload-from-url";
-import { requireAuth, updateProductService } from "@/services";
+import { updateProductWorkflow } from "@/services";
 import { actionError } from "@/boundary";
 import { validateAndFlatten } from "@/core/utils";
 
 import { productSchema } from "@/core/schemas";
 import { routes } from "@/core/domain";
-import { AppError } from "@/core/domain";
 
 import { revalidatePath } from "next/cache";
 
@@ -23,8 +20,6 @@ export const updateProduct = async (
   prev: unknown,
   formData: FormData,
 ): Promise<APIResponse<{ message: string }>> => {
-  const uploadedPublicIds: string[] = [];
-  const recordUpload = ({ publicId }: { publicId: string }) => uploadedPublicIds.push(publicId);
   const thumbnailFile = formData.get("thumbnail") as File;
   const previewFile = formData.get("previewUrl") as File;
 
@@ -63,46 +58,11 @@ export const updateProduct = async (
   }
 
   try {
-    const { role } = await requireAuth();
-    if (role !== "ADMIN") {
-      return {
-        success: false,
-        error: { category: "FORBIDDEN", message: "관리자 권한이 필요합니다." },
-      };
-    }
-
-    let thumbnailUrl = formData.get("currentThumbnail") as string;
-    if (thumbnailFile && thumbnailFile.size > 0) {
-      thumbnailUrl = await uploadProductImage(thumbnailFile, "thumbnail", recordUpload);
-    }
-
-    let previewUrl: string | undefined = formData.get(
-      "currentPreviewUrl",
-    ) as string;
-    if (previewFile && previewFile.size > 0) {
-      previewUrl = await uploadProductImage(previewFile, "preview", recordUpload);
-    }
-
-    const uploadedImageUrls = (
-      await Promise.all(
-        parsed.data.images.newFiles.map((file) => uploadProductImage(file, "images", recordUpload)),
-      )
-    ).filter((url): url is string => Boolean(url));
-    const images = [...parsed.data.images.existing, ...uploadedImageUrls];
-
-    const updated = await updateProductService(productId, {
+    await updateProductWorkflow(productId, {
       ...parsed.data,
-      images,
-      thumbnail: thumbnailUrl,
-      previewUrl,
+      previewFile,
+      currentPreviewUrl: formData.get("currentPreviewUrl") as string,
     });
-
-    // REQ-7: discriminatorKey가 "category"라 category를 바꿔 요청하면 mongoose가
-    // 바뀐 category 기준 모델로 원래 문서를 찾다가 매칭 실패 → null을 리턴한다.
-    // 검사 없이 넘어가면 실패인데 success:true가 나가는 무증상 실패가 된다.
-    if (!updated) {
-      throw new AppError("NOT_FOUND", "상품을 찾을 수 없습니다.");
-    }
 
     revalidatePath(routes.admin.products.root);
     revalidatePath(routes.products.root);
@@ -113,7 +73,6 @@ export const updateProduct = async (
       data: { message: "상품이 성공적으로 수정되었습니다." },
     };
   } catch (e) {
-    await Promise.allSettled(uploadedPublicIds.map((publicId) => deleteProductAsset(publicId)));
     return actionError(e);
   }
 };

--- a/src/actions/updateProductStatus.ts
+++ b/src/actions/updateProductStatus.ts
@@ -2,7 +2,7 @@
 
 import type { APIResponse } from "@/core/domain";
 import type { ProductStatus } from "@/core/domain";
-import { requireAuth, updateProductService } from "@/services";
+import { updateProductStatusAsAdminService } from "@/services";
 import { actionError } from "@/boundary";
 import { routes } from "@/core/domain";
 
@@ -13,21 +13,11 @@ export const updateProductStatus = async (
   status: ProductStatus,
 ): Promise<APIResponse<{ message: string }>> => {
   try {
-    const { role } = await requireAuth();
-    if (role !== "ADMIN") {
-      return {
-        success: false,
-        error: { category: "FORBIDDEN", message: "관리자 권한이 필요합니다." },
-      };
-    }
-
-    const updated = await updateProductService(productId, { status });
+    const updated = await updateProductStatusAsAdminService(productId, status);
 
     revalidatePath(routes.admin.products.root);
     revalidatePath(routes.products.root);
-    if (updated) {
-      revalidatePath(routes.products.detail(updated.category, productId));
-    }
+    revalidatePath(routes.products.detail(updated.category, productId));
 
     return {
       success: true,

--- a/src/actions/updateUserPassword.ts
+++ b/src/actions/updateUserPassword.ts
@@ -3,10 +3,8 @@
 import { validateAndFlatten } from "@/core/utils";
 import { PWConfirmSchema } from "@/core/schemas";
 import type { APIResponse } from "@/core/domain";
-import { changePassword } from "@/services";
+import { resetUserPasswordService } from "@/services";
 import { actionError } from "@/boundary";
-import { decrypt } from "@/adapters/jose";
-import { deleteCookie } from "@/adapters/cookies";
 
 // 유저가 비밀번호를 기억하지 못할 때 로그인하지 않은 상태에서 이메일로 비밀번호 변경
 export const updateUserPassword = async (
@@ -32,33 +30,8 @@ export const updateUserPassword = async (
     };
   }
 
-  const { password, token } = parsed.data;
-
   try {
-    const { payload } = await decrypt({ token, type: "ENTRY" });
-
-    if (!payload.id) {
-      return {
-        success: false,
-        error: {
-          category: "UNAUTHENTICATED",
-          message:
-            "유효하지 않거나 만료된 토큰입니다. 비밀번호 재설정을 다시 시도해주세요.",
-        },
-      };
-    }
-
-    const userFound = await changePassword(payload.id, password);
-    if (!userFound) {
-      return {
-        success: false,
-        error: {
-          category: "NOT_FOUND",
-          message: "해당 계정을 찾을 수 없습니다. 이메일 주소를 확인해주세요.",
-        },
-      };
-    }
-    await deleteCookie("userEmail");
+    await resetUserPasswordService(parsed.data);
     return {
       success: true,
       data: { message: "비밀번호가 성공적으로 변경되었습니다." },

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -2,8 +2,9 @@ import "server-only";
 import type { UserRole } from "@/core/domain";
 import { UserModel } from "@/models";
 import { dbConnect } from "@/db";
-import { getCookie, deleteCookie } from "@/adapters/cookies";
-import { decrypt } from "@/adapters/jose";
+import { getCookie, deleteCookie, setCookie } from "@/adapters/cookies";
+import { decrypt, encrypt } from "@/adapters/jose";
+import { comparePasswords } from "@/adapters/bcrypt";
 import mongoose from "mongoose";
 import { AppError } from "@/core/domain";
 import type { AuthSession } from "@/core/schemas";
@@ -87,11 +88,50 @@ export async function requireAuth(): Promise<AuthSession> {
   return session;
 }
 
+export async function requireAdmin(): Promise<AuthSession> {
+  const session = await requireAuth();
+  if (session.role !== "ADMIN") {
+    throw new AppError("FORBIDDEN", "관리자 권한이 필요합니다.");
+  }
+  return session;
+}
+
 /**
  * 로그아웃 처리를 위해 서버의 인증 토큰 쿠키를 삭제합니다.
  */
 export async function logoutService() {
   await deleteCookie("token");
+}
+
+export async function clearUserEmailCookieService() {
+  await deleteCookie("userEmail");
+}
+
+export async function loginUserService({
+  email,
+  password,
+  remember,
+}: {
+  email: string;
+  password: string;
+  remember: boolean;
+}): Promise<AuthSession> {
+  const user = await getUser({ email });
+  if (!user || !(await comparePasswords(password, user.password))) {
+    throw new AppError(
+      "UNAUTHENTICATED",
+      "이메일 또는 비밀번호가 일치하지 않습니다.",
+    );
+  }
+
+  const refreshJWT = await encrypt({
+    id: user._id.toString(),
+    role: user.role,
+    type: "REFRESH",
+  });
+  await setCookie({ name: "token", value: refreshJWT, remember });
+
+  return { role: user.role, email: user.email, userId: user._id.toString() };
 }
 
 // page.tsx(Server Component render) 전용 라우팅 게이트 — requireAuth()(throw)와 달리

--- a/src/services/coupleInfo.ts
+++ b/src/services/coupleInfo.ts
@@ -6,6 +6,9 @@ import { dbConnect } from "@/db";
 import { AppError } from "@/core/domain";
 
 import mongoose from "mongoose";
+import { requireAuth } from "./auth";
+import { isValidSubwayStationName } from "./subway";
+import { attachCoupleInfoToOrder } from "./order";
 
 export const createCoupleInfoService = async (
   data: CoupleInfoSchemaDto & { userId: string },
@@ -110,3 +113,36 @@ export const updateCoupleInfoService = async (
 
   return !!updated;
 };
+
+const validateSubwayStation = async (subwayStation?: string): Promise<void> => {
+  if (subwayStation && !(await isValidSubwayStationName(subwayStation))) {
+    throw new AppError("VALIDATION", "존재하지 않는 지하철역입니다.", {
+      subwayStation: ["존재하지 않는 지하철역입니다."],
+    });
+  }
+};
+
+export async function createCoupleInfoWorkflow(
+  data: CoupleInfoSchemaDto,
+  orderId?: string,
+): Promise<string> {
+  await validateSubwayStation(data.subwayStation);
+  const { userId } = await requireAuth();
+  const coupleInfo = await createCoupleInfoService({ ...data, userId });
+  const coupleInfoId = coupleInfo._id.toString();
+  if (orderId) {
+    await attachCoupleInfoToOrder(orderId, coupleInfoId, userId);
+  }
+  return coupleInfoId;
+}
+
+export async function updateCoupleInfoWorkflow(
+  coupleInfoId: string,
+  data: CoupleInfoSchemaDto,
+): Promise<void> {
+  await validateSubwayStation(data.subwayStation);
+  const { userId } = await requireAuth();
+  if (!(await updateCoupleInfoService(coupleInfoId, userId, data))) {
+    throw new AppError("INTERNAL", "커플 정보 업데이트에 실패하였습니다.");
+  }
+}

--- a/src/services/guestbook.ts
+++ b/src/services/guestbook.ts
@@ -4,6 +4,7 @@ import { GuestbookModel } from "@/models";
 import type { GuestbookType } from "@/core/schemas";
 import { dbConnect } from "@/db";
 import { AppError } from "@/core/domain";
+import { comparePasswords, hashPassword } from "@/adapters/bcrypt";
 
 import mongoose from "mongoose";
 
@@ -80,3 +81,31 @@ export const deleteGuestbookService = async (
 
   return result;
 };
+
+export async function createGuestbookWithPasswordService(
+  data: GuestbookType,
+): Promise<void> {
+  await createGuestbookService({
+    data: { ...data, password: await hashPassword(data.password) },
+  });
+}
+
+export async function deleteGuestbookWithPasswordService({
+  guestbookId,
+  password,
+}: {
+  guestbookId: string;
+  password: string;
+}): Promise<void> {
+  const guestbook = await getPrivateGuestbookService(guestbookId);
+  if (!guestbook) {
+    throw new AppError("NOT_FOUND", "해당 게시글을 찾을 수 없습니다.");
+  }
+  if (!(await comparePasswords(password, guestbook.password))) {
+    throw new AppError("UNAUTHENTICATED", "비밀번호가 일치하지 않습니다.");
+  }
+  const result = await deleteGuestbookService(guestbookId);
+  if (!result.acknowledged || result.deletedCount === 0) {
+    throw new AppError("INTERNAL", "게시글 삭제에 실패했습니다.");
+  }
+}

--- a/src/services/order.ts
+++ b/src/services/order.ts
@@ -8,6 +8,7 @@ import { dbConnect } from "@/db";
 import { AppError } from "@/core/domain";
 import { COUPLE_INFO_DEADLINE_DAYS } from "@/core/domain";
 import { getProductQuantityBoundsService } from "./product";
+import { requireAuth } from "./auth";
 
 const assertObjectIdLike = (id: string, label: string): void => {
   if (!mongoose.isObjectIdOrHexString(id)) {
@@ -88,6 +89,13 @@ export const createOrderService = async (
 
   return order.toObject();
 };
+
+export async function createOrderForCurrentUserService(
+  data: CreateOrderDto,
+): Promise<IOrder> {
+  const { userId } = await requireAuth();
+  return createOrderService({ ...data, userId });
+}
 
 /**
  * 결제 완료된 주문에 couple-info를 연결한다(TODO.md "couple-info를 payment

--- a/src/services/payment.ts
+++ b/src/services/payment.ts
@@ -19,6 +19,7 @@ import {
 } from "./order";
 import { AppError } from "@/core/domain";
 import { dbConnect } from "@/db";
+import { requireAuth } from "./auth";
 
 // 환경 변수 확인
 const PORTONE_API_SECRET = process.env.PORTONE_API_SECRET;
@@ -538,3 +539,15 @@ export const cancelExpiredAwaitingCoupleInfoOrders = async (
     ),
   );
 };
+
+export async function completePaymentService(paymentId: string): Promise<PayStatus> {
+  await requireAuth();
+  if (!paymentId) {
+    throw new AppError("VALIDATION", "올바르지 않은 요청입니다.");
+  }
+  const payment = await syncPayment(paymentId);
+  if (!payment) {
+    throw new AppError("INTERNAL", "결제 동기화에 실패했습니다.");
+  }
+  return payment.status;
+}

--- a/src/services/premiumFeature.ts
+++ b/src/services/premiumFeature.ts
@@ -3,10 +3,12 @@ import type { IFeature } from "@/models";
 import { FeatureModel } from "@/models";
 import type { PremiumFeatureDto } from "@/core/schemas";
 import type { PremiumFeature } from "@/core/domain";
+import { AppError } from "@/core/domain";
 export type { PremiumFeature } from "@/core/domain";
 import { dbConnect } from "@/db";
 
 import mongoose from "mongoose";
+import { requireAdmin } from "./auth";
 // FeatureJSON을 재사용
 // Mapper 함수: DB 결과를 PremiumFeature로 변환
 const mapToPremiumFeature = (doc: IFeature): PremiumFeature => ({
@@ -61,3 +63,23 @@ export const updatePremiumFeatureService = async (
 
   return updatedFeature;
 };
+
+export async function createPremiumFeatureAsAdminService(
+  data: PremiumFeatureDto,
+): Promise<void> {
+  await requireAdmin();
+  await createPremiumFeatureService(data);
+}
+
+export async function updatePremiumFeatureAsAdminService(
+  id: string,
+  data: PremiumFeatureDto,
+): Promise<void> {
+  await requireAdmin();
+  if (!(await updatePremiumFeatureService(id, data))) {
+    throw new AppError(
+      "NOT_FOUND",
+      "프리미엄 기능을 찾을 수 없습니다.",
+    );
+  }
+}

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -9,9 +9,42 @@ import type { InvitationTheme} from "@/core/domain";
 import { POPULAR_PRODUCTS_LIMIT } from "@/core/domain";
 import type { Model, Types } from "mongoose";
 import mongoose from "mongoose";
+import { deleteProductAsset } from "@/adapters/cloudinary/cleanup";
+import { uploadProductImage } from "@/adapters/cloudinary/upload-from-url";
+import { requireAdmin, requireAuth } from "./auth";
 
 // Product 타입을 export (다른 파일에서 사용)
 export type Product = ProductJSON;
+
+type ProductUploadInput = ProductDto & {
+  previewFile?: File;
+  currentPreviewUrl?: string;
+};
+
+const uploadProductAssets = async (
+  data: ProductUploadInput,
+  onUploaded: ({ publicId }: { publicId: string }) => void,
+) => {
+  const thumbnail =
+    data.thumbnail instanceof File
+      ? await uploadProductImage(data.thumbnail, "thumbnail", onUploaded)
+      : data.thumbnail;
+  const previewUrl =
+    data.previewFile && data.previewFile.size > 0
+      ? await uploadProductImage(data.previewFile, "preview", onUploaded)
+      : data.currentPreviewUrl;
+  const uploadedImages = (
+    await Promise.all(
+      data.images.newFiles.map((file) => uploadProductImage(file, "images", onUploaded)),
+    )
+  ).filter((url): url is string => Boolean(url));
+
+  return {
+    thumbnail,
+    previewUrl,
+    images: [...data.images.existing, ...uploadedImages],
+  };
+};
 
 type LeanProduct = ProductDB & {
   _id: Types.ObjectId;
@@ -363,3 +396,73 @@ export const updateProductLikeService = async (
 
   return !!updated;
 };
+
+export async function createProductWorkflow(data: ProductUploadInput): Promise<void> {
+  const { userId } = await requireAdmin();
+  const uploadedPublicIds: string[] = [];
+  try {
+    const assets = await uploadProductAssets(data, ({ publicId }) => {
+      uploadedPublicIds.push(publicId);
+    });
+    await createProductService({
+      ...data,
+      ...assets,
+      authorId: userId,
+    });
+  } catch (error) {
+    await Promise.allSettled(uploadedPublicIds.map(deleteProductAsset));
+    throw error;
+  }
+}
+
+export async function updateProductWorkflow(
+  productId: string,
+  data: ProductUploadInput,
+): Promise<ProductJSON> {
+  await requireAdmin();
+  const uploadedPublicIds: string[] = [];
+  try {
+    const assets = await uploadProductAssets(data, ({ publicId }) => {
+      uploadedPublicIds.push(publicId);
+    });
+    const updated = await updateProductService(productId, {
+      ...data,
+      ...assets,
+    });
+    if (!updated) {
+      throw new AppError("NOT_FOUND", "상품을 찾을 수 없습니다.");
+    }
+    return updated;
+  } catch (error) {
+    await Promise.allSettled(uploadedPublicIds.map(deleteProductAsset));
+    throw error;
+  }
+}
+
+export async function deleteProductAsAdminService(productId: string): Promise<void> {
+  await requireAdmin();
+  if (!(await deleteProductService(productId))) {
+    throw new AppError("NOT_FOUND", "상품을 찾을 수 없습니다.");
+  }
+}
+
+export async function updateProductStatusAsAdminService(
+  productId: string,
+  status: ProductDto["status"],
+): Promise<ProductJSON> {
+  await requireAdmin();
+  const updated = await updateProductService(productId, { status });
+  if (!updated) {
+    throw new AppError("NOT_FOUND", "상품을 찾을 수 없습니다.");
+  }
+  return updated;
+}
+
+export async function toggleProductLikeForCurrentUserService(
+  productId: string,
+): Promise<void> {
+  const { userId } = await requireAuth();
+  if (!(await updateProductLikeService(productId, userId))) {
+    throw new AppError("NOT_FOUND", "상품을 찾을 수 없거나 좋아요 업데이트에 실패했습니다.");
+  }
+}

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -2,8 +2,12 @@ import "server-only";
 import { AppError } from "@/core/domain";
 import type { BaseUser, IUser } from "@/models";
 import { UserModel } from "@/models";
-import bcrypt from "bcryptjs";
 import { dbConnect } from "@/db";
+import { hashPassword } from "@/adapters/bcrypt";
+import { decrypt, encrypt } from "@/adapters/jose";
+import { deleteCookie } from "@/adapters/cookies";
+import { sendEmail } from "@/adapters/nodemailer";
+import { routes } from "@/core/domain";
 // 유저 생성
 export const createUser = async (user: BaseUser): Promise<IUser> => {
   await dbConnect();
@@ -48,7 +52,7 @@ export const changePassword = async (
   await dbConnect();
 
   // 새 비밀번호 해싱
-  const hashedNewPassword = await bcrypt.hash(newPassword, 12);
+  const hashedNewPassword = await hashPassword(newPassword);
 
   // 비밀번호 업데이트
   const userBeforeUpdate = await UserModel.findOneAndUpdate(
@@ -64,3 +68,52 @@ export const changePassword = async (
 
   return !!userBeforeUpdate;
 };
+
+export async function signupUserService({
+  email,
+  name,
+  phone,
+  password,
+}: {
+  email: string;
+  name: string;
+  phone: string;
+  password: string;
+}): Promise<void> {
+  if (await checkEmailDuplicate(email)) {
+    throw new AppError("VALIDATION", "이미 존재하는 이메일 입니다.");
+  }
+  await createUser({ email, name, phone, password: await hashPassword(password) });
+}
+
+export async function requestPasswordResetService(email: string): Promise<void> {
+  if (!(await checkEmailDuplicate(email))) {
+    throw new AppError("VALIDATION", "등록되지 않은 이메일입니다.");
+  }
+  const token = await encrypt({ id: email, type: "ENTRY" });
+  const path =
+    process.env.NODE_ENV === "development"
+      ? `http://localhost:3000${routes.changePw}?t=${encodeURIComponent(token)}`
+      : "";
+  await sendEmail({ email, path });
+}
+
+export async function resetUserPasswordService({
+  token,
+  password,
+}: {
+  token: string;
+  password: string;
+}): Promise<void> {
+  const { payload } = await decrypt({ token, type: "ENTRY" });
+  if (!payload.id) {
+    throw new AppError(
+      "UNAUTHENTICATED",
+      "유효하지 않거나 만료된 토큰입니다. 비밀번호 재설정을 다시 시도해주세요.",
+    );
+  }
+  if (!(await changePassword(payload.id, password))) {
+    throw new AppError("NOT_FOUND", "해당 계정을 찾을 수 없습니다. 이메일 주소를 확인해주세요.");
+  }
+  await deleteCookie("userEmail");
+}


### PR DESCRIPTION
## 변경 사항
- Action의 bcrypt/JWT/cookie/mail/Cloudinary 직접 조합을 Service 유스케이스로 이동
- 상품 이미지 업로드 후 DB 실패 시 Cloudinary 보상 정리를 Service가 담당
- 인증·관리자 권한·방명록 비밀번호·커플정보 연결·결제 동기화 흐름 Service화
- actions에서 models/db/adapters 직접 import 금지

## 검증
- npm run lint
- npm run tsc
- npm run build

테스트는 Phase 8에서 재설계합니다.