### PR TITLE
fix: 로그아웃 실패해도 성공 토스트+홈 이동하던 문제를 dev에도 반영

### DIFF
--- a/src/app/(main)/_components/UserAccountNav.test.tsx
+++ b/src/app/(main)/_components/UserAccountNav.test.tsx
@@ -14,10 +14,13 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock, refresh: refreshMock }),
 }));
 vi.mock("@/ui/hooks", () => ({ useAuth: useAuthMock }));
-vi.mock("@/actions", () => ({ logoutUser: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/actions", () => ({
+  logoutUser: vi.fn().mockResolvedValue({ success: true, data: null }),
+}));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 import { logoutUser } from "@/actions";
+import { toast } from "sonner";
 import { UserAccountNav } from "./UserAccountNav";
 
 describe("UserAccountNav", () => {
@@ -30,6 +33,8 @@ describe("UserAccountNav", () => {
   });
 
   it("로그아웃 클릭 시 logoutUser 액션 호출 후 세션 캐시를 비운다", async () => {
+    vi.mocked(logoutUser).mockResolvedValue({ success: true, data: null });
+
     const user = userEvent.setup();
     render(<UserAccountNav />);
 
@@ -38,6 +43,29 @@ describe("UserAccountNav", () => {
 
     expect(logoutUser).toHaveBeenCalledOnce();
     expect(mutateMock).toHaveBeenCalledWith("/api/auth/me", null, false);
+    expect(toast.success).toHaveBeenCalledWith("로그아웃되었습니다.");
     expect(pushMock).toHaveBeenCalledWith("/");
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+
+  it("로그아웃 실패 시 에러 토스트를 띄우고 홈으로 이동하지 않는다", async () => {
+    vi.mocked(logoutUser).mockResolvedValue({
+      success: false,
+      error: { category: "INTERNAL", message: "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요." },
+    });
+
+    const user = userEvent.setup();
+    render(<UserAccountNav />);
+
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("로그아웃"));
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.",
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(mutateMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/(main)/_components/UserAccountNav.tsx
+++ b/src/app/(main)/_components/UserAccountNav.tsx
@@ -17,18 +17,18 @@ const UserAccountNav = () => {
   const router = useRouter();
 
   const handleLogout = async () => {
-    try {
-      await logoutUser();
+    const result = await logoutUser();
 
-      mutate("/api/auth/me", null, false);
-      toast.success("로그아웃되었습니다.");
-
-      router.push(routes.home);
-      router.refresh();
-    } catch (error) {
-      console.error("Logout Error:", error);
-      toast.error("로그아웃 처리 중 오류가 발생했습니다.");
+    if (result.success === false) {
+      toast.error(result.error.message || "로그아웃 처리 중 오류가 발생했습니다.");
+      return;
     }
+
+    mutate("/api/auth/me", null, false);
+    toast.success("로그아웃되었습니다.");
+
+    router.push(routes.home);
+    router.refresh();
   };
 
   return (


### PR DESCRIPTION
## Summary

- PR #107이 실제 트렁크인 `dev`가 아니라 `main`(커밋 2개뿐인 정체 브랜치, GitHub 기본 브랜치일 뿐 CI/실서비스 대상 아님)으로 머지되어 `dev`에는 이 수정이 반영되지 않은 상태였다.
- `f3d4292`(#107 커밋)를 `dev` 기준 새 브랜치로 cherry-pick했다. 소스(`UserAccountNav.tsx`)는 충돌 없이 자동 병합됐고, 테스트 파일(`UserAccountNav.test.tsx`)은 `dev`의 현재 import alias(`@/ui/hooks`, `@/actions`)로 conflict를 수동 해결했다 — 로직/단언 내용은 원본 커밋과 동일.

## Test plan

- `npx vitest run --project component "src/app/(main)/_components/UserAccountNav.test.tsx"` — 2 tests passed
- `npm run tsc` — passed
- `npx eslint` on both changed files — no errors

Closes #103