### PR TITLE
fix: 홈 섹션 폭을 하나의 컨테이너로 통일한다

### DIFF
--- a/src/app/(main)/_components/HomeTemplate.tsx
+++ b/src/app/(main)/_components/HomeTemplate.tsx
@@ -11,7 +11,7 @@ interface HomeTemplateProps {
 
 const HomeTemplate = ({ invitation, popularProducts }: HomeTemplateProps) => {
   return (
-    <div className="flex flex-col ">
+    <div className="flex flex-col container mx-auto px-4">
       <EcommerceHero />
 
       <SubCategoryNavSection />
@@ -20,8 +20,7 @@ const HomeTemplate = ({ invitation, popularProducts }: HomeTemplateProps) => {
 
       {/* 추천 템플릿 섹션: 데이터가 있을 경우에만 렌더링 */}
       {invitation.length > 0 && (
-        <section className="bg-background py-24">
-          <div className="container mx-auto px-4">
+        <section className="bg-background py-24">   
             <div className="mb-16 text-center">
               <TypographyH2 className="text-foreground mb-4 border-none text-3xl font-bold tracking-tight md:text-4xl">
                 베스트 디자인 템플릿
@@ -38,7 +37,6 @@ const HomeTemplate = ({ invitation, popularProducts }: HomeTemplateProps) => {
                 description="소중한 순간을 함께할 분들께 마음을 전하는 초대장"
               />
             </div>
-          </div>
         </section>
       )}
 

--- a/src/app/(main)/_components/PopularProductsSection.tsx
+++ b/src/app/(main)/_components/PopularProductsSection.tsx
@@ -22,7 +22,6 @@ export function PopularProductsSection({ products }: PopularProductsSectionProps
 
   return (
     <section className="py-8">
-      <div className="container mx-auto px-4">
         <TypographyH2 id="popular-products-heading" className="mb-4 border-none text-xl font-bold">
           인기 상품
         </TypographyH2>
@@ -46,7 +45,7 @@ export function PopularProductsSection({ products }: PopularProductsSectionProps
             <CarouselNext className="-right-12" />
           </div>
         </Carousel>
-      </div>
+ 
     </section>
   );
 }

--- a/src/app/(main)/_components/SubCategoryNavSection.tsx
+++ b/src/app/(main)/_components/SubCategoryNavSection.tsx
@@ -19,7 +19,7 @@ const categorizedSubCategories = PRODUCT_CATEGORIES.flatMap((category: ProductCa
 export function SubCategoryNavSection() {
   return (
     <section className="py-8">
-      <div className="container mx-auto px-4">
+   
         <TypographyH2 className="mb-4 border-none text-xl font-bold">
           카테고리 둘러보기
         </TypographyH2>
@@ -40,7 +40,7 @@ export function SubCategoryNavSection() {
             <CarouselNext className="-right-12" />
           </div>
         </Carousel>
-      </div>
+  
     </section>
   );
 }

--- a/src/ui/components/organisms/EcommerceHero.tsx
+++ b/src/ui/components/organisms/EcommerceHero.tsx
@@ -31,82 +31,84 @@ export const EcommerceHero = () => {
       onMouseEnter={() => setIsPaused(true)}
       onMouseLeave={() => setIsPaused(false)}
     >
-      <div className="md:flex">
-        {/* 탭 열 — 모바일: 상단 가로 언더라인 / 데스크톱: 좌측 세로 38.2% */}
-        <div className="border-border scrollbar-hide bg-background flex gap-1 overflow-x-auto border-b px-3 md:w-[38.2%] md:flex-shrink-0 md:flex-col md:justify-center md:gap-1.5 md:border-r md:border-b-0 md:px-8 md:py-10">
-          {promotions.map((promo, index) => {
-            const isActive = active.id === promo.id;
-            return (
-              <button
-                key={promo.id}
-                type="button"
-                onClick={() => {
-                  setIndex(index);
-                  setIsPaused(true);
-                }}
-                className={cn(
-                  "shrink-0 border-b-2 px-2 py-3.5 text-sm font-bold whitespace-nowrap transition-colors md:rounded-r-lg md:border-b-0 md:border-l-2 md:px-4 md:py-3",
-                  isActive
-                    ? "text-primary border-primary md:bg-secondary"
-                    : "text-muted-foreground hover:text-foreground border-transparent",
-                )}
+    
+        <div className="md:flex">
+          {/* 탭 열 — 모바일: 상단 가로 언더라인 / 데스크톱: 좌측 세로 38.2% */}
+          <div className="border-border scrollbar-hide bg-background flex gap-1 overflow-x-auto border-b px-3 md:w-[38.2%] md:flex-shrink-0 md:flex-col md:justify-center md:gap-1.5 md:border-r md:border-b-0 md:px-8 md:py-10">
+            {promotions.map((promo, index) => {
+              const isActive = active.id === promo.id;
+              return (
+                <button
+                  key={promo.id}
+                  type="button"
+                  onClick={() => {
+                    setIndex(index);
+                    setIsPaused(true);
+                  }}
+                  className={cn(
+                    "shrink-0 border-b-2 px-2 py-3.5 text-sm font-bold whitespace-nowrap transition-colors md:rounded-r-lg md:border-b-0 md:border-l-2 md:px-4 md:py-3",
+                    isActive
+                      ? "text-primary border-primary md:bg-secondary"
+                      : "text-muted-foreground hover:text-foreground border-transparent",
+                  )}
+                >
+                  {promo.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* 배너 — 이미지 전체 배경 + 텍스트 좌하단 오버레이(모바일/데스크톱 동일 개념) */}
+          <div className="relative min-h-[420px] overflow-hidden md:min-h-[560px] md:w-[61.8%]">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={active.id}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.35, ease: "easeOut" }}
+                className="absolute inset-0"
               >
-                {promo.label}
-              </button>
-            );
-          })}
+                <Image
+                  src={active.image}
+                  alt={active.label}
+                  fill
+                  sizes="(max-width: 768px) 100vw, 62vw"
+                  className="object-cover"
+                  priority
+                />
+                {/* 텍스트 가독성용 하단 스크림 — ProductCard 사진 오버레이와 동일 관례 */}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+
+                <div className="absolute inset-x-0 bottom-0 flex flex-col items-start gap-3 p-6 md:p-10">
+                  {active.badge && (
+                    <span className="bg-foreground/85 text-background w-fit rounded-full px-3 py-1.5 text-xs font-bold tracking-wide backdrop-blur-sm">
+                      {active.badge}
+                    </span>
+                  )}
+
+                  <TypographyH1 className="font-[var(--font-NotoSerif)] text-left text-2xl leading-tight font-bold text-white md:text-3xl">
+                    {active.title.split("\n").map((line, i) => (
+                      <Fragment key={i}>
+                        {line}
+                        <br />
+                      </Fragment>
+                    ))}
+                  </TypographyH1>
+
+                  <p className="text-sm leading-relaxed whitespace-pre-line text-white/80 md:text-base">
+                    {active.description}
+                  </p>
+
+                  <Button asChild size="lg" className="w-fit">
+                    <Link href={active.cta.href}>{active.cta.label}</Link>
+                  </Button>
+                </div>
+              </motion.div>
+            </AnimatePresence>
+          </div>
         </div>
-
-        {/* 배너 — 이미지 전체 배경 + 텍스트 좌하단 오버레이(모바일/데스크톱 동일 개념) */}
-        <div className="relative min-h-[420px] overflow-hidden md:min-h-[560px] md:w-[61.8%]">
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={active.id}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.35, ease: "easeOut" }}
-              className="absolute inset-0"
-            >
-              <Image
-                src={active.image}
-                alt={active.label}
-                fill
-                sizes="(max-width: 768px) 100vw, 62vw"
-                className="object-cover"
-                priority
-              />
-              {/* 텍스트 가독성용 하단 스크림 — ProductCard 사진 오버레이와 동일 관례 */}
-              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
-
-              <div className="absolute inset-x-0 bottom-0 flex flex-col items-start gap-3 p-6 md:p-10">
-                {active.badge && (
-                  <span className="bg-foreground/85 text-background w-fit rounded-full px-3 py-1.5 text-xs font-bold tracking-wide backdrop-blur-sm">
-                    {active.badge}
-                  </span>
-                )}
-
-                <TypographyH1 className="font-[var(--font-NotoSerif)] text-left text-2xl leading-tight font-bold text-white md:text-3xl">
-                  {active.title.split("\n").map((line, i) => (
-                    <Fragment key={i}>
-                      {line}
-                      <br />
-                    </Fragment>
-                  ))}
-                </TypographyH1>
-
-                <p className="text-sm leading-relaxed whitespace-pre-line text-white/80 md:text-base">
-                  {active.description}
-                </p>
-
-                <Button asChild size="lg" className="w-fit">
-                  <Link href={active.cta.href}>{active.cta.label}</Link>
-                </Button>
-              </div>
-            </motion.div>
-          </AnimatePresence>
-        </div>
-      </div>
+ 
     </section>
   );
 };

--- a/src/ui/components/organisms/LiveDemoSection.tsx
+++ b/src/ui/components/organisms/LiveDemoSection.tsx
@@ -11,8 +11,7 @@ import { routes } from "@/core/domain";
  */
 export const LiveDemoSection = () => {
   return (
-    <section className="bg-muted/30 py-20">
-      <div className="container mx-auto px-4">
+    <section className="bg-muted/30 py-20 ">
         <div className="flex flex-col items-center gap-12 lg:flex-row lg:items-stretch">
           {/* 설명 영역 */}
           <div className="flex flex-1 flex-col justify-center text-center lg:text-left">
@@ -65,7 +64,7 @@ export const LiveDemoSection = () => {
             </Card>
           </div>
         </div>
-      </div>
+   
     </section>
   );
 };


### PR DESCRIPTION
## Summary

- Hero/카테고리 네비/인기상품/추천템플릿/라이브데모 등 홈 섹션마다 각자 `container mx-auto px-4`를 중복 선언하고 있었고, Hero는 그마저 빠져서 다른 섹션과 폭이 어긋나 있었다.
- `HomeTemplate`의 최상위 래퍼 하나에 컨테이너 제약을 옮기고, 각 섹션의 중복된 컨테이너 div를 제거했다 — 이제 폭 기준이 한 곳에서만 정의된다.

## Test plan

- `npm run tsc` — 통과
- `npm run lint` — 통과
- `npm run test`(vitest, 759개) — 통과