### PR TITLE
fix: 포트원 에러 로그에 원인 판별 정보를 남긴다

### DIFF
--- a/src/services/payment.integration.test.ts
+++ b/src/services/payment.integration.test.ts
@@ -18,11 +18,20 @@ const { getPaymentMock, cancelPaymentMock } = vi.hoisted(() => ({
 
 vi.mock("@portone/server-sdk", () => {
   class PortOneError extends Error {}
+  // 실제 SDK와 동일: RestError extends PortOneError, data를 들고 message는 data.message에서 뽑는다
+  class RestError extends PortOneError {
+    data: { type: string; message?: string };
+    constructor(data: { type: string; message?: string }) {
+      super(data.message);
+      this.data = data;
+    }
+  }
   return {
     PortOneClient: () => ({
       payment: { getPayment: getPaymentMock, cancelPayment: cancelPaymentMock },
     }),
     PortOneError,
+    RestError,
   };
 });
 
@@ -42,7 +51,7 @@ vi.mock("./auth", async (importOriginal) => {
   };
 });
 
-import { PortOneError } from "@portone/server-sdk";
+import { PortOneError, RestError } from "@portone/server-sdk";
 import {
   syncPayment,
   cancelPayment,
@@ -831,9 +840,51 @@ describe("payment", () => {
         new PortOneErrorCtor("포트원 서버 오류"),
       );
 
-      await expect(syncPayment(order.merchantUid)).rejects.toMatchObject({
-        category: "EXTERNAL_SERVICE",
-      });
+      const error = await syncPayment(order.merchantUid).catch((e) => e);
+
+      expect(error).toMatchObject({ category: "EXTERNAL_SERVICE" });
+      // RestError가 아닌 PortOneError는 type을 알 수 없다 — UNKNOWN 폴백.
+      expect(error.message).toContain("type=UNKNOWN");
+      expect(error.message).toContain(order.merchantUid);
+    });
+
+    it("RestError(UNAUTHORIZED, message 없음)면 type과 merchantUid가 로그에 남고 빈 message는 폴백 문구로 대체된다", async () => {
+      const { order } = await setupProductAndOrder(1);
+      const RestErrorCtor = RestError as unknown as new (data: {
+        type: string;
+        message?: string;
+      }) => Error;
+      getPaymentMock.mockRejectedValue(
+        new RestErrorCtor({ type: "UNAUTHORIZED" }),
+      );
+
+      const error = await syncPayment(order.merchantUid).catch((e) => e);
+
+      expect(error).toMatchObject({ category: "EXTERNAL_SERVICE" });
+      expect(error.message).toContain("type=UNAUTHORIZED");
+      expect(error.message).toContain(order.merchantUid);
+      expect(error.message).toContain("(SDK 메시지 없음)");
+    });
+
+    it("RestError(PAYMENT_NOT_FOUND, message 있음)면 SDK 원문 메시지가 그대로 남는다", async () => {
+      const { order } = await setupProductAndOrder(1);
+      const RestErrorCtor = RestError as unknown as new (data: {
+        type: string;
+        message?: string;
+      }) => Error;
+      getPaymentMock.mockRejectedValue(
+        new RestErrorCtor({
+          type: "PAYMENT_NOT_FOUND",
+          message: "결제 건을 찾을 수 없습니다",
+        }),
+      );
+
+      const error = await syncPayment(order.merchantUid).catch((e) => e);
+
+      expect(error).toMatchObject({ category: "EXTERNAL_SERVICE" });
+      expect(error.message).toContain("type=PAYMENT_NOT_FOUND");
+      expect(error.message).toContain("결제 건을 찾을 수 없습니다");
+      expect(error.message).not.toContain("(SDK 메시지 없음)");
     });
   });
 
