### PR TITLE
feat(theme): 보태니컬·미드나이트 청첩장 테마 추가

### DIFF
--- a/src/app/(preview)/layout.tsx
+++ b/src/app/(preview)/layout.tsx
@@ -5,9 +5,11 @@ const PreviewLayout = ({ children }: { children: React.ReactNode }) => {
   // theme, 공통 Style 정의
 
   return (
-    <div className="bg-background border-muted-foreground-foreground mx-auto min-h-screen max-w-lg">
-      {children}
-      <GuestbookModal />
+    <div className="min-h-screen bg-[var(--preview-background)]">
+      <div className="bg-background border-muted-foreground-foreground mx-auto min-h-screen max-w-lg">
+        {children}
+        <GuestbookModal />
+      </div>
     </div>
   );
 };

--- a/src/app/(preview)/preview/sample/_constants/sampleInvitation.ts
+++ b/src/app/(preview)/preview/sample/_constants/sampleInvitation.ts
@@ -32,4 +32,4 @@ export const sampleInvitation = {
 } satisfies InvitationContent;
 
 export const SAMPLE_FEATURES = ["HORIZONTAL_SLIDE"] as const;
-export const SAMPLE_THEME = "default";
+export const SAMPLE_THEME = "blossom";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,6 +63,7 @@
 
 :root {
   font-family: var(--font-NotoSansKR), var(--font-NotoSerif), sans-serif;
+  --preview-background: #e8e3df;
   --card: #ffffff;
   --card-foreground: #3a342e;
   --popover: #ffffff;
@@ -138,7 +139,7 @@
   --destructive: oklch(0.704 0.191 22.216);
 }
 
