### PR TITLE
refactor: 페이지별 렌더링 전략을 명확히 한다

### DIFF
--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 300;
+export const dynamic = "force-dynamic";
 
 import { Card, CardContent, CardHeader, CardTitle, TypographyMuted, TypographySmall } from "@/ui/components/atoms";
 import { Package, DollarSign, ShoppingCart, Users } from "lucide-react";

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 300;
+export const dynamic = "force-dynamic";
 
 import React from "react";
 import { verifySession } from "@/services";

--- a/src/app/(admin)/admin/premium-features/new/page.tsx
+++ b/src/app/(admin)/admin/premium-features/new/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { routes } from "@/core/domain";

--- a/src/app/(admin)/admin/premium-features/page.tsx
+++ b/src/app/(admin)/admin/premium-features/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 600;
+export const dynamic = "force-dynamic";
 
 import { Badge, Card, CardContent, TypographyH1, TypographyH3, TypographyLarge, TypographyMuted } from "@/ui/components/atoms";
 

--- a/src/app/(admin)/admin/products/new/page.tsx
+++ b/src/app/(admin)/admin/products/new/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { getAllPremiumFeatureService, verifySession } from "@/services";
 import { Button, TypographyH1, TypographyMuted } from "@/ui/components/atoms";
 import { ProductRegistrationForm } from "./_components";

--- a/src/app/(admin)/admin/products/page.tsx
+++ b/src/app/(admin)/admin/products/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 600;
+export const dynamic = "force-dynamic";
 
 import { getAllProductsService, verifySession } from "@/services";
 import { AdminProductsTemplate } from "./_components";

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 import React from "react";
 import { verifySession } from "@/services";

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 600;
+export const dynamic = "force-dynamic";
 
 import React from "react";
 import { verifySession } from "@/services";

--- a/src/app/(main)/(products)/products/[category]/[id]/page.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/page.tsx
@@ -1,14 +1,9 @@
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 import { ProductDetailTemplate } from "./_components";
-import { getPremiumFeatureService, getAllProductsService, getProductService } from "@/services";
+import { getPremiumFeatureService, getProductService } from "@/services";
 
 import { notFound } from "next/navigation";
-
-export async function generateStaticParams() {
-  const products = await getAllProductsService();
-  return products.map((p) => ({ category: p.category, id: p._id.toString() }));
-}
 
 export default async function ProductDetailPage({
   params,

--- a/src/app/(main)/(products)/products/[category]/page.tsx
+++ b/src/app/(main)/(products)/products/[category]/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { TypographyH1, TypographyMuted } from "@/ui/components/atoms";
 import { ProductCatalog } from "../_components";
 import { getAllProductsService } from "@/services";

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 import { HomeTemplate } from "./_components";
 import type {


### PR DESCRIPTION
## Summary

- 공개 DB 페이지와 관리자 페이지의 렌더링 전략을 `force-dynamic`으로 명시했습니다.
- 상품 상세의 전체 상품 프리빌드를 제거해 빌드 타임 MongoDB 의존을 없앴습니다.
- `preview/[id]`의 ISR 설정은 기존대로 유지했습니다.

## Test plan

- `git diff --check` — 통과
- Not run: `npm run lint`, `npm run tsc`, `npm run build` — GitHub Actions CI에서 검증