@@ -898,6 +949,37 @@ describe("payment", () => {
       ).rejects.toMatchObject({
         category: "EXTERNAL_SERVICE",
       });
+
+      const updatedOrder = await OrderModel.findById(order._id).lean();
+      expect(updatedOrder?.orderStatus).toBe("CONFIRMED");
+    });
+
+    it("PortOne 취소 API가 RestError(UNAUTHORIZED)를 던지면 type과 merchantUid가 로그에 남고 상태를 바꾸지 않는다", async () => {
+      const { savedProduct, order } = await setupProductAndOrder(1);
+      getPaymentMock.mockResolvedValue(
+        paidPayload(
+          order.merchantUid,
+          savedProduct._id.toString(),
+          order.finalPrice,
+        ),
+      );
+      await syncPayment(order.merchantUid);
+
+      const RestErrorCtor = RestError as unknown as new (data: {
+        type: string;
+        message?: string;
+      }) => Error;
+      cancelPaymentMock.mockRejectedValue(
+        new RestErrorCtor({ type: "UNAUTHORIZED" }),
+      );
+
+      const error = await cancelPayment(order.merchantUid, "사유").catch(
+        (e) => e,
+      );
+
+      expect(error).toMatchObject({ category: "EXTERNAL_SERVICE" });
+      expect(error.message).toContain("type=UNAUTHORIZED");
+      expect(error.message).toContain(order.merchantUid);
 
       const updatedOrder = await OrderModel.findById(order._id).lean();
       expect(updatedOrder?.orderStatus).toBe("CONFIRMED");

--- a/src/services/payment.ts
+++ b/src/services/payment.ts
@@ -253,6 +253,28 @@ async function verifyPayment(payment: PaidPayment): Promise<boolean> {
 }
 
 /**
+ * PortOne 에러의 로그용 컨텍스트 문자열 — AppError.message에 실려 boundary.ts의
+ * toErrorPayload가 서버 로그에만 찍고, 클라이언트로는 EXTERNAL_SERVICE 안전문구로
+ * 치환돼 나간다(docs/architecture/error-handling.md 민감분류 규칙).
+ *
+ * SDK 제약: RestError에는 HTTP status 필드가 없다(constructor가 data만 wrap).
+ * data.type("UNAUTHORIZED"/"PAYMENT_NOT_FOUND" 등)이 사실상 그 식별자 역할을 한다.
+ * data.type의 타입은 string | unique symbol(Unrecognized)이라 typeof 가드가 필수다.
+ */
+const portOneErrorContext = (
+  e: PortOne.PortOneError,
+  merchantUid: string,
+): string => {
+  const type =
+    e instanceof PortOne.RestError && typeof e.data.type === "string"
+      ? e.data.type
+      : "UNKNOWN";
+  // RestError는 응답에 message가 없으면 Error("")가 돼 빈 문자열이 된다 — 폴백 필수.
+  const detail = e.message || "(SDK 메시지 없음)";
+  return `type=${type} merchantUid=${merchantUid} message=${detail}`;
+};
+
+/**
  * PortOne 결제 정보 동기화 및 검증
  * @param paymentId - merchantUid (주문번호)
  */
@@ -531,7 +553,10 @@ export const syncPayment = async (paymentId: string) => {
     return { success: false, status: mapPortOneStatus(actualPayment.status) };
   } catch (e) {
     if (e instanceof PortOne.PortOneError) {
-      throw new AppError("EXTERNAL_SERVICE", `포트원 오류: ${e.message}`);
+      throw new AppError(
+        "EXTERNAL_SERVICE",
+        `포트원 오류: ${portOneErrorContext(e, paymentId)}`,
+      );
     }
     if (e instanceof AppError) {
       throw e;
@@ -540,7 +565,9 @@ export const syncPayment = async (paymentId: string) => {
     // — services는 AppError 하나로 통일한다(docs/architecture/error-handling.md 에러 표현 규칙).
     throw new AppError(
       "INTERNAL",
-      e instanceof Error ? e.message : "결제 동기화에 실패했습니다.",
+      `결제 동기화 실패: merchantUid=${paymentId} message=${
+        e instanceof Error ? e.message || "(메시지 없음)" : String(e)
+      }`,
     );
   }
 };
@@ -605,14 +632,19 @@ export const cancelPayment = async (
     });
   } catch (e) {
     if (e instanceof PortOne.PortOneError) {
-      throw new AppError("EXTERNAL_SERVICE", `포트원 취소 오류: ${e.message}`);
+      throw new AppError(
+        "EXTERNAL_SERVICE",
+        `포트원 취소 오류: ${portOneErrorContext(e, merchantUid)}`,
+      );
     }
     if (e instanceof AppError) {
       throw e;
     }
     throw new AppError(
       "INTERNAL",
-      e instanceof Error ? e.message : "결제 취소에 실패했습니다.",
+      `결제 취소 실패: merchantUid=${merchantUid} message=${
+        e instanceof Error ? e.message || "(메시지 없음)" : String(e)
+      }`,
     );
   }
 };


### PR DESCRIPTION
## Summary

- `PORTONE_API_SECRET` 만료 등으로 포트원 API가 401을 반환했을 때 `PortOneError.message`가 빈 문자열이라, 서버 로그만으로 인증 실패/네트워크 오류/결제 건 문제를 구분할 수 없었다.
- `syncPayment`/`cancelPayment`의 catch 블록에서 `PortOne.RestError.data.type`(예: `UNAUTHORIZED`, `PAYMENT_NOT_FOUND`)과 대상 `merchantUid`를 로그 메시지에 포함시켰다. `message`가 비어 있을 때는 폴백 문구(`(SDK 메시지 없음)`)를 남긴다.
- INTERNAL 폴백(네트워크 예외 등 PortOneError가 아닌 경우)에도 `merchantUid`를 남겨, 완료조건 (2)가 모든 에러 경로에서 지켜지게 했다.
- SDK 제약(`RestError`에 HTTP status 필드가 없음)은 #77에 코멘트로 남기고, `data.type`으로 대체했다 — PortOne REST 스펙상 `UNAUTHORIZED` ↔ 401은 1:1이라 판별력은 동일하다.
- 작업 중 발견한 인접 위험(SECRET 만료 중 PAID 주문이 미결제로 오분류돼 자동 취소될 수 있음)은 이 PR 스코프 밖이라 #94로 분리했다.

Closes #77
Related to #94

## Test plan

- `npm run tsc` — 통과 (`data.type`이 `string | unique symbol`이라 `typeof` 가드 필요, 반영 완료)
- `npm run lint` — 통과
- `npm run test:integration -- payment.integration.test.ts` — 50 passed. mock 팩토리에 `RestError` 추가(기존엔 없어 `PortOne.RestError` 참조 시 `undefined`가 될 뻔함), UNAUTHORIZED/PAYMENT_NOT_FOUND(syncPayment) + UNAUTHORIZED(cancelPayment) 케이스 신규 추가, 기존 PortOneError 케이스에 `type=UNKNOWN` 폴백 assertion 보강.