### PR TITLE
fix: 서울 지하철 API 비-JSON 응답을 분류된 에러로 처리한다

### DIFF
--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — src/adapters/
 
 > 외부 SDK와 브라우저·프레임워크 API 경계를 감싸는 계층.
-> Last updated: 2026-08-19
+> Last updated: 2026-08-20
 
 ## 공통 디렉토리 컨벤션
 
@@ -16,6 +16,7 @@
 | `server/cookies/` | Next.js 쿠키 API | server-only |
 | `server/jose/` | JWT 암복호화 | server-only |
 | `server/nodemailer/` | 이메일 전송 | server-only |
+| `server/seoul-open-api/` | 서울 열린데이터광장 API 호출·가드·에러분류 | server-only |
 | `browser/cloudinary/` | 브라우저 업로드 | client-only |
 | `browser/daum/` | 주소 팝업 | client-only |
 | `browser/deeplink/` | 지도 앱 딥링크 | client-only |

--- a/src/adapters/server/seoul-open-api/request.test.ts
+++ b/src/adapters/server/seoul-open-api/request.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchSeoulOpenApi } from "./request";
+
+const SERVICE_NAME = "SearchSTNBySubwayLineInfo";
+
+type Row = { STATION_NM: string };
+
+function mockResponse(status: number, ok: boolean, contentType: string, body: string): Response {
+  return {
+    ok,
+    status,
+    headers: new Headers({ "content-type": contentType }),
+    text: async () => body,
+  } as Response;
+}
+
+describe("fetchSeoulOpenApi", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("정상 JSON 응답을 rows 배열로 리턴한다", async () => {
+    const body = JSON.stringify({
+      [SERVICE_NAME]: {
+        list_total_count: 1,
+        RESULT: { CODE: "INFO-000", MESSAGE: "정상 처리되었습니다" },
+        row: [{ STATION_NM: "서울" }],
+      },
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(200, true, "application/json", body));
+
+    const rows = await fetchSeoulOpenApi<Row>(SERVICE_NAME, [1, 1000]);
+
+    expect(rows).toEqual([{ STATION_NM: "서울" }]);
+  });
+
+  it("ok:true이지만 XML 본문(인증키 오류 등)이면 EXTERNAL_SERVICE로 분류한다", async () => {
+    const xml = "<RESULT><CODE>INFO-100</CODE><MESSAGE>인증키가 유효하지 않습니다.</MESSAGE></RESULT>";
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(200, true, "text/xml", xml));
+
+    await expect(fetchSeoulOpenApi<Row>(SERVICE_NAME, [1, 1000])).rejects.toMatchObject({
+      category: "EXTERNAL_SERVICE",
+    });
+  });
+
+  it("ok:false(HTTP 5xx)면 EXTERNAL_SERVICE로 분류하고 message에 status를 남긴다", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(500, false, "text/html", "<html>error</html>"));
+
+    await expect(fetchSeoulOpenApi<Row>(SERVICE_NAME, [1, 1000])).rejects.toMatchObject({
+      category: "EXTERNAL_SERVICE",
+      message: expect.stringContaining("500"),
+    });
+  });
+
+  it("content-type은 JSON인데 본문이 깨져 있으면 EXTERNAL_SERVICE로 분류한다", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(200, true, "application/json", ""));
+
+    await expect(fetchSeoulOpenApi<Row>(SERVICE_NAME, [1, 1000])).rejects.toMatchObject({
+      category: "EXTERNAL_SERVICE",
+    });
+  });
+
+  it("fetch 자체가 reject되면 EXTERNAL_SERVICE로 정규화한다", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError("fetch failed"));
+
+    await expect(fetchSeoulOpenApi<Row>(SERVICE_NAME, [1, 1000])).rejects.toMatchObject({
+      category: "EXTERNAL_SERVICE",
+    });
+  });
+
+  it("JSON이지만 API 레벨 실패(RESULT.CODE 에러)면 message에 CODE를 남긴다", async () => {
+    const body = JSON.stringify({
+      RESULT: { CODE: "ERROR-336", MESSAGE: "일별 트래픽 제한을 초과했습니다." },
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(200, true, "application/json", body));
+
+    await expect(fetchSeoulOpenApi<Row>(SERVICE_NAME, [1, 1000])).rejects.toMatchObject({
+      category: "EXTERNAL_SERVICE",
+      message: expect.stringContaining("ERROR-336"),
+    });
+  });
+
+  it("결과 0건(INFO-200)은 실패가 아니라 빈 배열이다", async () => {
+    const body = JSON.stringify({ RESULT: { CODE: "INFO-200", MESSAGE: "해당 데이터가 없습니다." } });
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(200, true, "application/json", body));
+
+    const rows = await fetchSeoulOpenApi<Row>(SERVICE_NAME, [1, 50, "존재안함역"]);
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/src/adapters/server/seoul-open-api/request.ts
+++ b/src/adapters/server/seoul-open-api/request.ts
@@ -1,0 +1,42 @@
+import "server-only";
+import { AppError } from "@/core/domain";
+import { parseSeoulOpenApiResponse } from "@/core/utils";
+
+export async function fetchSeoulOpenApi<T>(
+  serviceName: string,
+  pathParams: (string | number)[],
+): Promise<T[]> {
+  const path = [serviceName, ...pathParams.map((p) => encodeURIComponent(p))].join("/");
+  const url = `${process.env.SUBWAY_SEOUL_BASE_URL}/${process.env.SEOUL_PUBLIC_API_KEY}/json/${path}/`;
+
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (error) {
+    throw new AppError(
+      "EXTERNAL_SERVICE",
+      `서울 열린데이터광장 API 요청 실패: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const text = await res.text();
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new AppError(
+      "EXTERNAL_SERVICE",
+      `서울 열린데이터광장 API가 JSON이 아닌 응답을 반환함 (status=${res.status}): ${text.slice(0, 300)}`,
+    );
+  }
+
+  const result = parseSeoulOpenApiResponse<T>(serviceName, json);
+  if (result.kind === "failure") {
+    throw new AppError(
+      "EXTERNAL_SERVICE",
+      `서울 열린데이터광장 API 오류 (${result.code}): ${result.message}`,
+    );
+  }
+
+  return result.rows;
+}

--- a/src/app/api/subway/[station]/route.ts
+++ b/src/app/api/subway/[station]/route.ts
@@ -1,7 +1,7 @@
 import type { APIRouteResponse} from "@/boundary";
 import { routeSuccess, routeError } from "@/boundary";
 import { AppError } from "@/core/domain";
-import { parseSeoulOpenApiResponse } from "@/core/utils";
+import { fetchSeoulOpenApi } from "@/adapters/server/seoul-open-api/request";
 import { SUBWAY_LINE_COLORS, DEFAULT_SUBWAY_LINE_COLOR } from "@/core/domain";
 import type { SubwayStationLineInfoResponse } from "@/core/schemas";
 import type { NextRequest } from "next/server";
@@ -20,21 +20,13 @@ export const GET = async (
   try {
     const { station } = await params;
 
-    const res = await fetch(
-      `${process.env.SUBWAY_SEOUL_BASE_URL}/${process.env.SEOUL_PUBLIC_API_KEY}/json/${SERVICE_NAME}/1/50/${encodeURIComponent(station)}/`,
-    );
-    const json = await res.json();
+    const rows = await fetchSeoulOpenApi<SubwayNameSearchRow>(SERVICE_NAME, [1, 50, station]);
 
-    const result = parseSeoulOpenApiResponse<SubwayNameSearchRow>(SERVICE_NAME, json);
-    if (result.kind === "failure") {
-      throw new AppError("EXTERNAL_SERVICE", result.message);
-    }
-
-    if (result.rows.length === 0) {
+    if (rows.length === 0) {
       throw new AppError("NOT_FOUND", "해당 역을 찾을 수 없습니다.");
     }
 
-    const uniqueLineNames = [...new Set(result.rows.map((row) => row.LINE_NUM))];
+    const uniqueLineNames = [...new Set(rows.map((row) => row.LINE_NUM))];
 
     const lines = uniqueLineNames.map((name) => ({
       name,

--- a/src/services/subway.ts
+++ b/src/services/subway.ts
@@ -1,28 +1,30 @@
 import "server-only";
-import { AppError } from "@/core/domain";
-import { parseSeoulOpenApiResponse } from "@/core/utils";
+import { unstable_cache } from "next/cache";
+import { fetchSeoulOpenApi } from "@/adapters/server/seoul-open-api/request";
 
 const SERVICE_NAME = "SearchSTNBySubwayLineInfo";
-// 역 목록은 거의 안 바뀐다 — 저장 시점 검증/드롭다운 둘 다 매 요청마다 799건 외부 API를 다시 안 부르도록 하루 캐시.
 const CACHE_REVALIDATE_SECONDS = 60 * 60 * 24;
 
 type SubwayLineInfoRow = {
   STATION_NM: string;
 };
 
+// 역 목록은 거의 안 바뀐다 — 저장 시점 검증/드롭다운 둘 다 매 요청마다 799건 외부 API를 다시 안 부르도록 하루 캐시.
+// fetch 레벨 next.revalidate 대신 unstable_cache를 쓴다 — 서울 API는 인증키 오류/한도초과 시에도
+// HTTP 200으로 응답하는데, fetch의 Data Cache는 상태코드 200만 보고 캐싱 여부를 정하므로(Next 내부
+// patch-fetch.js) 그 경로로는 실패 응답도 그대로 하루 캐시에 눌러앉는다. unstable_cache는 콜백이
+// throw하면 캐시 쓰기 자체를 건너뛰므로, 실패가 캐시에 갇히는 문제가 없다.
+const getCachedSubwayStationNames = unstable_cache(
+  async (): Promise<string[]> => {
+    const rows = await fetchSeoulOpenApi<SubwayLineInfoRow>(SERVICE_NAME, [1, 1000]);
+    return [...new Set(rows.map((row) => row.STATION_NM))];
+  },
+  ["subway-station-names"],
+  { revalidate: CACHE_REVALIDATE_SECONDS },
+);
+
 export async function getAllSubwayStationNames(): Promise<string[]> {
-  const res = await fetch(
-    `${process.env.SUBWAY_SEOUL_BASE_URL}/${process.env.SEOUL_PUBLIC_API_KEY}/json/${SERVICE_NAME}/1/1000/`,
-    { next: { revalidate: CACHE_REVALIDATE_SECONDS } },
-  );
-  const json = await res.json();
-
-  const result = parseSeoulOpenApiResponse<SubwayLineInfoRow>(SERVICE_NAME, json);
-  if (result.kind === "failure") {
-    throw new AppError("EXTERNAL_SERVICE", result.message);
-  }
-
-  return [...new Set(result.rows.map((row) => row.STATION_NM))];
+  return getCachedSubwayStationNames();
 }
 
 export async function isValidSubwayStationName(name: string): Promise<boolean> {

--- a/src/ui/hooks/useSubwayLineInfo.ts
+++ b/src/ui/hooks/useSubwayLineInfo.ts
@@ -7,8 +7,10 @@ import type { SubwayStationLineInfoResponse } from "@/core/schemas";
 export function useSubwayLineInfo(station?: string) {
   const swrKey = station ? `/api/subway/${encodeURIComponent(station)}` : null;
 
-  const { data, error, isLoading } = useSWR(swrKey, (url: string) =>
-    fetcher<SubwayStationLineInfoResponse>(url),
+  const { data, error, isLoading } = useSWR(
+    swrKey,
+    (url: string) => fetcher<SubwayStationLineInfoResponse>(url),
+    { shouldRetryOnError: false },
   );
 
   return {

--- a/src/ui/hooks/useSubwayStations.ts
+++ b/src/ui/hooks/useSubwayStations.ts
@@ -8,6 +8,7 @@ export function useSubwayStations() {
   const { data, error, isLoading } = useSWR<SubwayStationsResponse>(
     "/api/subway",
     fetcher,
+    { shouldRetryOnError: false },
   );
 
   return {


### PR DESCRIPTION
## Summary

- 서울 열린데이터광장 API가 인증키 오류·호출한도초과 시 HTTP 200 + XML 본문으로 응답하는데, `src/services/subway.ts`와 `src/app/api/subway/[station]/route.ts`가 `res.json()`을 무가드로 호출해 `SyntaxError`로 죽고 `[Route] Unknown error`로만 로그가 남던 문제를 고친다.
- 두 호출부의 중복 fetch/파싱 로직을 `src/adapters/server/seoul-open-api/request.ts`(신규)로 추출 — body를 text로 먼저 읽어 `JSON.parse`를 try/catch(비-ok/비-JSON/본문깨짐 전부 한 경로로 수렴), fetch 자체의 reject도 정규화해서, 모든 실패가 `AppError("EXTERNAL_SERVICE", ...)`로 분류되고 원인(status/API 결과코드·메시지)이 서버 로그에 남는다.
- 반복 로그의 실제 원인 2가지를 추가로 확인해 같이 고쳤다(이슈가 요청한 "반복 호출 주체 확인" 항목):
  - SWR 기본 무한 재시도(지수 백오프, 재시도 횟수 무제한) — 페이지를 열어두기만 해도 10~40초 간격으로 재시도되고 있었다. `useSubwayStations`/`useSubwayLineInfo`에 `shouldRetryOnError: false` 추가(기존 `useFetchInvitation.ts` 선례와 동일 패턴).
  - `src/services/subway.ts`의 fetch 레벨 24시간 캐시(`next.revalidate`)는 Next Data Cache가 HTTP 상태코드 200만 보고 캐싱 여부를 정하므로(`node_modules/next/dist/server/lib/patch-fetch.js`), 인증키 오류(200+XML)도 그대로 24시간 캐시에 눌러앉을 수 있었다. `unstable_cache`로 전환 — 콜백이 throw하면 캐시 쓰기 자체를 건너뛰므로 실패가 캐시에 갇히지 않는다(Next 소스 확인 완료).

## Test plan

- `npm run test:unit` — 신규 `src/adapters/server/seoul-open-api/request.test.ts`(7 케이스: 정상/XML응답/HTTP 5xx/깨진 JSON/네트워크 reject/API 레벨 실패/빈 결과) 포함 전체 통과
- `npm run tsc` — 통과
- `npm run lint` — 통과
- 로컬 dev 서버로 `/api/subway`, `/api/subway/서울역` 정상 키로 200 확인
- `SEOUL_PUBLIC_API_KEY`를 임시로 무효화해 콜드 스타트로 재현 — `/api/subway/서울역` 502 `EXTERNAL_SERVICE` 확인, 서버 로그에 `INFO-100 인증키가 유효하지 않습니다` 원문 남는 것 확인, `/api/subway`도 콜드 스타트에서 502로 정상 실패(캐시에 안 갇힘) 확인 후 유효 키로 원복해 콜드 스타트 200 확인

Closes #85