### PR TITLE
fix: 리디렉션 결제 완료를 주문에 반영한다

### DIFF
--- a/src/adapters/browser/portone/request-payment.ts
+++ b/src/adapters/browser/portone/request-payment.ts
@@ -16,6 +16,14 @@ export const requestPayment: RequestPayment = async (request) => {
     process.env.NODE_ENV !== "production" &&
     process.env.NEXT_PUBLIC_PORTONE_E2E_MOCK === "enabled"
   ) {
+    if (request.redirectUrl) {
+      const redirectUrl = new URL(request.redirectUrl);
+      redirectUrl.searchParams.set("paymentId", request.paymentId);
+      location.href = redirectUrl.toString();
+
+      return new Promise(() => {});
+    }
+
     return {
       transactionType: "PAYMENT",
       txId: `e2e-${request.paymentId}`,

--- a/src/app/(main)/payment-result/_components/PaymentResult.test.tsx
+++ b/src/app/(main)/payment-result/_components/PaymentResult.test.tsx
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const {
+  completePaymentMock,
+  replaceMock,
+  clearOrderMock,
+  setPaymentStatusMock,
+} = vi.hoisted(() => ({
+  completePaymentMock: vi.fn(),
+  replaceMock: vi.fn(),
+  clearOrderMock: vi.fn(),
+  setPaymentStatusMock: vi.fn(),
+}));
+
+vi.mock("@/actions", () => ({ completePayment: completePaymentMock }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock }),
+}));
+vi.mock("@/ui/stores", () => ({
+  useOrderStore: (
+    selector: (state: {
+      clearOrder: typeof clearOrderMock;
+      setPaymentStatus: typeof setPaymentStatusMock;
+    }) => unknown,
+  ) =>
+    selector({
+      clearOrder: clearOrderMock,
+      setPaymentStatus: setPaymentStatusMock,
+    }),
+}));
+
+import { PaymentResult } from "./PaymentResult";
+
+describe("PaymentResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("paymentId로 결제를 완료하고 성공 페이지로 이동한다", async () => {
+    completePaymentMock.mockResolvedValue({
+      success: true,
+      data: { status: "PAID" },
+    });
+
+    render(<PaymentResult paymentId="ORDER-1" />);
+
+    expect(screen.getByText("결제를 확인하고 있습니다")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(completePaymentMock).toHaveBeenCalledTimes(1);
+      expect(completePaymentMock).toHaveBeenCalledWith("ORDER-1");
+      expect(setPaymentStatusMock).toHaveBeenCalledWith("PAID");
+      expect(clearOrderMock).toHaveBeenCalledTimes(1);
+      expect(replaceMock).toHaveBeenCalledWith(
+        "/payment/success?orderId=ORDER-1",
+      );
+    });
+  });
+
+  it("결제 완료가 실패하면 서버의 안전한 오류 메시지를 표시한다", async () => {
+    completePaymentMock.mockResolvedValue({
+      success: false,
+      error: {
+        category: "EXTERNAL_SERVICE",
+        message: "결제 처리에 실패했습니다.",
+      },
+    });
+
+    render(<PaymentResult paymentId="ORDER-1" />);
+
+    expect(
+      await screen.findByText("결제 처리에 실패했습니다."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "주문 내역 확인" }),
+    ).toHaveAttribute("href", "/my-orders");
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("paymentId가 없으면 결제 완료를 호출하지 않고 오류를 표시한다", () => {
+    render(<PaymentResult />);
+
+    expect(
+      screen.getByText("결제 정보가 올바르지 않습니다."),
+    ).toBeInTheDocument();
+    expect(completePaymentMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(main)/payment-result/_components/PaymentResult.tsx
+++ b/src/app/(main)/payment-result/_components/PaymentResult.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { completePayment } from "@/actions";
+import { routes } from "@/core/domain";
+import { useOrderStore } from "@/ui/stores";
+import { PaymentResultTemplate } from "./PaymentResultTemplate";
+
+interface PaymentResultProps {
+  paymentId?: string;
+}
+
+export function PaymentResult({ paymentId }: PaymentResultProps) {
+  const router = useRouter();
+  const clearOrder = useOrderStore((state) => state.clearOrder);
+  const setPaymentStatus = useOrderStore((state) => state.setPaymentStatus);
+  const started = useRef(false);
+  const [, startTransition] = useTransition();
+  const [errorMessage, setErrorMessage] = useState<string | null>(
+    paymentId ? null : "결제 정보가 올바르지 않습니다.",
+  );
+
+  useEffect(() => {
+    if (!paymentId || started.current) return;
+    started.current = true;
+
+    startTransition(async () => {
+      try {
+        const result = await completePayment(paymentId);
+
+        if (result.success === false) {
+          setErrorMessage(result.error.message);
+          return;
+        }
+
+        if (result.data.status !== "PAID") {
+          setErrorMessage("결제 검증에 실패했습니다. 고객센터에 문의해주세요.");
+          return;
+        }
+
+        setPaymentStatus("PAID");
+        clearOrder();
+        router.replace(
+          `${routes.payment.success}?orderId=${encodeURIComponent(paymentId)}`,
+        );
+      } catch (error) {
+        console.error("Payment completion error:", error);
+        setErrorMessage("결제 처리 중 오류가 발생했습니다.");
+      }
+    });
+  }, [clearOrder, paymentId, router, setPaymentStatus]);
+
+  return <PaymentResultTemplate errorMessage={errorMessage} />;
+}

--- a/src/app/(main)/payment-result/_components/PaymentResultTemplate.tsx
+++ b/src/app/(main)/payment-result/_components/PaymentResultTemplate.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { AlertCircle } from "lucide-react";
+import { routes } from "@/core/domain";
+import {
+  Button,
+  Card,
+  CardContent,
+  TypographyH1,
+  TypographyMuted,
+} from "@/ui/components/atoms";
+import { Spinner } from "@/ui/components/molecules";
+
+interface PaymentResultTemplateProps {
+  errorMessage: string | null;
+}
+
+export function PaymentResultTemplate({
+  errorMessage,
+}: PaymentResultTemplateProps) {
+  return (
+    <div className="container mx-auto flex min-h-[60vh] items-center px-4 py-12">
+      <Card className="mx-auto w-full max-w-lg">
+        <CardContent className="flex flex-col items-center gap-4 py-10 text-center">
+          {errorMessage ? (
+            <>
+              <AlertCircle className="text-destructive h-12 w-12" />
+              <TypographyH1 className="text-2xl">
+                결제 확인에 실패했습니다
+              </TypographyH1>
+              <TypographyMuted>{errorMessage}</TypographyMuted>
+              <Button asChild>
+                <Link href={routes.myOrders.root}>주문 내역 확인</Link>
+              </Button>
+            </>
+          ) : (
+            <>
+              <Spinner />
+              <TypographyH1 className="text-2xl">
+                결제를 확인하고 있습니다
+              </TypographyH1>
+              <TypographyMuted>
+                페이지를 닫지 말고 잠시만 기다려 주세요.
+              </TypographyMuted>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(main)/payment-result/_components/index.tsx
+++ b/src/app/(main)/payment-result/_components/index.tsx
@@ -1,0 +1,1 @@
+export * from "./PaymentResult";

--- a/src/app/(main)/payment-result/page.tsx
+++ b/src/app/(main)/payment-result/page.tsx
@@ -1,0 +1,11 @@
+import { PaymentResult } from "./_components";
+
+export default async function PaymentResultPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ paymentId?: string }>;
+}) {
+  const { paymentId } = await searchParams;
+
+  return <PaymentResult paymentId={paymentId} />;
+}

--- a/src/core/domain/routes.ts
+++ b/src/core/domain/routes.ts
@@ -14,6 +14,7 @@ export const routes = {
   deliveryInfo: "/delivery-info",
   payment: {
     root: "/payment",
+    result: "/payment-result",
     success: "/payment/success",
   },
   myOrders: {

--- a/src/ui/hooks/usePortOnePayment.test.ts
+++ b/src/ui/hooks/usePortOnePayment.test.ts
@@ -72,6 +72,11 @@ describe("usePortOnePayment", () => {
     });
 
     expect(completePayment).toHaveBeenCalledWith("merchant-1");
+    expect(requestPaymentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUrl: `${location.origin}/payment-result`,
+      }),
+    );
     await waitFor(() => {
       expect(result.current.paymentStatus).toBe("PAID");
     });

--- a/src/ui/hooks/usePortOnePayment.ts
+++ b/src/ui/hooks/usePortOnePayment.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { requestPayment } from "@/adapters/browser/portone/request-payment";
-import type { PayStatus } from "@/core/domain";
+import { routes, type PayStatus } from "@/core/domain";
 import type { CreateOrderResult } from "@/actions";
 import { completePayment } from "@/actions";
 import { useOrderStore } from "@/ui/stores";
@@ -53,6 +53,7 @@ export function usePortOnePayment({ onSuccess, onError }: UsePortOnePaymentOptio
           storeId,
           channelKey,
           paymentId: merchantUid,
+          redirectUrl: `${location.origin}${routes.payment.result}`,
           orderName: `${title} 모바일 청첩장`,
           totalAmount: finalPrice,
           currency: "CURRENCY_KRW",

--- a/testing/e2e/core.spec.ts
+++ b/testing/e2e/core.spec.ts
@@ -105,9 +105,14 @@ test("기존 상세 이미지와 thumbnail을 유지한 채 상품명을 수정�
   await expect(page.getByText("E2E 기존 이미지 유지 완료")).toBeVisible();
 });
 
-test("실제 주문을 생성하고 mock PortOne 경계로 결제를 완료한다", async ({ page }) => {
+test("mock PG 리디렉션으로 복귀해 실제 주문의 결제를 완료한다", async ({ page }) => {
+  const navigatedPaths: string[] = [];
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame())
+      navigatedPaths.push(new URL(frame.url()).pathname);
+  });
+
   await loginAsUser(page);
-  await page.goto("/payment");
   await page.evaluate(() => {
     sessionStorage.setItem("order-storage", JSON.stringify({
       state: {
@@ -127,7 +132,7 @@ test("실제 주문을 생성하고 mock PortOne 경계로 결제를 완료한�
       version: 0,
     }));
   });
-  await page.reload();
+  await page.goto("/payment");
 
   await page.getByLabel("이름").fill("테스트 구매자");
   await page.getByLabel("연락처").fill("010-1234-5678");
@@ -136,6 +141,7 @@ test("실제 주문을 생성하고 mock PortOne 경계로 결제를 완료한�
   await page.getByRole("button", { name: "결제하기" }).click();
 
   await expect(page).toHaveURL(/\/payment\/success\?orderId=ORDER-/, { timeout: 30_000 });
+  expect(navigatedPaths).toContain("/payment-result");
   await expect(page.getByRole("heading", { name: "결제가 완료되었습니다!" })).toBeVisible();
   await page.getByRole("link", { name: "주문 내역 확인" }).click();
   await expect(page.getByText("E2E 결제 상품")).toBeVisible();


### PR DESCRIPTION
## Summary

- 결제 요청에 현재 origin 기반의 public 복귀 URL `/payment-result`를 전달합니다.
- 복귀 페이지가 마운트된 뒤 `paymentId`로 결제를 검증하고, 성공 시 기존 결제 완료 화면으로 이동합니다.
- Fake PG가 실제 리디렉션을 수행하도록 확장해 전체 복귀 흐름을 CI E2E로 검증합니다. 이 mock은 localhost 간 same-site 이동이므로 실제 PG에서의 `SameSite=Strict` cross-site 복귀 조건은 재현하지 않습니다.

Closes #76

## Test plan

- `npm run test:component -- --run src/ui/hooks/usePortOnePayment.test.ts src/adapters/browser/portone/request-payment.test.ts src/app/\(main\)/payment-result/_components/PaymentResult.test.tsx` — 3 files, 10 tests passed
- `npm run tsc` — passed
- `npm run lint -- --no-warn-ignored ...` — changed files passed
- `BASE_URL=http://127.0.0.1:3100 DEPLOYMENT_BASE_URL=http://127.0.0.1:3100 npm run test:e2e -- --grep "mock PG 리디렉션"` — 1 passed
- Not run: 실제 PG 모바일 스모크 — 외부 결제사 화면의 사용자 인증이 필요함