-/* ── Default Theme (웜베이지) ──
+/* ── Default Theme / Classic (웜베이지) ──
    청첩장(invitation 상품)의 "default" 테마 값을 여기 고정한다. 청첩장은 발행되고
    나면 그 자체로 하객에게 전달되는 완성 상품이라, 이후 쇼핑몰 :root가 다시
    리브랜딩되더라도 이미 발행된 청첩장 외관은 흔들리면 안 된다 — 그래서 :root를
@@ -171,26 +172,77 @@
 
 /* ── Blossom Theme (벚꽃) ── */
 [data-theme="blossom"] {
-  --background:          oklch(0.98 0.012 5);
-  --foreground:          oklch(0.25 0.04 355);
-  --card:                oklch(1 0.006 5);
-  --card-foreground:     oklch(0.25 0.04 355);
-  --popover:             oklch(1 0.006 5);
-  --popover-foreground:  oklch(0.25 0.04 355);
-  --muted:               oklch(0.94 0.03 355);
-  --muted-foreground:    oklch(0.52 0.07 355);
-  --primary:             oklch(0.62 0.17 355);
-  --primary-foreground:  oklch(0.98 0 0);
-  --secondary:           oklch(0.93 0.04 355);
-  --secondary-foreground:oklch(0.32 0.06 355);
-  --accent:              oklch(0.93 0.04 355);
-  --accent-foreground:   oklch(0.32 0.06 355);
-  --border:              oklch(0.87 0.05 355);
-  --input:               oklch(0.87 0.05 355);
-  --ring:                oklch(0.62 0.17 355);
+  --background:           #fff8f7;
+  --foreground:           #4a2d35;
+  --card:                 #fffdfc;
+  --card-foreground:      #4a2d35;
+  --popover:              #fffdfc;
+  --popover-foreground:   #4a2d35;
+  --muted:                #f5ecec;
+  --muted-foreground:     #80656c;
+  --primary:              #b84f69;
+  --primary-foreground:   #ffffff;
+  --secondary:            #f7e4e8;
+  --secondary-foreground: #5b3540;
+  --accent:               #efd0d8;
+  --accent-foreground:    #5b3540;
+  --border:               #e9cdd3;
+  --input:                #e9cdd3;
+  --ring:                 #b84f69;
 
-  --blossom-pink:        oklch(0.70 0.16 355);
-  --blossom-light:       oklch(0.90 0.07 355);
+  --blossom-pink:         #d77f94;
+  --blossom-light:        #f9e9ec;
+  --blossom-gold:         #b99a64;
+}
+
+/* ── Botanical Theme (세이지 그린) ── */
+[data-theme="botanical"] {
+  --background:           #f6f7f0;
+  --foreground:           #30382c;
+  --card:                 #fbfcf8;
+  --card-foreground:      #30382c;
+  --popover:              #fbfcf8;
+  --popover-foreground:   #30382c;
+  --muted:                #edf0e7;
+  --muted-foreground:     #687162;
+  --primary:              #68785b;
+  --primary-foreground:   #ffffff;
+  --secondary:            #e3e8dc;
+  --secondary-foreground: #35402f;
+  --accent:               #d8e0d0;
+  --accent-foreground:    #35402f;
+  --border:               #ccd5c5;
+  --input:                #ccd5c5;
+  --ring:                 #68785b;
+
+  --botanical-green:      #7f9270;
+  --botanical-light:      #e8ede2;
+  --botanical-gold:       #a99467;
+}
+
+/* ── Midnight Theme (네이비 골드) ── */
+[data-theme="midnight"] {
+  --background:           #171b29;
+  --foreground:           #f5f0e8;
+  --card:                 #202534;
+  --card-foreground:      #f5f0e8;
+  --popover:              #202534;
+  --popover-foreground:   #f5f0e8;
+  --muted:                #292e40;
+  --muted-foreground:     #b8b2a8;
+  --primary:              #c9a96e;
+  --primary-foreground:   #171b29;
+  --secondary:            #292e40;
+  --secondary-foreground: #f5f0e8;
+  --accent:               #343a4f;
+  --accent-foreground:    #f5f0e8;
+  --border:               #3c4357;
+  --input:                #3c4357;
+  --ring:                 #c9a96e;
+
+  --midnight-gold:        #c9a96e;
+  --midnight-navy:        #202534;
+  --midnight-light:       #f5f0e8;
 }
 
 /* Calendar: D-day 하이라이트 + 주말 색상 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,7 +63,7 @@
 
 :root {
   font-family: var(--font-NotoSansKR), var(--font-NotoSerif), sans-serif;
-  --preview-background: #e8e3df;
+  --preview-background: #ffffff;
   --card: #ffffff;
   --card-foreground: #3a342e;
   --popover: #ffffff;

--- a/src/core/domain/theme.ts
+++ b/src/core/domain/theme.ts
@@ -1,8 +1,18 @@
-export type InvitationTheme = "blossom" | "default";
+// ---- 값이 원본 ----
+export const INVITATION_THEMES = [
+  "default",
+  "blossom",
+  "botanical",
+  "midnight",
+] as const;
+
+export type InvitationTheme = (typeof INVITATION_THEMES)[number];
 
 export const INVITATION_THEME_LABELS: Record<InvitationTheme, string> = {
   default: "기본",
   blossom: "벚꽃",
+  botanical: "세이지그린",
+  midnight: "네이비골드",
 };
 
 export const getInvitationThemeOptions = () =>

--- a/src/core/schemas/request/product.schema.ts
+++ b/src/core/schemas/request/product.schema.ts
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { SUB_CATEGORY_MAP, PRODUCT_CATEGORIES } from "@/core/domain";
+import { INVITATION_THEMES, SUB_CATEGORY_MAP, PRODUCT_CATEGORIES } from "@/core/domain";
 
 export const productSchema = z
   .object({
@@ -7,7 +7,7 @@ export const productSchema = z
     description: z.string().min(10, "상품 설명은 최소 10자 이상이어야 합니다."),
     category: z.enum(PRODUCT_CATEGORIES),
     subCategory: z.string().min(1, "서브 카테고리를 선택해주세요."),
-    theme: z.enum(["blossom", "default"]).optional(),
+    theme: z.enum(INVITATION_THEMES).optional(),
     price: z.number().min(0, "가격은 0 이상이어야 합니다."),
     isPremium: z.boolean(),
     featureIds: z.array(z.string()).optional(),

--- a/src/core/schemas/response/product.schema.ts
+++ b/src/core/schemas/response/product.schema.ts
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { PRODUCT_CATEGORIES } from "@/core/domain";
+import { INVITATION_THEMES, PRODUCT_CATEGORIES } from "@/core/domain";
 
 const isoDateString = z.string().refine((v) => !isNaN(Date.parse(v)), {
   message: "ISO date string이 아님",
@@ -12,7 +12,7 @@ export const productResponseSchema = z.object({
   description: z.string(),
   thumbnail: z.string(),
   previewUrl: z.string().optional(),
-  theme: z.enum(["blossom", "default"]).optional(),
+  theme: z.enum(INVITATION_THEMES).optional(),
   price: z.number(),
   category: z.enum(PRODUCT_CATEGORIES),
   subCategory: z.string(),

--- a/src/models/product.model.ts
+++ b/src/models/product.model.ts
@@ -10,7 +10,8 @@ import type {
 } from "@/core/domain";
 import {
   SUB_CATEGORY_MAP,
-  PRODUCT_CATEGORIES
+  PRODUCT_CATEGORIES,
+  INVITATION_THEMES
 } from "@/core/domain";
 
 export type { ProductCategory, ProductJSON, SubCategory };
@@ -159,7 +160,7 @@ export const ProductModel =
 
 const invitationProductSchema = new Schema<IInvitationProduct>({
   previewUrl: { type: String },
-  theme: { type: String, enum: ["blossom", "default"], default: "default" },
+  theme: { type: String, enum: INVITATION_THEMES, default: "default" },
 });
 
 // discriminator 이름("invitation")이 곧 category 필드에 저장되는 값이다 —


### PR DESCRIPTION
## Summary

- `INVITATION_THEMES` 배열을 도입해 청첩장 테마 값의 단일 원본으로 만들고, `theme.ts`/request·response 스키마/`product.model.ts` 4곳에 흩어져 있던 `["blossom","default"]` 하드코딩을 제거했다.
- CSS 토큰만 미리 정의돼 있던 `botanical`(세이지그린), `midnight`(네이비골드) 테마를 enum·라벨까지 실제로 연결했다.
- Preview 레이아웃에 `--preview-background` 서피스를 감싸 테마와 무관하게 청첩장 카드가 중립 배경 위에서 보이게 했다.

## Test plan

- `npm run tsc` — 통과
- `npm run lint` — 통과
- `npx vitest run --project unit src/core/schemas/response/product.schema.test.ts src/core/schemas/request/product.schema.test.ts` — 55개 테스트 통과
- Not run: `src/services/product.integration.test.ts` — 로컬 워크트리에 `JWT_SECRET` 등 env 미설정으로 실행 불가(테마 변경과 무관한 기존 인프라 제약)