### PR TITLE
fix: 비밀번호 재설정 이메일 링크가 프로덕션에서 빈 URL이 되는 문제 수정

### DIFF
--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -11,4 +11,5 @@ export * from "./page";
 export * from "./price";
 export * from "./seoul-open-api-parser";
 export * from "./sidebar";
+export * from "./url";
 export * from "./validate-and-flatten";

--- a/src/core/utils/url.test.ts
+++ b/src/core/utils/url.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { getAppBaseUrl } from "./url";
+
+describe("getAppBaseUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("개발 환경이면 BASE_URL을 사용한다", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("BASE_URL", "http://localhost:3000");
+    vi.stubEnv("DEPLOYMENT_BASE_URL", "https://tie-knot-pi.vercel.app");
+
+    expect(getAppBaseUrl()).toBe("http://localhost:3000");
+  });
+
+  it("개발 환경이 아니면 DEPLOYMENT_BASE_URL을 사용한다", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BASE_URL", "http://localhost:3000");
+    vi.stubEnv("DEPLOYMENT_BASE_URL", "https://tie-knot-pi.vercel.app");
+
+    expect(getAppBaseUrl()).toBe("https://tie-knot-pi.vercel.app");
+  });
+
+  it("선택된 환경변수가 없으면 AppError(INTERNAL)를 던진다", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DEPLOYMENT_BASE_URL", "");
+
+    expect(() => getAppBaseUrl()).toThrowError(
+      expect.objectContaining({ category: "INTERNAL" }),
+    );
+  });
+});

--- a/src/core/utils/url.ts
+++ b/src/core/utils/url.ts
@@ -1,0 +1,17 @@
+import { AppError } from "@/core/domain";
+
+export const getAppBaseUrl = (): string => {
+  const baseUrl =
+    process.env.NODE_ENV === "development"
+      ? process.env.BASE_URL
+      : process.env.DEPLOYMENT_BASE_URL;
+
+  if (!baseUrl) {
+    throw new AppError(
+      "INTERNAL",
+      "BASE_URL/DEPLOYMENT_BASE_URL 환경변수가 설정되지 않았습니다.",
+    );
+  }
+
+  return baseUrl;
+};

--- a/src/services/user.integration.test.ts
+++ b/src/services/user.integration.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi, afterEach } from "vitest";
 import mongoose from "mongoose";
 import { dbConnect } from "@/db";
 import { buildUserInput, clearCollections } from "@testing/support";
@@ -12,7 +12,11 @@ import {
   getUserById,
   changePassword,
   signupUserService,
+  requestPasswordResetService,
 } from "./user";
+
+const sendEmailMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("@/adapters/server/nodemailer", () => ({ sendEmail: sendEmailMock }));
 
 describe("user", () => {
   beforeEach(async () => {
@@ -53,6 +57,33 @@ describe("user", () => {
 
       await expect(
         signupUserService({ ...input, password: "pw1234!" }),
+      ).rejects.toMatchObject({ category: "VALIDATION" });
+    });
+  });
+
+  describe("requestPasswordResetService", () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      sendEmailMock.mockClear();
+    });
+
+    it("등록된 이메일이면 배포 환경 origin으로 시작하는 절대 링크를 메일로 보낸다", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("DEPLOYMENT_BASE_URL", "https://tie-knot-pi.vercel.app");
+      const input = buildUserInput();
+      await UserModel.create(input);
+
+      await requestPasswordResetService(input.email);
+
+      expect(sendEmailMock).toHaveBeenCalledOnce();
+      const { path } = sendEmailMock.mock.calls[0][0];
+      expect(path).not.toBe("");
+      expect(path.startsWith("https://tie-knot-pi.vercel.app/change-password?t=")).toBe(true);
+    });
+
+    it("등록되지 않은 이메일이면 VALIDATION을 던진다", async () => {
+      await expect(
+        requestPasswordResetService("no-such-user@example.com"),
       ).rejects.toMatchObject({ category: "VALIDATION" });
     });
   });

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -8,6 +8,7 @@ import { decrypt, encrypt } from "@/adapters/server/jose";
 import { deleteCookie } from "@/adapters/server/cookies";
 import { sendEmail } from "@/adapters/server/nodemailer";
 import { routes } from "@/core/domain";
+import { getAppBaseUrl } from "@/core/utils";
 // 유저 생성
 export const createUser = async (user: BaseUser): Promise<IUser> => {
   await dbConnect();
@@ -91,10 +92,10 @@ export async function requestPasswordResetService(email: string): Promise<void> 
     throw new AppError("VALIDATION", "등록되지 않은 이메일입니다.");
   }
   const token = await encrypt({ id: email, type: "ENTRY" });
-  const path =
-    process.env.NODE_ENV === "development"
-      ? `http://localhost:3000${routes.changePw}?t=${encodeURIComponent(token)}`
-      : "";
+  const path = new URL(
+    `${routes.changePw}?t=${encodeURIComponent(token)}`,
+    getAppBaseUrl(),
+  ).toString();
   await sendEmail({ email, path });
 }
 


### PR DESCRIPTION
## Summary

- `requestPasswordResetService`(`src/services/user.ts`)가 `NODE_ENV === "development"`가 아닐 때 재설정 링크를 빈 문자열로 생성해, 프로덕션을 포함한 모든 배포 환경에서 비밀번호 재설정 이메일의 버튼이 `href=""`가 되는 문제를 수정한다.
- 새 환경변수를 도입하지 않았다. `src/app/layout.tsx`가 이미 `BASE_URL`(dev)/`DEPLOYMENT_BASE_URL`(그 외) 쌍으로 동일한 문제를 풀고 있고, 이 두 변수는 layout.tsx의 빌드타임 필수 체크 때문에 프로덕션이 빌드된다는 사실 자체가 이미 배포 환경에 설정돼 있다는 근거다. 이 로직을 `src/core/utils/url.ts`의 `getAppBaseUrl()`로 뽑아 재사용했다.
- `layout.tsx`를 `getAppBaseUrl()`로 통합하는 리팩터는 하지 않았다 — layout.tsx는 두 변수 모두를 필수로 요구하는 더 엄격한 빌드타임 체크인 반면 `getAppBaseUrl()`은 선택된 쪽 하나만 요구한다. 통합하면 빌드타임 검증 강도가 달라져 이번 fix 스코프를 벗어난다고 판단했다.

## Test plan

- `npx vitest run --project unit "src/core/utils/url.test.ts"` — 3 tests passed
- `npx vitest run --project integration "src/services/user.integration.test.ts"` — 14 tests passed (신규 회귀 테스트 2건 포함, 수정 전 상태로는 fail하는 것을 확인함)
- `npm run tsc` — passed
- `npx eslint` on all changed files — no errors

## 배포 후속 조치

- Vercel Production/Preview 양쪽에서 `DEPLOYMENT_BASE_URL`이 실제 서비스 origin(`https://tie-knot-pi.vercel.app`)으로 설정돼 있는지 확인 필요.

Closes #106