### PR TITLE
fix: 로그아웃 실패해도 성공 토스트+홈 이동하던 문제 수정

### DIFF
--- a/src/app/(main)/_components/UserAccountNav.test.tsx
+++ b/src/app/(main)/_components/UserAccountNav.test.tsx
@@ -14,10 +14,13 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock, refresh: refreshMock }),
 }));
 vi.mock("@/client/hooks", () => ({ useAuth: useAuthMock }));
-vi.mock("@/server/actions", () => ({ logoutUser: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/server/actions", () => ({
+  logoutUser: vi.fn().mockResolvedValue({ success: true, data: null }),
+}));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 import { logoutUser } from "@/server/actions";
+import { toast } from "sonner";
 import { UserAccountNav } from "./UserAccountNav";
 
 describe("UserAccountNav", () => {
@@ -30,6 +33,8 @@ describe("UserAccountNav", () => {
   });
 
   it("로그아웃 클릭 시 logoutUser 액션 호출 후 세션 캐시를 비운다", async () => {
+    vi.mocked(logoutUser).mockResolvedValue({ success: true, data: null });
+
     const user = userEvent.setup();
     render(<UserAccountNav />);
 
@@ -38,6 +43,29 @@ describe("UserAccountNav", () => {
 
     expect(logoutUser).toHaveBeenCalledOnce();
     expect(mutateMock).toHaveBeenCalledWith("/api/auth/me", null, false);
+    expect(toast.success).toHaveBeenCalledWith("로그아웃되었습니다.");
     expect(pushMock).toHaveBeenCalledWith("/");
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+
+  it("로그아웃 실패 시 에러 토스트를 띄우고 홈으로 이동하지 않는다", async () => {
+    vi.mocked(logoutUser).mockResolvedValue({
+      success: false,
+      error: { category: "INTERNAL", message: "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요." },
+    });
+
+    const user = userEvent.setup();
+    render(<UserAccountNav />);
+
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("로그아웃"));
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.",
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(mutateMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/(main)/_components/UserAccountNav.tsx
+++ b/src/app/(main)/_components/UserAccountNav.tsx
@@ -17,18 +17,18 @@ const UserAccountNav = () => {
   const router = useRouter();
 
   const handleLogout = async () => {
-    try {
-      await logoutUser();
+    const result = await logoutUser();
 
-      mutate("/api/auth/me", null, false);
-      toast.success("로그아웃되었습니다.");
-
-      router.push(routes.home);
-      router.refresh();
-    } catch (error) {
-      console.error("Logout Error:", error);
-      toast.error("로그아웃 처리 중 오류가 발생했습니다.");
+    if (result.success === false) {
+      toast.error(result.error.message || "로그아웃 처리 중 오류가 발생했습니다.");
+      return;
     }
+
+    mutate("/api/auth/me", null, false);
+    toast.success("로그아웃되었습니다.");
+
+    router.push(routes.home);
+    router.refresh();
   };
 
   return (


### PR DESCRIPTION
## Summary
- `UserAccountNav`'s `handleLogout` ignored the `APIResponse` envelope returned by `logoutUser()` (a Server Action that never throws per project convention) and unconditionally showed a success toast + redirected home, even when server-side logout failed.
- Now branches on `result.success`: on failure, shows an error toast (using `result.error.message`, falling back to a generic message) and returns early without touching the SWR cache or navigating. The unreachable `try/catch` is removed since `logoutUser` cannot throw.

## Test plan
- `npx vitest run --project unit "src/app/(main)/_components/UserAccountNav.test.tsx"` — passed (2 tests: success path enriched with toast/refresh assertions, new failure-path test added).
- Confirmed the new failure-path test actually goes red against the pre-fix source (temporarily reverted the source change, re-ran the test, saw the expected assertion failure, then restored the fix).
- `npm run typecheck` — passed.
- `npx eslint` on both changed files — no errors.
- `npm run test:unit` — 123 files / 559 tests passed, no regressions.
- `node scripts/tdd-guard/bin/guard.mjs verify --ci` — `valid: true`, no failures.

Closes #103