### PR TITLE
fix: 홈 섹션 풀블리드 배경이 컨테이너에 갇히던 회귀 수정

### DIFF
--- a/src/app/(main)/_components/HomeTemplate.tsx
+++ b/src/app/(main)/_components/HomeTemplate.tsx
@@ -11,7 +11,7 @@ interface HomeTemplateProps {
 
 const HomeTemplate = ({ invitation, popularProducts }: HomeTemplateProps) => {
   return (
-    <div className="flex flex-col container mx-auto px-4">
+    <div className="flex flex-col">
       <EcommerceHero />
 
       <SubCategoryNavSection />
@@ -20,7 +20,8 @@ const HomeTemplate = ({ invitation, popularProducts }: HomeTemplateProps) => {
 
       {/* 추천 템플릿 섹션: 데이터가 있을 경우에만 렌더링 */}
       {invitation.length > 0 && (
-        <section className="bg-background py-24">   
+        <section className="bg-background py-24">
+          <div className="container mx-auto px-4">
             <div className="mb-16 text-center">
               <TypographyH2 className="text-foreground mb-4 border-none text-3xl font-bold tracking-tight md:text-4xl">
                 베스트 디자인 템플릿
@@ -37,6 +38,7 @@ const HomeTemplate = ({ invitation, popularProducts }: HomeTemplateProps) => {
                 description="소중한 순간을 함께할 분들께 마음을 전하는 초대장"
               />
             </div>
+          </div>
         </section>
       )}
 

--- a/src/app/(main)/_components/PopularProductsSection.tsx
+++ b/src/app/(main)/_components/PopularProductsSection.tsx
@@ -22,6 +22,7 @@ export function PopularProductsSection({ products }: PopularProductsSectionProps
 
   return (
     <section className="py-8">
+      <div className="container mx-auto px-4">
         <TypographyH2 id="popular-products-heading" className="mb-4 border-none text-xl font-bold">
           인기 상품
         </TypographyH2>
@@ -45,7 +46,7 @@ export function PopularProductsSection({ products }: PopularProductsSectionProps
             <CarouselNext className="-right-12" />
           </div>
         </Carousel>
- 
+      </div>
     </section>
   );
 }

--- a/src/app/(main)/_components/SubCategoryNavSection.tsx
+++ b/src/app/(main)/_components/SubCategoryNavSection.tsx
@@ -19,7 +19,7 @@ const categorizedSubCategories = PRODUCT_CATEGORIES.flatMap((category: ProductCa
 export function SubCategoryNavSection() {
   return (
     <section className="py-8">
-   
+      <div className="container mx-auto px-4">
         <TypographyH2 className="mb-4 border-none text-xl font-bold">
           카테고리 둘러보기
         </TypographyH2>
@@ -40,7 +40,7 @@ export function SubCategoryNavSection() {
             <CarouselNext className="-right-12" />
           </div>
         </Carousel>
-  
+      </div>
     </section>
   );
 }

--- a/src/ui/components/organisms/EcommerceHero.tsx
+++ b/src/ui/components/organisms/EcommerceHero.tsx
@@ -31,7 +31,7 @@ export const EcommerceHero = () => {
       onMouseEnter={() => setIsPaused(true)}
       onMouseLeave={() => setIsPaused(false)}
     >
-    
+      <div className="container mx-auto px-4">
         <div className="md:flex">
           {/* 탭 열 — 모바일: 상단 가로 언더라인 / 데스크톱: 좌측 세로 38.2% */}
           <div className="border-border scrollbar-hide bg-background flex gap-1 overflow-x-auto border-b px-3 md:w-[38.2%] md:flex-shrink-0 md:flex-col md:justify-center md:gap-1.5 md:border-r md:border-b-0 md:px-8 md:py-10">
@@ -108,7 +108,7 @@ export const EcommerceHero = () => {
             </AnimatePresence>
           </div>
         </div>
- 
+      </div>
     </section>
   );
 };

--- a/src/ui/components/organisms/LiveDemoSection.tsx
+++ b/src/ui/components/organisms/LiveDemoSection.tsx
@@ -11,7 +11,8 @@ import { routes } from "@/core/domain";
  */
 export const LiveDemoSection = () => {
   return (
-    <section className="bg-muted/30 py-20 ">
+    <section className="bg-muted/30 py-20">
+      <div className="container mx-auto px-4">
         <div className="flex flex-col items-center gap-12 lg:flex-row lg:items-stretch">
           {/* 설명 영역 */}
           <div className="flex flex-1 flex-col justify-center text-center lg:text-left">
@@ -64,7 +65,7 @@ export const LiveDemoSection = () => {
             </Card>
           </div>
         </div>
-   
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
## Summary

- `/code-review`로 최근 머지된 #102("섹션 폭 통일")를 리뷰한 결과, `container mx-auto px-4`를 각 섹션 내부에서 `HomeTemplate` 루트로 끌어올리면서 모든 섹션이 컨테이너 안에 중첩돼 `LiveDemoSection`의 `bg-muted/30` 풀블리드 배경 밴드가 넓은 화면(컨테이너 max-width 1536px 이상)에서 더 이상 가장자리까지 안 나가는 회귀가 있었다.
- `EcommerceHero`가 좁아진 것 자체는 #102의 의도된 결과였다(커밋 메시지: "Hero had drifted to skip container entirely... making its width inconsistent with everything below it" — Hero도 다른 섹션과 동일 폭 제약을 받도록 의도적으로 고친 것). 이건 그대로 두고 되돌리지 않았다.
- container를 `HomeTemplate` 루트에서 다시 각 섹션 내부 wrapper로 이동했다(Header.tsx/Footer.tsx가 쓰는 기존 패턴과 동일). 섹션(`<section>`)은 배경용으로 전체 폭을 유지하고, 그 안의 `<div className="container mx-auto px-4">`가 콘텐츠 폭만 정렬한다. `HomeTemplate.tsx`, `EcommerceHero.tsx`, `LiveDemoSection.tsx`, `PopularProductsSection.tsx`, `SubCategoryNavSection.tsx` 모두 동일 패턴 적용.
- #102가 남긴 공백 전용 잔여 라인(불완전한 편집 흔적)도 함께 정리했다.

## Test plan

- `npm run tsc` — passed
- `npx eslint` on all changed files — no errors
- `npx vitest run --project component --project integration-component` — 91 files / 329 tests passed, no regressions
- Playwright로 1920x1080 뷰포트에서 실제 렌더 확인: `LiveDemoSection`의 `<section>`이 뷰포트 전체 폭(1920px)을 차지하고 내부 `.container`만 1536px로 중앙정렬됨을 `getBoundingClientRect()`로 검증. `EcommerceHero` 이미지 폭이 컨테이너(1536px)의 61.8%(929px)로 의도된 비율과 일치함을 확인.
