### PR TITLE
docs: 상품 카테고리 문서의 경로 표기를 정정한다

### DIFF
--- a/src/app/(main)/(products)/products/AGENTS.md
+++ b/src/app/(main)/(products)/products/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — src/app/(main)/(products)/products/
 
-> Last updated: 2026-07-29
+> Last updated: 2026-08-20
 
 ## Overview
 
@@ -9,4 +9,4 @@
 ## Critical Convention
 
 - 카테고리는 경로 세그먼트로 구분한다(`/products/[category]`, `routes.products.byCategory`) — 상품 상세는 `/products/[category]/[id]`로 그 아래 중첩한다. Next.js는 같은 레벨의 형제 dynamic segment가 서로 다른 이름을 갖는 걸 허용하지 않는다("You cannot use different slug names for the same dynamic path", 공식 문서 근거) — `[category]`와 `[id]`를 형제로 두면 이 제약에 걸려서, `[id]`를 `[category]` 하위로 중첩했다.
-- 새 카테고리 추가 절차(타입 확장부터 시작)는 `src/core/constants/AGENTS.md` 참고 — `product-category.ts`가 단일 소스다.
+- 새 카테고리 추가 절차(타입 확장부터 시작)는 `src/core/domain/product-category.ts`가 단일 소스다.


### PR DESCRIPTION
## Summary

- `src/app/(main)/(products)/products/AGENTS.md`가 새 카테고리 추가 절차에서 `src/core/constants/AGENTS.md`를 참고하라며 `product-category.ts`를 그 아래 단일 소스로 지목했으나, `src/core/constants/` 폴더 자체가 `src/core/domain/`으로 통합되며 사라져 존재하지 않는 경로였다.
- 실제 위치인 `src/core/domain/product-category.ts`를 직접 가리키도록 정정했다(그 경로엔 폴더 단위 AGENTS.md가 없어 파일을 직접 링크).

## Test plan

- 문서 변경만 — 코드 변경 없음. 참조 경로(`src/core/domain/product-category.ts`) 실존 확인(`test -f`)

Closes #73