### PR TITLE
fix: 미구현 Google 로그인/가입 버튼을 준비 중 상태로 전환

### DIFF
--- a/src/ui/components/organisms/LoginForm.test.tsx
+++ b/src/ui/components/organisms/LoginForm.test.tsx
@@ -23,4 +23,11 @@ describe("LoginForm", () => {
     expect(screen.getByRole("link", { name: "회원가입" })).toHaveAttribute("href", "/signup");
     expect(screen.getByRole("link", { name: "아이디 찾기" })).toHaveAttribute("href", "/find-id");
   });
+
+  it("Google 버튼은 준비 중 상태로 비활성화되고 안내 문구를 보여준다", () => {
+    render(<LoginForm action={vi.fn()} pending={false} />);
+
+    expect(screen.getByRole("button", { name: /Google/ })).toBeDisabled();
+    expect(screen.getByText("소셜 계정 연동은 준비 중입니다. 이메일 계정을 이용해 주세요.")).toBeInTheDocument();
+  });
 });

--- a/src/ui/components/organisms/LoginForm.tsx
+++ b/src/ui/components/organisms/LoginForm.tsx
@@ -76,15 +76,20 @@ export function LoginForm({
         </div>
       </div>
 
+      {/* OAuth 미구현 — 연동 전까지 비활성 안내만 */}
       <Button
         type="button"
         variant="outline"
         className="w-full bg-transparent"
         size="lg"
+        disabled
       >
         <Globe className="mr-2 h-5 w-5" />
-        Google로 계속하기
+        Google로 계속하기 (준비 중)
       </Button>
+      <TypographyMuted className="text-center text-xs">
+        소셜 계정 연동은 준비 중입니다. 이메일 계정을 이용해 주세요.
+      </TypographyMuted>
 
       <div className="space-y-2 text-center">
         <TypographyMuted>

--- a/src/ui/components/organisms/SignupForm.test.tsx
+++ b/src/ui/components/organisms/SignupForm.test.tsx
@@ -40,4 +40,11 @@ describe("SignupForm", () => {
 
     expect(screen.getByRole("link", { name: "로그인" })).toHaveAttribute("href", "/login");
   });
+
+  it("Google 버튼은 준비 중 상태로 비활성화되고 안내 문구를 보여준다", () => {
+    render(<SignupForm action={vi.fn()} pending={false} state={null} />);
+
+    expect(screen.getByRole("button", { name: /Google/ })).toBeDisabled();
+    expect(screen.getByText("소셜 계정 연동은 준비 중입니다. 이메일 계정을 이용해 주세요.")).toBeInTheDocument();
+  });
 });

--- a/src/ui/components/organisms/SignupForm.tsx
+++ b/src/ui/components/organisms/SignupForm.tsx
@@ -117,15 +117,20 @@ export function SignupForm({ action, pending, state }: SignupFormProps) {
         </div>
       </div>
 
+      {/* OAuth 미구현 — 연동 전까지 비활성 안내만 */}
       <Button
         type="button"
         variant="outline"
         className="w-full bg-transparent"
         size="lg"
+        disabled
       >
         <Globe className="aspect-square w-4" />
-        Google로 가입하기
+        Google로 가입하기 (준비 중)
       </Button>
+      <TypographyMuted className="text-center text-xs">
+        소셜 계정 연동은 준비 중입니다. 이메일 계정을 이용해 주세요.
+      </TypographyMuted>
 
       <div className="text-center">
         <TypographyMuted>


### PR DESCRIPTION
## Summary

- 로그인/회원가입 페이지의 "Google로 계속하기/가입하기" 버튼이 `onClick`/`href` 없이 방치돼 있어 클릭해도 아무 반응이 없었다(dead-end UI).
- OAuth 연동이 아직 없으므로 버튼을 제거하는 대신 `disabled` + "(준비 중)" 레이블 + 안내 문구로 상태를 명시했다. 저장소 내 다른 미구현 기능(MyProfileTemplate, ProductOptions 등)이 이미 같은 패턴을 쓴다.
- 레이블에 "로그인"/"회원가입" 단어를 넣지 않아 기존 e2e(`testing/e2e/core.spec.ts`)의 role-name strict 매칭과 충돌하지 않는다.
- 실제 OAuth 연동은 스코프 밖 — 필요 시 별도 feat 이슈로 진행.

## Test plan

- `npx vitest run --project component src/ui/components/organisms/LoginForm.test.tsx src/ui/components/organisms/SignupForm.test.tsx` — 7 tests passed
- `npm run tsc` — passed
- `npx eslint` on changed files — no errors

Closes #104