### PR TITLE
fix: 카카오맵 API 비-JSON 응답을 분류된 에러로 처리한다

### DIFF
--- a/src/app/api/kakaomap/route.test.ts
+++ b/src/app/api/kakaomap/route.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function mockResponse(status: number, ok: boolean, body: string): Response {
+  return {
+    ok,
+    status,
+    text: async () => body,
+  } as Response;
+}
+
+const buildRequest = (address: string) =>
+  new NextRequest(`http://localhost/api/kakaomap?address=${encodeURIComponent(address)}`);
+
+describe("GET /api/kakaomap", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("정상 JSON 응답이면 200과 데이터를 리턴한다", async () => {
+    const body = JSON.stringify({ documents: [{ address_name: "서울시 강남구" }] });
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(200, true, body));
+
+    const res = await GET(buildRequest("강남구"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({
+      success: true,
+      data: { documents: [{ address_name: "서울시 강남구" }] },
+    });
+  });
+
+  it("ok:false이고 JSON 에러 본문이면 502 EXTERNAL_SERVICE를 리턴한다", async () => {
+    const body = JSON.stringify({ errorType: "InvalidArgumentError", message: "query is required" });
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(400, false, body));
+
+    const res = await GET(buildRequest(""));
+    const json = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(json.success).toBe(false);
+    expect(json.error.category).toBe("EXTERNAL_SERVICE");
+  });
+
+  it("ok:true이지만 비-JSON(HTML 에러 페이지) 본문이면 502 EXTERNAL_SERVICE로 분류한다", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      mockResponse(200, true, "<html><body>Bad Gateway</body></html>"),
+    );
+
+    const res = await GET(buildRequest("강남구"));
+    const json = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(json.success).toBe(false);
+    expect(json.error.category).toBe("EXTERNAL_SERVICE");
+  });
+
+  it("ok:false이고 비-JSON 본문이면 SyntaxError로 죽지 않고 502 EXTERNAL_SERVICE로 분류한다", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(502, false, "<html>Bad Gateway</html>"));
+
+    const res = await GET(buildRequest("강남구"));
+    const json = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(json.success).toBe(false);
+    expect(json.error.category).toBe("EXTERNAL_SERVICE");
+  });
+
+  it("fetch 자체가 reject되면 502 EXTERNAL_SERVICE로 정규화한다", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError("fetch failed"));
+
+    const res = await GET(buildRequest("강남구"));
+    const json = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(json.success).toBe(false);
+    expect(json.error.category).toBe("EXTERNAL_SERVICE");
+  });
+});

--- a/src/app/api/kakaomap/route.ts
+++ b/src/app/api/kakaomap/route.ts
@@ -12,14 +12,31 @@ export const GET = async (
     const address = searchParams.get("address");
     const REST_API_KEY = process.env.KAKAO_REST_API_KEY;
 
-    const response = await fetch(
-      `https://dapi.kakao.com/v2/local/search/address?query=${address}`,
-      {
-        headers: { Authorization: `KakaoAK ${REST_API_KEY}` },
-      },
-    );
+    let response: Response;
+    try {
+      response = await fetch(
+        `https://dapi.kakao.com/v2/local/search/address?query=${address}`,
+        {
+          headers: { Authorization: `KakaoAK ${REST_API_KEY}` },
+        },
+      );
+    } catch (error) {
+      throw new AppError(
+        "EXTERNAL_SERVICE",
+        `카카오맵 API 요청 실패: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
 
-    const data = await response.json();
+    const text = await response.text();
+    let data: KakaomapResponse & { errorType?: string; message?: string };
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new AppError(
+        "EXTERNAL_SERVICE",
+        `카카오맵 API가 JSON이 아닌 응답을 반환함 (status=${response.status}): ${text.slice(0, 300)}`,
+      );
+    }
 
     if (!response.ok || data.errorType) {
       throw new AppError(


### PR DESCRIPTION
## Summary

- 카카오맵 API가 비-2xx 상태에서 JSON이 아닌 본문(HTML 에러 페이지 등)을 반환하면 `response.json()`에서 `SyntaxError`가 던져져 `AppError` 분류를 타지 못하고 `[Route] Unknown error`로 로그가 찍혔다(#89, #85에서 발견된 것과 동일 계열 버그, #90에서 서울 열린데이터광장 API 쪽은 이미 수정됨).
- `response.text()`로 먼저 읽고 `JSON.parse`를 try/catch로 감싸, 비-JSON 본문과 `fetch` 자체 실패 모두 `AppError("EXTERNAL_SERVICE", ...)`로 분류되게 했다.

## Test plan

- `npx tsc --noEmit -p .` — 통과
- `npx eslint src/app/api/kakaomap/` — 통과
- `npx vitest run --project unit src/app/api/kakaomap/route.test.ts` — 신규 5케이스(정상/JSON 에러/비-JSON 본문 ok true·false/fetch reject) 통과
- `npx vitest run --project unit` — 172 pass, 1 fail(`src/proxy.test.ts`, `JWT_SECRET is not defined` — 워크트리 `.env` 미반영으로 인한 무관한 환경설정 실패, 이번 변경과 무관)

Closes #89