### PR TITLE
refactor: enforce runtime import boundaries

### DIFF
--- a/docs/decisions/0001-role-based-directory-architecture.md
+++ b/docs/decisions/0001-role-based-directory-architecture.md
@@ -72,6 +72,8 @@ Mongoose Model이 persistence 접근을 이미 제공하며, 추가 추상화는
 
 현재 운영 규칙의 단일 원본은 각 계층의 `AGENTS.md`와 `docs/architecture/`, `docs/conventions/`, `docs/validation/`이다. 이 ADR은 그 규칙을 복제하지 않고 선택의 이유를 보존한다.
 
+`server-only`와 `client-only` 경계는 marker가 선언된 모듈이 실제 소비 그래프에 연결된 production build에서 검증된다. marker가 누락된 파일과 아직 소비되지 않은 혼합 배럴은 작성 시점에 발견되지 않을 수 있다. 서로 다른 런타임이 실제로 연결되면 필수 production build가 이를 차단한다. 반복적인 누락 사례가 없고 필수 build가 배포를 차단하므로 현재는 별도 구조 검사기를 도입하지 않는다.
+
 ## 관련 이력
 
 - 1차 런타임 중심 이동: `2499913`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,45 @@ const eslintConfig = [...nextCoreWebVitals, ...nextTypescript, {
     }],
   },
 }, {
+  files: ["src/core/**/*.{ts,tsx}"],
+  ignores: [
+    "src/core/**/*.test.ts",
+    "src/core/**/*.test.tsx",
+    "src/core/**/*.integration.test.ts",
+    "src/core/**/*.integration.test.tsx",
+  ],
+  rules: {
+    "import/no-nodejs-modules": "error",
+    "no-restricted-imports": ["error", {
+      paths: [
+        { name: "mongoose", message: "core는 Mongoose에 의존하지 않는다" },
+        { name: "next", message: "core는 Next.js에 의존하지 않는다" },
+        { name: "server-only", message: "core는 runtime marker에 의존하지 않는다" },
+        { name: "client-only", message: "core는 runtime marker에 의존하지 않는다" },
+      ],
+      patterns: [
+        { group: ["mongoose/*"], message: "core는 Mongoose에 의존하지 않는다" },
+        { group: ["next/*"], message: "core는 Next.js에 의존하지 않는다" },
+      ],
+    }],
+  },
+}, {
+  files: ["src/actions/**/*.{ts,tsx}"],
+  ignores: [
+    "src/actions/**/*.test.ts",
+    "src/actions/**/*.test.tsx",
+    "src/actions/**/*.integration.test.ts",
+    "src/actions/**/*.integration.test.tsx",
+  ],
+  rules: {
+    "no-restricted-imports": ["error", {
+      paths: [
+        { name: "server-only", message: "action은 server-only marker를 사용하지 않는다" },
+        { name: "client-only", message: "action은 client-only marker를 사용하지 않는다" },
+      ],
+    }],
+  },
+}, {
   files: ["src/actions/**/*.test.ts", "src/actions/**/*.integration.test.ts"],
   rules: {
     "import/no-restricted-paths": "off",


### PR DESCRIPTION
## Summary
- Enforce the approved runtime import boundaries with existing ESLint rules: core product files reject Node.js builtins through `import/no-nodejs-modules` and reject Mongoose, Next.js runtime APIs, and runtime markers through `no-restricted-imports`; Action product files reject `server-only` and `client-only` markers through `no-restricted-imports`.
- Exclude unit and integration test files because tests may require runtime-specific fixtures and dependencies while the guardrails target product code. The existing Action test override for restricted paths remains unchanged.
- Document that production builds validate connected `server-only`/`client-only` graphs and that no separate structural checker or CI workflow change is warranted while required builds block deployment.

## Test plan
- Violation probes — core imports of `fs`, `node:fs`, and `node:path`, plus `export * from "fs"`, named re-export from `fs`, and `import("fs")`, failed with `import/no-nodejs-modules`; `require("fs")` reported both `import/no-nodejs-modules` and `@typescript-eslint/no-require-imports`.
- Violation probes — core imports of `mongoose`, `mongoose/types`, `next/server`, `server-only`, and `client-only` failed with `no-restricted-imports`; Action imports of `server-only` and `client-only` failed with `no-restricted-imports`.
- Allow probes — core imports of `zod`, React types, `lucide-react`, `clsx`, `tailwind-merge`, an internal core alias, and an internal relative path passed; an Action import from `@/services` passed the new marker rule.
- Test exclusion probes — a core test importing `node:fs` and an Action test importing `server-only` received no report from the new rules.
- Node protocol fallback — not required because the installed rule rejected both `node:fs` and `node:path`.
- `git diff --check` — passed.
- `npm run lint` — passed.
- `npm run tsc` — passed.
- `npm run build` — passed outside the sandbox after the sandbox blocked Turbopack local port binding.