### PR TITLE
chore: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,40 @@
+name: 작업
+description: 기능, 버그, 리팩터링, 테스트, CI, 문서 등의 작업을 등록합니다.
+title: ""
+labels: []
+body:
+  - type: textarea
+    id: background
+    attributes:
+      label: 배경
+      description: 해결하려는 문제나 작업이 필요한 이유를 작성해 주세요.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 작업 내용
+      description: 이번 작업에서 수행할 내용을 작성해 주세요.
+      placeholder: |
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: 완료 조건
+      description: 작업 완료를 판단할 수 있는 조건을 작성해 주세요.
+      placeholder: |
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 참고 자료
+      description: 관련 문서, Issue, PR 또는 링크가 있다면 작성해 주세요.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- 범용 Issue Form을 추가해 작업의 배경, 범위 및 완료 조건을 일관되게 기록합니다.
- 빈 Issue 생성을 비활성화하고 참고 자료는 선택 입력으로 유지합니다.

## Test plan

- `node_modules/.bin/prettier --check .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/task.yml` — 통과
- 기본 파일 검사 — 탭 없음 및 마지막 줄 개행 확인