### PR TITLE
fix: PENDING 주문 재결제 시 중복 결제를 막는다

### DIFF
--- a/src/app/(main)/(checkout)/payment/_components/CheckoutForm.test.tsx
+++ b/src/app/(main)/(checkout)/payment/_components/CheckoutForm.test.tsx
@@ -14,8 +14,9 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/actions", () => ({ createOrder: vi.fn() }));
 
 vi.mock("@/ui/stores", () => ({
-  useOrderStore: (selector: (s: { clearOrder: () => void }) => unknown) =>
-    selector({ clearOrder: clearOrderMock }),
+  useOrderStore: (
+    selector: (s: { clearOrder: () => void; resumePayment: null }) => unknown,
+  ) => selector({ clearOrder: clearOrderMock, resumePayment: null }),
 }));
 
 vi.mock("@/ui/hooks", () => ({

--- a/src/app/(main)/(checkout)/payment/_components/CheckoutForm.tsx
+++ b/src/app/(main)/(checkout)/payment/_components/CheckoutForm.tsx
@@ -12,6 +12,7 @@ import { useCheckoutData } from "@/ui/hooks";
 import { useCheckoutForm } from "@/ui/hooks";
 import { CheckoutForm as PureCheckoutForm } from "@/ui/components/organisms";
 import { routes } from "@/core/domain";
+import { RetryPaymentCard } from "./RetryPaymentCard";
 export function CheckoutForm() {
   const router = useRouter();
   const clearOrder = useOrderStore((state) => state.clearOrder);
@@ -65,6 +66,21 @@ export function CheckoutForm() {
     }
     handleSubmit(e);
   };
+
+  // PaymentButton이 PG 조회 결과 진짜 미결제로 판정한 기존 주문 — 새 주문(createOrder)
+  // 대신 같은 merchantUid로 재결제한다(GH #78). 훅 전부(위)를 거친 뒤 마지막에
+  // 분기해야 훅 호출 순서가 매 렌더 동일하게 유지된다.
+  const resumePayment = useOrderStore((s) => s.resumePayment);
+  if (resumePayment) {
+    return (
+      <RetryPaymentCard
+        order={resumePayment}
+        paymentStatus={paymentStatus}
+        errorMessage={errorMessage}
+        onConfirm={() => triggerPayment(resumePayment)}
+      />
+    );
+  }
 
   return (
     <PureCheckoutForm

--- a/src/app/(main)/(checkout)/payment/_components/RetryPaymentCard.tsx
+++ b/src/app/(main)/(checkout)/payment/_components/RetryPaymentCard.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import type { CreateOrderResult } from "@/actions";
+import type { PayStatus } from "@/core/domain";
+import { Button } from "@/ui/components/atoms";
+import { TypographyLarge, TypographyMuted, TypographySmall } from "@/ui/components/atoms";
+import { PaymentPendingOverlay } from "./PaymentPendingOverlay";
+
+interface RetryPaymentCardProps {
+  order: CreateOrderResult;
+  paymentStatus: PayStatus | "IDLE";
+  errorMessage: string | null;
+  onConfirm: () => void;
+}
+
+// 기존 merchantUid로 재결제를 시도하는 뷰 — buyer info 입력은 최초 주문 생성 시
+// 이미 받았으므로 폼을 다시 안 보여준다. 주문 요약(제목/금액/결제수단)은
+// (checkout)/layout.tsx가 이미 렌더하는 OrderSummary와 중복돼 확인 문구만 둔다.
+// PortOne 팝업(triggerPayment)은 반드시 이 버튼의 onClick에서 직접 호출돼야
+// 한다 — 마운트 시 자동 트리거하면 사용자 제스처 없이 팝업이 열려 차단될 수 있다.
+export function RetryPaymentCard({
+  order,
+  paymentStatus,
+  errorMessage,
+  onConfirm,
+}: RetryPaymentCardProps) {
+  const isProcessing = paymentStatus === "PENDING";
+
+  return (
+    <div className="relative space-y-6 pb-24">
+      <PaymentPendingOverlay visible={isProcessing} />
+      <div className="space-y-2">
+        <TypographyLarge>재결제를 진행합니다</TypographyLarge>
+        <TypographyMuted>
+          이전 결제가 완료되지 않아 같은 주문으로 다시 결제를 진행합니다.
+        </TypographyMuted>
+      </div>
+
+      {errorMessage && (
+        <div className="border-destructive/50 bg-destructive/10 text-destructive flex items-start gap-3 rounded-lg border p-4 text-sm">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <TypographySmall className="font-medium">오류가 발생했습니다</TypographySmall>
+            <TypographyMuted className="text-destructive/80 mt-1">{errorMessage}</TypographyMuted>
+          </div>
+        </div>
+      )}
+
+      <Button
+        size="lg"
+        className="w-full"
+        disabled={isProcessing}
+        onClick={onConfirm}
+      >
+        {isProcessing ? "결제 진행 중..." : `${order.finalPrice.toLocaleString()}원 재결제하기`}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(main)/(my-order)/my-orders/_components/PaymentButton.test.tsx
+++ b/src/app/(main)/(my-order)/my-orders/_components/PaymentButton.test.tsx
@@ -3,10 +3,13 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { OrderJSON } from "@/core/domain";
 
-const { pushMock, setOrderMock } = vi.hoisted(() => ({
-  pushMock: vi.fn(),
-  setOrderMock: vi.fn(),
-}));
+const { pushMock, setOrderMock, setResumePaymentMock, completePaymentMock } =
+  vi.hoisted(() => ({
+    pushMock: vi.fn(),
+    setOrderMock: vi.fn(),
+    setResumePaymentMock: vi.fn(),
+    completePaymentMock: vi.fn(),
+  }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock }),
@@ -14,14 +17,26 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/ui/stores", () => ({
   useOrderStore: (
-    selector: (s: { setOrder: (item: unknown) => void }) => unknown,
-  ) => selector({ setOrder: setOrderMock }),
+    selector: (s: {
+      setOrder: (item: unknown) => void;
+      setResumePayment: (data: unknown) => void;
+    }) => unknown,
+  ) => selector({ setOrder: setOrderMock, setResumePayment: setResumePaymentMock }),
 }));
+
+vi.mock("@/actions", () => ({ completePayment: completePaymentMock }));
 
 import { PaymentButton } from "./PaymentButton";
 
 const buildOrder = (): OrderJSON =>
   ({
+    _id: "order-1",
+    merchantUid: "order-merchant-1",
+    userId: "user-1",
+    buyerName: "홍길동",
+    buyerEmail: "buyer@example.com",
+    buyerPhone: "01000000000",
+    payMethod: "CARD",
     finalPrice: 9000,
     product: {
       productId: "product-1",
@@ -38,7 +53,26 @@ describe("PaymentButton (컨테이너)", () => {
     vi.clearAllMocks();
   });
 
-  it("클릭 시 주문 정보를 store에 저장하고 결제 페이지로 이동한다", async () => {
+  it("PG 확인 결과 이미 PAID면 결제 페이지로 가지 않고 주문 상세로 이동한다", async () => {
+    completePaymentMock.mockResolvedValue({
+      success: true,
+      data: { status: "PAID" },
+    });
+    const user = userEvent.setup();
+    render(<PaymentButton order={buildOrder()} />);
+
+    await user.click(screen.getByRole("button", { name: /결제하기/ }));
+
+    expect(completePaymentMock).toHaveBeenCalledWith("order-merchant-1");
+    expect(pushMock).toHaveBeenCalledWith("/my-orders/order-1");
+    expect(setOrderMock).not.toHaveBeenCalled();
+  });
+
+  it("PG 확인 결과 미결제면 기존 merchantUid로 재결제 상태를 세팅하고 결제 페이지로 이동한다", async () => {
+    completePaymentMock.mockResolvedValue({
+      success: true,
+      data: { status: "FAILED" },
+    });
     const user = userEvent.setup();
     render(<PaymentButton order={buildOrder()} />);
 
@@ -46,6 +80,25 @@ describe("PaymentButton (컨테이너)", () => {
 
     expect(setOrderMock).toHaveBeenCalledWith(
       expect.objectContaining({ productId: "product-1" }),
+    );
+    expect(setResumePaymentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ merchantUid: "order-merchant-1" }),
+    );
+    expect(pushMock).toHaveBeenCalledWith("/payment");
+  });
+
+  it("PortOne 조회 자체가 실패해도(EXTERNAL_SERVICE) 재결제로 진행한다", async () => {
+    completePaymentMock.mockResolvedValue({
+      success: false,
+      error: { category: "EXTERNAL_SERVICE", message: "포트원 오류" },
+    });
+    const user = userEvent.setup();
+    render(<PaymentButton order={buildOrder()} />);
+
+    await user.click(screen.getByRole("button", { name: /결제하기/ }));
+
+    expect(setResumePaymentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ merchantUid: "order-merchant-1" }),
     );
     expect(pushMock).toHaveBeenCalledWith("/payment");
   });

--- a/src/app/(main)/(my-order)/my-orders/_components/PaymentButton.tsx
+++ b/src/app/(main)/(my-order)/my-orders/_components/PaymentButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/ui/components/atoms";
 import { CreditCard } from "lucide-react";
@@ -8,12 +8,32 @@ import { useOrderStore } from "@/ui/stores";
 import type { OrderJSON } from "@/core/domain";
 import type { CheckoutItem } from "@/core/domain";
 import { routes } from "@/core/domain";
+import { completePayment } from "@/actions";
 
 const PaymentButton = ({ order }: { order: OrderJSON }) => {
   const router = useRouter();
   const setOrder = useOrderStore((state) => state.setOrder);
+  const setResumePayment = useOrderStore((state) => state.setResumePayment);
+  const [isChecking, setIsChecking] = useState(false);
 
-  const handleClick = () => {
+  const handleClick = async () => {
+    setIsChecking(true);
+    // 재시도 전 PG 실제 상태를 먼저 확인한다(GH #78) — 이미 PAID인데 DB 반영만
+    // 실패해 PENDING으로 남은 주문에 이 버튼을 누르면 새 merchantUid로 새 주문이
+    // 생성돼 실제 결제가 한 번 더 일어난다. completePayment는 PG 조회 + 동기화를
+    // 수행하고 PAID였다면 이 호출로 이미 CONFIRMED 반영까지 끝낸다.
+    const result = await completePayment(order.merchantUid);
+    setIsChecking(false);
+
+    if (result.success && result.data.status === "PAID") {
+      router.push(routes.myOrders.detail(order._id));
+      return;
+    }
+
+    // 그 외(PAID 아님, 또는 PortOne에 한 번도 제출 안 된 merchantUid라 조회 자체가
+    // 실패한 경우 포함) → 진짜 미결제로 보고 같은 merchantUid로 재시도한다. 이
+    // 판정이 틀려도 PortOne 자체가 이미 PAID인 paymentId 재사용을 막아주므로 이
+    // 체크가 유일한 방어선은 아니다.
     const optionsTotalPrice = order.product.selectedFeatures.reduce(
       (sum, f) => sum + f.price,
       0,
@@ -39,11 +59,25 @@ const PaymentButton = ({ order }: { order: OrderJSON }) => {
     };
 
     setOrder(checkoutItem);
+    setResumePayment({
+      merchantUid: order.merchantUid,
+      finalPrice: order.finalPrice,
+      payMethod: order.payMethod,
+      buyerName: order.buyerName,
+      buyerEmail: order.buyerEmail,
+      buyerPhone: order.buyerPhone,
+      title: order.product.title,
+      userId: order.userId,
+      productId: order.product.productId.toString(),
+      // CreateOrderResult가 요구하는 필드지만 triggerPayment는 읽지 않는다
+      // (src/ui/hooks/usePortOnePayment.ts) — 타입만 맞추는 고정 문자열.
+      message: "재결제를 진행합니다.",
+    });
     router.push(routes.payment.root);
   };
 
   return (
-    <Button size="lg" variant="default" onClick={handleClick}>
+    <Button size="lg" variant="default" onClick={handleClick} disabled={isChecking}>
       <CreditCard className="mr-1 h-4 w-4" />
       결제하기
     </Button>

--- a/src/services/order.integration.test.ts
+++ b/src/services/order.integration.test.ts
@@ -19,7 +19,6 @@ import {
   getOrderSeviceByMerchantUid,
   getOrdersPageForUser,
   cancelPendingOrderForCurrentUser,
-  cancelExpiredPendingOrders,
   findExpiredAwaitingInvitationOrders,
 } from "./order";
 import { createProductService } from "./product";
@@ -714,57 +713,7 @@ describe("order", () => {
     });
   });
 
-  describe("cancelExpiredPendingOrders", () => {
-    it("24시간이 지난 결제 전 주문을 자동취소한다", async () => {
-      const userId = new mongoose.Types.ObjectId().toString();
-      const order = await createOrderService(buildOrderInputForTest({ userId }));
-      await setCreatedAt(order._id, new Date(Date.now() - 25 * 60 * 60 * 1000));
-
-      await cancelExpiredPendingOrders(userId);
-
-      const updated = await OrderModel.findById(order._id).lean();
-      expect(updated?.orderStatus).toBe("CANCELLED");
-      expect(updated?.cancelReason).toBe("결제 미완료로 인한 자동 취소");
-    });
-
-    it("가상계좌가 발급된 주문은 기한이 지나도 만료 대상이 아니다", async () => {
-      const userId = new mongoose.Types.ObjectId().toString();
-      const order = await createOrderService(buildOrderInputForTest({ userId }));
-      await OrderModel.updateOne(
-        { _id: order._id },
-        { $set: { paymentId: new mongoose.Types.ObjectId() } },
-      );
-      await setCreatedAt(order._id, new Date(Date.now() - 72 * 60 * 60 * 1000));
-
-      await cancelExpiredPendingOrders(userId);
-
-      const untouched = await OrderModel.findById(order._id).lean();
-      expect(untouched?.orderStatus).toBe("PENDING");
-    });
-
-    it("가상계좌 결제수단 주문은 결제 동기화 전이어도 만료 대상이 아니다", async () => {
-      const userId = new mongoose.Types.ObjectId().toString();
-      // paymentId는 syncPayment가 발급을 확인한 뒤에야 붙는다 — 그 전 구간을 본다.
-      const order = await createOrderService(
-        buildOrderInputForTest({ userId, payMethod: "VIRTUAL_ACCOUNT" }),
-      );
-      await setCreatedAt(order._id, new Date(Date.now() - 72 * 60 * 60 * 1000));
-
-      await cancelExpiredPendingOrders(userId);
-
-      const untouched = await OrderModel.findById(order._id).lean();
-      expect(untouched?.orderStatus).toBe("PENDING");
-    });
-
-    it("아직 24시간이 안 지난 주문은 그대로 둔다", async () => {
-      const userId = new mongoose.Types.ObjectId().toString();
-      const order = await createOrderService(buildOrderInputForTest({ userId }));
-      await setCreatedAt(order._id, new Date(Date.now() - 23 * 60 * 60 * 1000));
-
-      await cancelExpiredPendingOrders(userId);
-
-      const untouched = await OrderModel.findById(order._id).lean();
-      expect(untouched?.orderStatus).toBe("PENDING");
-    });
-  });
+  // cancelExpiredPendingOrders는 취소 전 PG 실제 상태를 확인하도록 payment.ts로
+  // 이관됐다(GH #78) — 관련 테스트는 src/services/payment.integration.test.ts의
+  // describe("cancelExpiredPendingOrders", ...)로 옮겼다.
 });

--- a/src/services/order.ts
+++ b/src/services/order.ts
@@ -416,42 +416,32 @@ export const cancelPendingOrderForCurrentUser = async (
 };
 
 /**
- * 결제창을 벗어난 채 방치된 주문의 자동취소 — paymentId가 없는 PENDING만 대상이다.
- * 가상계좌 발급 주문(paymentId 있음)은 입금 대기 중인 정상 주문이므로 제외한다,
- * 여기 끌어들이면 입금받고 주문을 죽이는 결과가 된다. 결제 전 주문이라 PortOne
- * 환불이 필요 없어 DB 상태 전이만 한다.
+ * 결제창을 벗어난 채 방치된 주문(자동취소 후보)을 조회한다 — paymentId가 없는
+ * PENDING만 대상이다. 가상계좌 발급 주문(paymentId 있음)은 입금 대기 중인 정상
+ * 주문이므로 제외한다, 여기 끌어들이면 입금받고 주문을 죽이는 결과가 된다.
+ * 순수 조회만 담당하고 취소 전 PG 실제 상태 확인은 payment.service의
+ * 오케스트레이션이 맡는다(findExpiredAwaitingInvitationOrders와 대칭 — order.service가
+ * payment.service를 import하면 순환 의존이 생긴다). 오케스트레이션 쪽이 같은
+ * `deadline`으로 취소 대상을 다시 걸러야 하므로 함께 리턴한다.
  */
-export const cancelExpiredPendingOrders = async (
+export const findExpiredPendingOrders = async (
   userId: string | mongoose.Types.ObjectId,
-): Promise<void> => {
+): Promise<{ orders: IOrder[]; deadline: Date }> => {
   await dbConnect();
 
   const deadline = new Date(
     Date.now() - PENDING_ORDER_EXPIRE_HOURS * 60 * 60 * 1000,
   );
 
-  await OrderModel.updateMany(
-    {
-      userId,
-      orderStatus: "PENDING",
-      paymentId: null,
-      // paymentId는 syncPayment가 가상계좌 발급을 확인한 뒤에 붙는다 — 발급 직후
-      // 사용자가 창을 닫아 아직 동기화되지 않은 주문까지 덮으려면 결제수단도 본다.
-      payMethod: { $ne: "VIRTUAL_ACCOUNT" },
-      createdAt: { $lt: deadline },
-    },
-    {
-      $set: {
-        orderStatus: "CANCELLED",
-        cancelledAt: new Date(),
-        cancelReason: PENDING_ORDER_CANCEL_REASONS.expired,
-      },
-    },
-    { runValidators: true },
-  ).catch((err) => {
-    throw new AppError(
-      "INTERNAL",
-      err instanceof Error ? err.message : "만료 주문 취소에 실패했습니다.",
-    );
-  });
+  const orders = await OrderModel.find({
+    userId,
+    orderStatus: "PENDING",
+    paymentId: null,
+    // paymentId는 syncPayment가 가상계좌 발급을 확인한 뒤에 붙는다 — 발급 직후
+    // 사용자가 창을 닫아 아직 동기화되지 않은 주문까지 덮으려면 결제수단도 본다.
+    payMethod: { $ne: "VIRTUAL_ACCOUNT" },
+    createdAt: { $lt: deadline },
+  }).lean<IOrder[]>();
+
+  return { orders, deadline };
 };

--- a/src/services/payment.integration.test.ts
+++ b/src/services/payment.integration.test.ts
@@ -9,6 +9,7 @@ import {
 import { ProductModel, OrderModel, PaymentModel } from "@/models";
 import { createProductService } from "./product";
 import { createOrderService } from "./order";
+import type * as AuthModule from "./auth";
 
 const { getPaymentMock, cancelPaymentMock } = vi.hoisted(() => ({
   getPaymentMock: vi.fn(),
@@ -25,11 +26,29 @@ vi.mock("@portone/server-sdk", () => {
   };
 });
 
+// 세션 조회만 대체한다 — 쿠키/JWT는 이 파일의 검증 대상이 아니고, 나머지 auth 구현은
+// 그대로 둔다(partial mock, order.integration.test.ts와 동일 패턴).
+const { authState } = vi.hoisted(() => ({ authState: { userId: "" } }));
+
+vi.mock("./auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof AuthModule>();
+  return {
+    ...actual,
+    requireAuth: async () => ({
+      userId: authState.userId,
+      email: "buyer@example.com",
+      role: "USER",
+    }),
+  };
+});
+
 import { PortOneError } from "@portone/server-sdk";
 import {
   syncPayment,
   cancelPayment,
   cancelExpiredAwaitingInvitationOrders,
+  cancelExpiredPendingOrders,
+  completePaymentService,
 } from "./payment";
 
 describe("payment", () => {
@@ -990,6 +1009,192 @@ describe("payment", () => {
       const updatedOrder2 = await OrderModel.findById(order2._id).lean();
       expect(updatedOrder1?.orderStatus).toBe("CONFIRMED");
       expect(updatedOrder2?.orderStatus).toBe("CANCELLED");
+    });
+  });
+
+  describe("cancelExpiredPendingOrders", () => {
+    // order.ts에서 payment.ts로 이관되면서(GH #78, 취소 전 PG 확인 추가) 여기로
+    // 옮겨온 기존 테스트들 — 이관 전엔 PortOne을 아예 호출하지 않았지만, 이제는
+    // 후보로 걸리는 케이스마다 getPaymentMock을 명시적으로 세팅해야 한다.
+    const setCreatedAt = async (
+      orderId: mongoose.Types.ObjectId,
+      createdAt: Date,
+    ) => {
+      await OrderModel.updateOne(
+        { _id: orderId },
+        { $set: { createdAt } },
+        { timestamps: false, overwriteImmutable: true },
+      );
+    };
+
+    it("24시간이 지났고 PortOne에 한 번도 제출 안 된(조회 자체가 실패하는) 주문은 자동취소한다", async () => {
+      const { order } = await setupProductAndOrder(1);
+      await setCreatedAt(order._id, new Date(Date.now() - 25 * 60 * 60 * 1000));
+      // 실제 PortOneError는 abstract class라 직접 new할 수 없다(위 "PortOne SDK 자체
+      // 오류" 테스트와 동일한 이유로 캐스팅).
+      const PortOneErrorCtor = PortOneError as unknown as new (
+        message: string,
+      ) => Error;
+      getPaymentMock.mockRejectedValue(new PortOneErrorCtor("no such payment"));
+
+      await cancelExpiredPendingOrders(order.userId.toString());
+
+      const updated = await OrderModel.findById(order._id).lean();
+      expect(updated?.orderStatus).toBe("CANCELLED");
+      expect(updated?.cancelReason).toBe("결제 미완료로 인한 자동 취소");
+    });
+
+    it("가상계좌가 발급된 주문(paymentId 있음)은 기한이 지나도 만료 대상이 아니다", async () => {
+      const { order } = await setupProductAndOrder(1);
+      await OrderModel.updateOne(
+        { _id: order._id },
+        { $set: { paymentId: new mongoose.Types.ObjectId() } },
+      );
+      await setCreatedAt(order._id, new Date(Date.now() - 72 * 60 * 60 * 1000));
+
+      await cancelExpiredPendingOrders(order.userId.toString());
+
+      expect(getPaymentMock).not.toHaveBeenCalled();
+      const untouched = await OrderModel.findById(order._id).lean();
+      expect(untouched?.orderStatus).toBe("PENDING");
+    });
+
+    it("아직 24시간이 안 지난 주문은 PG 조회 없이 그대로 둔다", async () => {
+      const { order } = await setupProductAndOrder(1);
+      await setCreatedAt(order._id, new Date(Date.now() - 23 * 60 * 60 * 1000));
+
+      await cancelExpiredPendingOrders(order.userId.toString());
+
+      expect(getPaymentMock).not.toHaveBeenCalled();
+      const untouched = await OrderModel.findById(order._id).lean();
+      expect(untouched?.orderStatus).toBe("PENDING");
+    });
+
+    // ── GH #78 Part B 결함 수정 검증 — "동기화 후에도 PENDING이면 무조건 취소"였던
+    // 최초 설계는 PG상 PAID인데 검증/트랜잭션만 실패한 주문까지 취소해버려 이슈
+    // 원래 버그(PAID 주문 오취소)를 재현했다. outcome 기반 필터링으로 고정한다.
+    it("만료됐지만 PG상 PAID였던 주문은 취소하지 않고 CONFIRMED로 동기화한다", async () => {
+      const { savedProduct, order } = await setupProductAndOrder(1);
+      await setCreatedAt(order._id, new Date(Date.now() - 25 * 60 * 60 * 1000));
+      getPaymentMock.mockResolvedValue(
+        paidPayload(
+          order.merchantUid,
+          savedProduct._id.toString(),
+          order.finalPrice,
+        ),
+      );
+
+      await cancelExpiredPendingOrders(order.userId.toString());
+
+      const updated = await OrderModel.findById(order._id).lean();
+      expect(updated?.orderStatus).toBe("CONFIRMED");
+      expect(updated?.cancelReason).toBeUndefined();
+    });
+
+    it("만료됐고 실제로 미결제(READY)인 주문은 그대로 취소된다", async () => {
+      const { order } = await setupProductAndOrder(1);
+      await setCreatedAt(order._id, new Date(Date.now() - 25 * 60 * 60 * 1000));
+      getPaymentMock.mockResolvedValue({ status: "READY", id: order.merchantUid });
+
+      await cancelExpiredPendingOrders(order.userId.toString());
+
+      const updated = await OrderModel.findById(order._id).lean();
+      expect(updated?.orderStatus).toBe("CANCELLED");
+      expect(updated?.cancelReason).toBe("결제 미완료로 인한 자동 취소");
+    });
+
+    it("PG상 PAID인데 검증 실패(VALIDATION)로 동기화가 실패하면 취소하지 않고 PENDING을 유지한다", async () => {
+      const { savedProduct, order } = await setupProductAndOrder(1);
+      await setCreatedAt(order._id, new Date(Date.now() - 25 * 60 * 60 * 1000));
+      // 금액 불일치 → syncPayment가 AppError(VALIDATION)를 던진다(위 "PAID 상태
+      // 처리" 스위트의 동일 케이스 참고) — EXTERNAL_SERVICE가 아니므로 취소
+      // 후보에서 빠져야 한다.
+      getPaymentMock.mockResolvedValue(
+        paidPayload(
+          order.merchantUid,
+          savedProduct._id.toString(),
+          order.finalPrice + 1000,
+        ),
+      );
+
+      await cancelExpiredPendingOrders(order.userId.toString());
+
+      const untouched = await OrderModel.findById(order._id).lean();
+      expect(untouched?.orderStatus).toBe("PENDING");
+      expect(untouched?.cancelReason).toBeUndefined();
+    });
+
+    it("한 후보의 동기화 실패가 같은 유저의 다른 만료 후보 처리를 막지 않는다", async () => {
+      const { savedProduct, order: order1 } = await setupProductAndOrder(1);
+      await setCreatedAt(order1._id, new Date(Date.now() - 25 * 60 * 60 * 1000));
+
+      const { order: order2 } = await setupProductAndOrder(1);
+      await OrderModel.updateOne(
+        { _id: order2._id },
+        { userId: order1.userId },
+      );
+      await setCreatedAt(order2._id, new Date(Date.now() - 25 * 60 * 60 * 1000));
+
+      getPaymentMock.mockImplementation(({ paymentId }: { paymentId: string }) => {
+        if (paymentId === order1.merchantUid) {
+          // PG상 PAID인데 검증 실패 — 취소 보류 대상(취소되면 안 됨)
+          return Promise.resolve(
+            paidPayload(
+              order1.merchantUid,
+              savedProduct._id.toString(),
+              order1.finalPrice + 1000,
+            ),
+          );
+        }
+        // 진짜 미결제 — 취소 대상
+        return Promise.resolve({ status: "READY", id: order2.merchantUid });
+      });
+
+      await expect(
+        cancelExpiredPendingOrders(order1.userId.toString()),
+      ).resolves.toBeUndefined();
+
+      const updatedOrder1 = await OrderModel.findById(order1._id).lean();
+      const updatedOrder2 = await OrderModel.findById(order2._id).lean();
+      expect(updatedOrder1?.orderStatus).toBe("PENDING");
+      expect(updatedOrder2?.orderStatus).toBe("CANCELLED");
+    });
+  });
+
+  describe("completePaymentService", () => {
+    it("본인 소유 주문이면 PG 상태를 동기화하고 결과를 리턴한다", async () => {
+      const { savedProduct, order } = await setupProductAndOrder(1);
+      authState.userId = order.userId.toString();
+      getPaymentMock.mockResolvedValue(
+        paidPayload(
+          order.merchantUid,
+          savedProduct._id.toString(),
+          order.finalPrice,
+        ),
+      );
+
+      const status = await completePaymentService(order.merchantUid);
+
+      expect(status).toBe("PAID");
+    });
+
+    it("다른 유저의 merchantUid로 호출하면 FORBIDDEN을 던지고 PortOne을 조회하지 않는다", async () => {
+      const { order } = await setupProductAndOrder(1);
+      authState.userId = new mongoose.Types.ObjectId().toString();
+
+      await expect(
+        completePaymentService(order.merchantUid),
+      ).rejects.toMatchObject({ category: "FORBIDDEN" });
+      expect(getPaymentMock).not.toHaveBeenCalled();
+    });
+
+    it("존재하지 않는 merchantUid면 NOT_FOUND를 던진다", async () => {
+      authState.userId = new mongoose.Types.ObjectId().toString();
+
+      await expect(
+        completePaymentService("no-such-merchant-uid"),
+      ).rejects.toMatchObject({ category: "NOT_FOUND" });
+      expect(getPaymentMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/payment.ts
+++ b/src/services/payment.ts
@@ -13,6 +13,8 @@ import { getProductService } from "./product";
 import {
   getOrderSeviceByMerchantUid,
   findExpiredAwaitingInvitationOrders,
+  findExpiredPendingOrders,
+  PENDING_ORDER_CANCEL_REASONS,
 } from "./order";
 import { AppError } from "@/core/domain";
 import { dbConnect } from "@/db";
@@ -472,7 +474,7 @@ export const syncPayment = async (paymentId: string) => {
 
     // 가상계좌 발급 — 아직 입금 전이지만 계좌번호·입금기한을 사용자에게 안내해야 하고,
     // 주문이 결제를 참조해야 "결제창을 벗어난 방치 주문"과 구분돼 자동취소 대상에서
-    // 빠진다(order.service의 cancelExpiredPendingOrders). Payment 저장 + Order 참조
+    // 빠진다(findExpiredPendingOrders의 쿼리 필터, order.service). Payment 저장 + Order 참조
     // 연결은 하나의 논리적 단위라 트랜잭션으로 묶는다(PAID 분기와 같은 이유).
     if (actualPayment.status === "VIRTUAL_ACCOUNT_ISSUED") {
       const issuedPayment = actualPayment as VirtualAccountIssuedPayment;
@@ -639,13 +641,98 @@ export const cancelExpiredAwaitingInvitationOrders = async (
   );
 };
 
+/**
+ * 결제창을 벗어난 채 방치된 주문의 자동취소 — 취소 전 PG 실제 상태를 먼저
+ * 확인한다(PAID인데 DB 동기화만 실패한 주문을 시간만 보고 잘못 취소하는 회귀
+ * 방지, GH #78). order.service의 findExpiredPendingOrders(순수 조회)와 결합하는
+ * 오케스트레이션 — cancelExpiredAwaitingInvitationOrders와 같은 이유로 여기 위치.
+ *
+ * syncPayment가 실패해도 이유에 따라 취소 여부를 가른다 — PG 쪽 조회 자체가 안
+ * 되는 경우(AppError EXTERNAL_SERVICE, "한 번도 PortOne에 제출 안 된 merchantUid"의
+ * 실제 시그널)만 "확인 결과 미결제"로 취급해 취소 후보에 남긴다. PG는 PAID인데
+ * verifyPayment 검증(VALIDATION)이나 트랜잭션(INTERNAL)만 실패한 경우까지 취소해
+ * 버리면 이슈의 원래 버그(PAID 주문 오취소)를 그대로 재현하게 되므로, 이 경우는
+ * 취소하지 않고 PENDING으로 남겨 수동 검토 대상으로 뺀다. 개별 주문 동기화 실패가
+ * 다른 주문 처리를 막지 않도록 격리한다(cancelExpiredAwaitingInvitationOrders와 동일).
+ */
+export const cancelExpiredPendingOrders = async (
+  userId: string | mongoose.Types.ObjectId,
+): Promise<void> => {
+  const { orders: candidates, deadline } =
+    await findExpiredPendingOrders(userId);
+  if (candidates.length === 0) return;
+
+  const outcomes = await Promise.allSettled(
+    candidates.map((order) => syncPayment(order.merchantUid)),
+  );
+
+  const cancelableIds = candidates
+    .filter((order, i) => {
+      const outcome = outcomes[i];
+      // PAID였다면 syncPayment가 이미 CONFIRMED로 전이시켰다 — 아래 updateMany의
+      // orderStatus:"PENDING" 조건에서 자연히 제외된다.
+      if (outcome.status === "fulfilled") return true;
+
+      const reason = outcome.reason;
+      if (reason instanceof AppError && reason.category === "EXTERNAL_SERVICE") {
+        return true;
+      }
+
+      console.error(
+        `[cancelExpiredPendingOrders] ${order.merchantUid} 동기화 실패(취소 보류, 수동 검토 필요):`,
+        reason,
+      );
+      return false;
+    })
+    .map((order) => order._id);
+
+  if (cancelableIds.length === 0) return;
+
+  await OrderModel.updateMany(
+    {
+      _id: { $in: cancelableIds },
+      orderStatus: "PENDING",
+      paymentId: null,
+      payMethod: { $ne: "VIRTUAL_ACCOUNT" },
+      createdAt: { $lt: deadline },
+    },
+    {
+      $set: {
+        orderStatus: "CANCELLED",
+        cancelledAt: new Date(),
+        cancelReason: PENDING_ORDER_CANCEL_REASONS.expired,
+      },
+    },
+    { runValidators: true },
+  ).catch((err) => {
+    throw new AppError(
+      "INTERNAL",
+      err instanceof Error ? err.message : "만료 주문 취소에 실패했습니다.",
+    );
+  });
+};
+
 export async function completePaymentService(
   paymentId: string,
 ): Promise<PayStatus> {
-  await requireAuth();
+  const { userId } = await requireAuth();
   if (!paymentId) {
     throw new AppError("VALIDATION", "올바르지 않은 요청입니다.");
   }
+
+  // completePayment 액션은 이제 방금 자신이 만든 merchantUid뿐 아니라
+  // PaymentButton(다른 세션에서 만들어진 주문 목록)에서 넘어온 merchantUid로도
+  // 호출된다 — 소유권을 세션에서 다시 조회해 대조한다(src/actions/AGENTS.md).
+  // syncPayment 자체에는 이 체크를 넣지 않는다 — webhook(세션 없음)과
+  // cancelExpiredPendingOrders(이미 userId로 스코프됨)가 세션 없이 직접 호출한다.
+  const order = await getOrderSeviceByMerchantUid(paymentId);
+  if (!order) {
+    throw new AppError("NOT_FOUND", "주문을 찾을 수 없습니다.");
+  }
+  if (order.userId.toString() !== userId) {
+    throw new AppError("FORBIDDEN", "본인 주문만 결제 확인할 수 있습니다.");
+  }
+
   const payment = await syncPayment(paymentId);
   if (!payment) {
     throw new AppError("INTERNAL", "결제 동기화에 실패했습니다.");

--- a/src/ui/stores/order.store.ts
+++ b/src/ui/stores/order.store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import type { CheckoutItem } from "@/core/domain";
 import type { PayStatus } from "@/core/domain";
+import type { CreateOrderResult } from "@/actions";
 
 interface OrderState {
   order: CheckoutItem | null;
@@ -11,6 +12,12 @@ interface OrderState {
   setPaymentStatus: (status: PayStatus | "IDLE") => void;
   _hasHydrated: boolean;
   setHasHydrated: (state: boolean) => void;
+  // PENDING 주문 재결제(GH #78) — PG상 진짜 미결제로 확인된 기존 주문을 같은
+  // merchantUid로 재시도할 때 PaymentButton이 채우고, CheckoutForm이 이 값이
+  // 있으면 buyer info 폼 대신 재결제 확인 뷰를 렌더한다.
+  resumePayment: CreateOrderResult | null;
+  setResumePayment: (data: CreateOrderResult) => void;
+  clearResumePayment: () => void;
 }
 
 export const useOrderStore = create<OrderState>()(
@@ -18,19 +25,25 @@ export const useOrderStore = create<OrderState>()(
     (set) => ({
       order: null as CheckoutItem | null,
       // order 트리거 시점(구매하기/결제하기)과 paymentStatus 트리거 시점(체크아웃 폼 제출)이
-      // 서로 달라, 리셋 안 하면 이전 결제 시도의 상태가 새 주문으로 새어 들어간다.
-      setOrder: (orderData) => set({ order: orderData, paymentStatus: "IDLE" }),
-      clearOrder: () => set({ order: null }),
+      // 서로 달라, 리셋 안 하면 이전 결제 시도의 상태가 새 주문으로 새어 들어간다. 같은 이유로
+      // resumePayment도 같이 리셋한다 — 안 하면 새 주문(구매하기)에 이전 재결제 시도가 새어든다.
+      setOrder: (orderData) =>
+        set({ order: orderData, paymentStatus: "IDLE", resumePayment: null }),
+      clearOrder: () => set({ order: null, resumePayment: null }),
       paymentStatus: "IDLE",
       setPaymentStatus: (status) => set({ paymentStatus: status }),
       _hasHydrated: false,
       setHasHydrated: (state) => set({ _hasHydrated: state }),
+      resumePayment: null as CreateOrderResult | null,
+      setResumePayment: (data) => set({ resumePayment: data }),
+      clearResumePayment: () => set({ resumePayment: null }),
     }),
     {
       name: "order-storage",
       storage: createJSONStorage(() => sessionStorage),
-      partialize: (state): Pick<OrderState, "order"> => ({
+      partialize: (state): Pick<OrderState, "order" | "resumePayment"> => ({
         order: state.order,
+        resumePayment: state.resumePayment,
       }),
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true);


### PR DESCRIPTION
## Summary

- PG(PortOne)에서는 이미 승인됐지만 DB 반영이 실패해 `orderStatus: "PENDING"`, `paymentId` 미설정으로 남은 주문에 "결제하기"를 누르면, PG 상태 확인 없이 새 `merchantUid`로 새 주문을 만들어 실제 결제가 한 번 더 일어나던 문제(401 장애 기간 실제 3건 발생)를 수정한다.
- `PaymentButton`은 클릭 시 `completePayment`(PG 조회+동기화)를 먼저 호출한다. 이미 PAID면 새 주문 생성 없이 주문 상세 페이지로 이동하고, 진짜 미결제면 같은 `merchantUid`로 재결제한다(버이어 정보 재입력 없이 `/payment`의 새 재결제 확인 뷰에서 사용자가 직접 클릭 → PortOne 팝업, 팝업 차단 방지 위해 자동 트리거 안 함).
- `cancelExpiredPendingOrders`(24시간 경과 PENDING 자동취소)도 같은 원인의 버그가 있었다 — PG 확인 없이 시간만 보고 취소해 PAID인데 DB만 안 된 주문을 "결제 미완료로 인한 자동 취소"로 오분류했다. 취소 전 PG 실제 상태를 먼저 확인하도록 고쳤고(`order.ts`의 순수 조회 `findExpiredPendingOrders` / `payment.ts`의 오케스트레이션으로 분리, 기존 `cancelExpiredAwaitingInvitationOrders` 패턴과 동일 구조), PortOne 조회 자체가 실패한 경우(한 번도 제출 안 된 주문)만 취소 대상으로 삼고 PG는 PAID인데 검증/트랜잭션만 실패한 경우는 취소하지 않고 수동 검토로 남긴다.
- `completePaymentService`가 이제 목록에서 넘어온 merchantUid로도 호출되므로, 소유권 검증(다른 유저 주문이면 `FORBIDDEN`)을 추가했다.

## Test plan

- `npm run tsc` — 통과
- `npm run lint` — 통과
- `npm run test` — 126개 파일, 717개 테스트 전부 통과(신규 서비스 통합테스트 12개, 컴포넌트 테스트 3개 포함)
- 수동 브라우저 검증은 하지 않음: `Not run: PortOne 테스트 키/PG상 PAID-DB PENDING 불일치 상태 재현이 로컬에서 어려움`
