### PR TITLE
fix(preview): 청첩장 섹션 라벨 정렬 및 타이포그래피 반응형 정리

### DIFF
--- a/src/app/(preview)/preview/[publicKey]/_components/EyebrowSection.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/EyebrowSection.tsx
@@ -12,7 +12,7 @@ const EyebrowSection = ({ eyebrow, heading, children }: EyebrowSectionProps) => 
     <section className="bg-background px-6 py-20">
       <div className="mx-auto max-w-2xl text-center">
         <TypographyEyebrow className="text-primary">{eyebrow}</TypographyEyebrow>
-        <TypographyLead className="text-foreground p-4 font-[var(--font-NotoSerif)] font-semibold">
+        <TypographyLead className="text-foreground p-4 font-[var(--font-NotoSerif)] font-semibold sm:text-2xl">
           {heading}
         </TypographyLead>
         <div className="space-y-4">{children}</div>

--- a/src/app/(preview)/preview/[publicKey]/_components/InvitationMessage.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/InvitationMessage.tsx
@@ -28,13 +28,21 @@ export function InvitationMessage({ parties }: InvitationMessageMappedProps) {
 
       <div className="space-y-10">
         {parties.map((party, index) => (
-          <div key={party.title} className="flex flex-col items-center">
-            <div className="flex w-full max-w-xs items-center justify-center gap-4">
-              <TypographyMuted className="text-base">{party.parentNames}</TypographyMuted>
-              <div className="flex items-center gap-2">
-                <TypographyMuted className="text-xs opacity-60">{party.title}</TypographyMuted>
-                <TypographyLarge className="text-xl font-bold">{party.name}</TypographyLarge>
-              </div>
+          <div key={party.title} className="flex flex-col items-center gap-2">
+            <div className="flex items-center justify-center gap-6">
+              {party.parents.map((parent) => (
+                <div key={parent.label} className="flex items-center gap-2">
+                  <TypographyMuted className="text-xs opacity-60 sm:text-sm">
+                    {parent.label}
+                  </TypographyMuted>
+                  <TypographyMuted className="text-base sm:text-lg">{parent.name}</TypographyMuted>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <TypographyMuted className="text-xs opacity-60 sm:text-sm">{party.title}</TypographyMuted>
+              <TypographyLarge className="text-xl font-bold sm:text-2xl">{party.name}</TypographyLarge>
             </div>
 
             <Button

--- a/src/app/(preview)/preview/[publicKey]/_components/LocationSection.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/LocationSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Badge } from "@/ui/components/atoms";
 import { ClipboardButton, KakaoMap } from "@/ui/components/molecules";
 import { useCopy, useNavigationGeo, useSubwayLineInfo } from "@/ui/hooks";
 import { EyebrowSection } from "./EyebrowSection";
@@ -21,9 +22,9 @@ export function LocationSection({
   return (
     <EyebrowSection eyebrow="LOCATION" heading="오시는 길">
       <div>
-        <p className="text-foreground text-md font-semibold">{venueName}</p>
+        <p className="text-foreground text-md font-semibold sm:text-lg">{venueName}</p>
         <div className="flex items-center justify-center gap-2">
-          <p className="text-muted-foreground text-sm">{fullAddress}</p>
+          <p className="text-muted-foreground text-sm sm:text-base">{fullAddress}</p>
           {/* 재사용 가능한 ClipboardButton으로 교체 */}
           <ClipboardButton
             isCopied={isCopied}
@@ -42,18 +43,21 @@ export function LocationSection({
 
       {/* Transportation Info */}
       {lineInfo && (
-        <div className="flex items-center justify-center gap-2 text-sm">
-          <span className="text-muted-foreground">{lineInfo.station}역</span>
-          <div className="flex gap-1.5">
-            {lineInfo.lines.map((line) => (
-              <span
-                key={line.name}
-                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium text-white"
-                style={{ backgroundColor: line.color }}
-              >
-                {line.name}
-              </span>
-            ))}
+        <div className="space-y-2 text-left">
+          <p className="text-sm font-bold sm:text-base">지하철</p>
+          <div className="flex items-center gap-2 text-sm sm:text-base">
+            <span className="text-muted-foreground">{lineInfo.station}역</span>
+            <div className="flex gap-1.5">
+              {lineInfo.lines.map((line) => (
+                <Badge
+                  key={line.name}
+                  className="text-white"
+                  style={{ backgroundColor: line.color }}
+                >
+                  {line.name}
+                </Badge>
+              ))}
+            </div>
           </div>
         </div>
       )}

--- a/src/app/(preview)/preview/[publicKey]/_components/Navigation.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/Navigation.tsx
@@ -12,9 +12,9 @@ interface NavigationProps {
 
 const Navigation = ({ address, geoState }: NavigationProps) => {
   return (
-    <div className="space-y-2">
-      <p className="text-sm font-bold">네비게이션</p>
-      <p className="text-muted-foreground text-xs">
+    <div className="space-y-2 text-left">
+      <p className="text-sm font-bold sm:text-base">네비게이션</p>
+      <p className="text-muted-foreground text-xs sm:text-sm">
         원하시는 앱을 선택하시면 길안내가 시작됩니다.
       </p>
       <div className="flex flex-col gap-2">

--- a/src/app/(preview)/preview/[publicKey]/_utils/invitationMessage.mapper.ts
+++ b/src/app/(preview)/preview/[publicKey]/_utils/invitationMessage.mapper.ts
@@ -6,8 +6,13 @@ interface Contact {
   phone: string;
 }
 
+interface ParentName {
+  label: string;
+  name: string;
+}
+
 interface Party {
-  parentNames: string;
+  parents: ParentName[];
   name: string;
   title: string;
   contacts: Contact[];
@@ -35,16 +40,16 @@ function createContact(
   };
 }
 
-// 헬퍼 함수 2: 부모님 이름 문자열 생성
-function getParentNamesString(parents: CoupleSide): string {
-  const parts = [];
+// 헬퍼 함수 2: 부모님 이름 목록 생성
+function getParentNames(parents: CoupleSide): ParentName[] {
+  const list: ParentName[] = [];
   if (parents.father?.name) {
-    parts.push(`아버지 ${parents.father.name}`);
+    list.push({ label: "아버지", name: parents.father.name });
   }
   if (parents.mother?.name) {
-    parts.push(`어머니 ${parents.mother.name}`);
+    list.push({ label: "어머니", name: parents.mother.name });
   }
-  return parts.join(" · ");
+  return list;
 }
 
 /**
@@ -72,13 +77,13 @@ export function mapCoupleInfoToInvitationProps(
   // 3. UI 표시에 필요한 최종 데이터 배열 조립
   const displayParties: Party[] = [
     {
-      parentNames: getParentNamesString(coupleInfoData.groom),
+      parents: getParentNames(coupleInfoData.groom),
       name: coupleInfoData.groom.name,
       title: "신랑",
       contacts: groomSideContacts,
     },
     {
-      parentNames: getParentNamesString(coupleInfoData.bride),
+      parents: getParentNames(coupleInfoData.bride),
       name: coupleInfoData.bride.name,
       title: "신부",
       contacts: brideSideContacts,

--- a/src/app/(preview)/preview/sample/_constants/sampleInvitation.ts
+++ b/src/app/(preview)/preview/sample/_constants/sampleInvitation.ts
@@ -21,7 +21,7 @@ export const sampleInvitation = {
   venue: "타이노트 웨딩홀",
   address: "서울특별시 중구 세종대로 110",
   addressDetail: "그랜드홀 2층",
-  subwayStation: "시청역",
+  subwayStation: "시청",
   guestbookEnabled: true,
   thumbnailImages: [
     "/assets/images/output.webp",


### PR DESCRIPTION
## Summary

- LocationSection의 지하철/네비게이션 서브 라벨이 `EyebrowSection`의 `text-center` 상속으로 가운데 정렬돼 있던 걸 왼쪽 정렬로 통일하고, 두 라벨의 텍스트 크기를 맞췄다.
- `EyebrowSection` 공통 헤딩과 LocationSection/Navigation/InvitationMessage 주요 텍스트에 `sm:` 반응형 크기를 추가해 HeroSection에 이미 있던 반응형 컨벤션을 다른 섹션에도 맞췄다.
- 샘플 데이터 `subwayStation`의 중복된 "역" 표기(`시청역` → `시청`)를 LocationSection이 자체적으로 "역"을 붙이는 구조에 맞게 수정했다.
- `InvitationMessage`: 부모님 성함을 하나로 합친 문자열 대신 "아버지 [이름]" / "어머니 [이름]"을 자녀와 동일한 네이밍 패턴으로 분리해 2열 가운데 정렬로, 신랑/신부 이름은 그 아래 가운데 정렬로 재구성했다.

## Test plan

- `npm run tsc` — 통과
- `npm run lint` — 통과
- 브라우저(모바일 390px / 데스크톱 800px 뷰포트)에서 `/preview/sample` 직접 렌더 확인: 지하철/네비게이션 라벨 정렬, InvitationMessage 2열 구조, 반응형 크기 확대 모두 의도대로 동작
- Not run: 컴포넌트 단위 테스트 없음(기존에도 없던 파일들)