### PR TITLE
fix(hero): 히어로 캐러셀을 풀블리드 embla 방식으로 교체

### DIFF
--- a/src/ui/components/organisms/EcommerceHero.tsx
+++ b/src/ui/components/organisms/EcommerceHero.tsx
@@ -1,29 +1,52 @@
 "use client";
 
-import { Fragment, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { motion, AnimatePresence } from "motion/react";
-import { Button, TypographyH1 } from "@/ui/components/atoms";
+import {
+  Button,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  TypographyH1,
+  type CarouselApi,
+} from "@/ui/components/atoms";
 import { cn } from "@/core/utils";
 import promotionsData from "@/core/content/promotions.json";
 import type { Promotion } from "@/core/domain";
-import { useIntervalIndex } from "@/ui/hooks";
 
 const promotions = (promotionsData as Promotion[]).filter((p) => p.isActive);
+const AUTOPLAY_INTERVAL = 5000;
 
 export const EcommerceHero = () => {
+  const [api, setApi] = useState<CarouselApi>();
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
 
-  const { currentIndex, setIndex } = useIntervalIndex({
-    length: promotions.length,
-    interval: 5000,
-    isPaused,
-  });
+  useEffect(() => {
+    if (!api) return;
+
+    const onSelect = () => setSelectedIndex(api.selectedScrollSnap());
+    onSelect();
+    api.on("select", onSelect);
+    api.on("reInit", onSelect);
+
+    return () => {
+      api.off("select", onSelect);
+      api.off("reInit", onSelect);
+    };
+  }, [api]);
+
+  useEffect(() => {
+    if (!api || isPaused || promotions.length <= 1) return;
+
+    const timer = setInterval(() => api.scrollNext(), AUTOPLAY_INTERVAL);
+    return () => clearInterval(timer);
+  }, [api, isPaused]);
 
   if (promotions.length === 0) return null;
-
-  const active = promotions[currentIndex];
 
   return (
     <section
@@ -31,84 +54,76 @@ export const EcommerceHero = () => {
       onMouseEnter={() => setIsPaused(true)}
       onMouseLeave={() => setIsPaused(false)}
     >
-      <div className="container mx-auto px-4">
-        <div className="md:flex">
-          {/* 탭 열 — 모바일: 상단 가로 언더라인 / 데스크톱: 좌측 세로 38.2% */}
-          <div className="border-border scrollbar-hide bg-background flex gap-1 overflow-x-auto border-b px-3 md:w-[38.2%] md:flex-shrink-0 md:flex-col md:justify-center md:gap-1.5 md:border-r md:border-b-0 md:px-8 md:py-10">
-            {promotions.map((promo, index) => {
-              const isActive = active.id === promo.id;
-              return (
+      <Carousel setApi={setApi} opts={{ loop: true }} className="relative">
+        <CarouselContent className="ml-0">
+          {promotions.map((promo) => (
+            <CarouselItem key={promo.id} className="relative min-h-[420px] pl-0 md:min-h-[560px]">
+              <Image
+                src={promo.image}
+                alt={promo.label}
+                fill
+                sizes="100vw"
+                className="object-cover"
+                priority
+              />
+              {/* 텍스트 가독성용 하단 스크림 — ProductCard 사진 오버레이와 동일 관례 */}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+
+              <div className="absolute inset-x-0 bottom-0 flex flex-col items-start gap-3 p-6 md:p-10">
+                {promo.badge && (
+                  <span className="bg-foreground/85 text-background w-fit rounded-full px-3 py-1.5 text-xs font-bold tracking-wide backdrop-blur-sm">
+                    {promo.badge}
+                  </span>
+                )}
+
+                <TypographyH1 className="font-[var(--font-NotoSerif)] max-w-2xl text-left text-2xl leading-tight font-bold text-white md:text-3xl">
+                  {promo.title.split("\n").map((line, i) => (
+                    <Fragment key={i}>
+                      {line}
+                      <br />
+                    </Fragment>
+                  ))}
+                </TypographyH1>
+
+                <p className="max-w-xl text-sm leading-relaxed whitespace-pre-line text-white/80 md:text-base">
+                  {promo.description}
+                </p>
+
+                <Button asChild size="lg" className="w-fit">
+                  <Link href={promo.cta.href}>{promo.cta.label}</Link>
+                </Button>
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+
+        {promotions.length > 1 && (
+          <>
+            <div className="hidden md:block">
+              <CarouselPrevious className="left-4 -translate-y-1/2 bg-white/80 hover:bg-white" />
+              <CarouselNext className="right-4 -translate-y-1/2 bg-white/80 hover:bg-white" />
+            </div>
+
+            <div className="absolute right-4 bottom-4 z-10 flex items-center gap-2 md:right-8 md:bottom-6">
+              {promotions.map((promo, index) => (
                 <button
                   key={promo.id}
                   type="button"
+                  aria-label={promo.label}
                   onClick={() => {
-                    setIndex(index);
+                    api?.scrollTo(index);
                     setIsPaused(true);
                   }}
                   className={cn(
-                    "shrink-0 border-b-2 px-2 py-3.5 text-sm font-bold whitespace-nowrap transition-colors md:rounded-r-lg md:border-b-0 md:border-l-2 md:px-4 md:py-3",
-                    isActive
-                      ? "text-primary border-primary md:bg-secondary"
-                      : "text-muted-foreground hover:text-foreground border-transparent",
+                    "h-1.5 rounded-full transition-all",
+                    selectedIndex === index ? "w-6 bg-white" : "w-1.5 bg-white/50",
                   )}
-                >
-                  {promo.label}
-                </button>
-              );
-            })}
-          </div>
-
-          {/* 배너 — 이미지 전체 배경 + 텍스트 좌하단 오버레이(모바일/데스크톱 동일 개념) */}
-          <div className="relative min-h-[420px] overflow-hidden md:min-h-[560px] md:w-[61.8%]">
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={active.id}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.35, ease: "easeOut" }}
-                className="absolute inset-0"
-              >
-                <Image
-                  src={active.image}
-                  alt={active.label}
-                  fill
-                  sizes="(max-width: 768px) 100vw, 62vw"
-                  className="object-cover"
-                  priority
                 />
-                {/* 텍스트 가독성용 하단 스크림 — ProductCard 사진 오버레이와 동일 관례 */}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
-
-                <div className="absolute inset-x-0 bottom-0 flex flex-col items-start gap-3 p-6 md:p-10">
-                  {active.badge && (
-                    <span className="bg-foreground/85 text-background w-fit rounded-full px-3 py-1.5 text-xs font-bold tracking-wide backdrop-blur-sm">
-                      {active.badge}
-                    </span>
-                  )}
-
-                  <TypographyH1 className="font-[var(--font-NotoSerif)] text-left text-2xl leading-tight font-bold text-white md:text-3xl">
-                    {active.title.split("\n").map((line, i) => (
-                      <Fragment key={i}>
-                        {line}
-                        <br />
-                      </Fragment>
-                    ))}
-                  </TypographyH1>
-
-                  <p className="text-sm leading-relaxed whitespace-pre-line text-white/80 md:text-base">
-                    {active.description}
-                  </p>
-
-                  <Button asChild size="lg" className="w-fit">
-                    <Link href={active.cta.href}>{active.cta.label}</Link>
-                  </Button>
-                </div>
-              </motion.div>
-            </AnimatePresence>
-          </div>
-        </div>
-      </div>
+              ))}
+            </div>
+          </>
+        )}
+      </Carousel>
     </section>
   );
 };


### PR DESCRIPTION
## Summary

- 탭+38.2/61.8 split 레이아웃과 자체 motion crossfade 구현을 걷어내고, 이미지가 배너 전체를 덮는 풀블리드 레이아웃 + 프로젝트 공용 embla 기반 `Carousel` atom(`src/ui/components/atoms/carousel.tsx`)으로 교체했다.
- 프로모션 탭 라벨 리스트는 제거하고 화살표(md 이상만 노출) + 자동재생(5초) + dot indicator로 대체했다. 모바일은 스와이프 제스처 + dot만 사용한다.
- 기존 호버 시 자동재생 일시정지 동작은 그대로 유지했다.

## Test plan

- Not run: 로컬 `tsc`/`eslint`/`build` 미실행, `dev` PR의 `static` 필수 체크(CI)로 검증 위임