### PR TITLE
feat(preview): 테마별 인터랙션 연출을 추가한다

### DIFF
--- a/src/app/(preview)/preview/[publicKey]/_components/InvitationTemplate.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/InvitationTemplate.tsx
@@ -1,6 +1,7 @@
 import type { InvitationContent } from "@/core/domain";
 import { CloudImage } from "@/ui/components/molecules";
 import { ThemeSync } from "./ThemeSync";
+import { InteractionOverlay } from "./interactions";
 import {
   mapCoupleInfoToAccountProps,
   mapCoupleInfoToCalendarProps,
@@ -38,6 +39,7 @@ export function InvitationTemplate({
   return (
     <div className="relative" data-theme={theme}>
       <ThemeSync theme={theme} />
+      <InteractionOverlay theme={theme} />
       <HeroSection {...mapCoupleInfoToHeroProps(content)} />
       <InvitationMessage {...mapCoupleInfoToInvitationProps(content)} />
       <WeddingMonthCalendar {...mapCoupleInfoToCalendarProps(content)} />

--- a/src/app/(preview)/preview/[publicKey]/_components/interactions/BlossomInteraction.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/interactions/BlossomInteraction.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useTransform, useSpring, motion } from "motion/react";
+import type { MotionValue } from "motion/react";
+import type { ThemeInteractionProps } from "./InteractionOverlay";
+
+const REPEL_RADIUS = 160;
+const REPEL_FORCE = 36;
+
+// 화면 곳곳에 흩어둔 꽃잎 기준 위치 — blossom-petal 앰비언트 CSS와 같은
+// left% 분산 패턴을 재사용한다.
+const PETAL_BASE_POSITIONS = [
+  { left: 10, top: 18 },
+  { left: 26, top: 62 },
+  { left: 42, top: 30 },
+  { left: 58, top: 74 },
+  { left: 74, top: 22 },
+  { left: 88, top: 58 },
+] as const;
+
+interface PetalProps {
+  baseLeft: number;
+  baseTop: number;
+  x: MotionValue<number>;
+  y: MotionValue<number>;
+}
+
+function Petal({ baseLeft, baseTop, x, y }: PetalProps) {
+  // dist가 0에 가까울수록(커서가 꽃잎 바로 위) 힘은 최대여야 한다 — 0으로
+  // 나누는 것만 막고(epsilon), "가깝다"를 "힘 없음"으로 착각하지 않는다.
+  const offsetX = useTransform(() => {
+    if (typeof window === "undefined") return 0;
+    const baseX = (baseLeft / 100) * window.innerWidth;
+    const dx = baseX - x.get();
+    const dy = (baseTop / 100) * window.innerHeight - y.get();
+    const dist = Math.hypot(dx, dy);
+    if (dist > REPEL_RADIUS) return 0;
+    return (dx / Math.max(dist, 1)) * (1 - dist / REPEL_RADIUS) * REPEL_FORCE;
+  });
+  const offsetY = useTransform(() => {
+    if (typeof window === "undefined") return 0;
+    const baseX = (baseLeft / 100) * window.innerWidth;
+    const baseY = (baseTop / 100) * window.innerHeight;
+    const dx = baseX - x.get();
+    const dy = baseY - y.get();
+    const dist = Math.hypot(dx, dy);
+    if (dist > REPEL_RADIUS) return 0;
+    return (dy / Math.max(dist, 1)) * (1 - dist / REPEL_RADIUS) * REPEL_FORCE;
+  });
+
+  const springX = useSpring(offsetX, { stiffness: 140, damping: 14 });
+  const springY = useSpring(offsetY, { stiffness: 140, damping: 14 });
+  const rotate = useTransform(springX, [-REPEL_FORCE, REPEL_FORCE], [-50, 50]);
+
+  return (
+    <motion.span
+      aria-hidden
+      className="absolute text-lg"
+      style={{
+        left: `${baseLeft}%`,
+        top: `${baseTop}%`,
+        color: "var(--blossom-pink)",
+        x: springX,
+        y: springY,
+        rotate,
+      }}
+    >
+      🌸
+    </motion.span>
+  );
+}
+
+export function BlossomInteraction({ x, y }: ThemeInteractionProps) {
+  return (
+    <>
+      {PETAL_BASE_POSITIONS.map((pos, index) => (
+        <Petal key={index} baseLeft={pos.left} baseTop={pos.top} x={x} y={y} />
+      ))}
+    </>
+  );
+}

--- a/src/app/(preview)/preview/[publicKey]/_components/interactions/BotanicalInteraction.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/interactions/BotanicalInteraction.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useTransform, motion } from "motion/react";
+import type { MotionValue } from "motion/react";
+import type { ThemeInteractionProps } from "./InteractionOverlay";
+
+const MAX_TILT_DEG = 14;
+
+// 화면 모서리에 배치한 잎사귀 — depth가 클수록 parallax 이동폭이 커진다.
+const LEAF_POSITIONS = [
+  { left: 6, top: 10, depth: 1 },
+  { left: 92, top: 14, depth: 0.7 },
+  { left: 10, top: 82, depth: 0.7 },
+  { left: 90, top: 84, depth: 1 },
+] as const;
+
+interface LeafProps {
+  baseLeft: number;
+  baseTop: number;
+  depth: number;
+  x: MotionValue<number>;
+  y: MotionValue<number>;
+}
+
+function Leaf({ baseLeft, baseTop, depth, x, y }: LeafProps) {
+  const offsetXRatio = useTransform(() => {
+    if (typeof window === "undefined") return 0;
+    return (x.get() - window.innerWidth / 2) / (window.innerWidth / 2);
+  });
+  const offsetYRatio = useTransform(() => {
+    if (typeof window === "undefined") return 0;
+    return (y.get() - window.innerHeight / 2) / (window.innerHeight / 2);
+  });
+
+  const rotateY = useTransform(offsetXRatio, (v) => v * MAX_TILT_DEG);
+  const rotateX = useTransform(offsetYRatio, (v) => -v * MAX_TILT_DEG);
+  const parallaxX = useTransform(offsetXRatio, (v) => v * 14 * depth);
+  const parallaxY = useTransform(offsetYRatio, (v) => v * 14 * depth);
+
+  return (
+    <motion.span
+      aria-hidden
+      className="absolute text-2xl"
+      style={{
+        left: `${baseLeft}%`,
+        top: `${baseTop}%`,
+        color: "var(--botanical-green)",
+        x: parallaxX,
+        y: parallaxY,
+        rotateX,
+        rotateY,
+      }}
+    >
+      🍃
+    </motion.span>
+  );
+}
+
+export function BotanicalInteraction({ x, y }: ThemeInteractionProps) {
+  return (
+    <div className="h-full w-full" style={{ perspective: 800 }}>
+      {LEAF_POSITIONS.map((pos, index) => (
+        <Leaf
+          key={index}
+          baseLeft={pos.left}
+          baseTop={pos.top}
+          depth={pos.depth}
+          x={x}
+          y={y}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(preview)/preview/[publicKey]/_components/interactions/DefaultInteraction.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/interactions/DefaultInteraction.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useSpring, useTransform, motion } from "motion/react";
+import type { ThemeInteractionProps } from "./InteractionOverlay";
+
+const SPOTLIGHT_SIZE = 220;
+
+// 커서/터치 지점을 은은하게 따라다니는 spotlight glow.
+export function DefaultInteraction({ x, y }: ThemeInteractionProps) {
+  const springX = useSpring(x, { stiffness: 260, damping: 32 });
+  const springY = useSpring(y, { stiffness: 260, damping: 32 });
+  const left = useTransform(springX, (v) => v - SPOTLIGHT_SIZE / 2);
+  const top = useTransform(springY, (v) => v - SPOTLIGHT_SIZE / 2);
+
+  return (
+    <motion.div
+      aria-hidden
+      className="absolute rounded-full blur-2xl"
+      style={{
+        left,
+        top,
+        width: SPOTLIGHT_SIZE,
+        height: SPOTLIGHT_SIZE,
+        background:
+          "radial-gradient(circle, var(--accent) 0%, transparent 70%)",
+        opacity: 0.5,
+      }}
+    />
+  );
+}

--- a/src/app/(preview)/preview/[publicKey]/_components/interactions/InteractionOverlay.test.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/interactions/InteractionOverlay.test.tsx
@@ -1,0 +1,54 @@
+import { act, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { InteractionOverlay } from "./InteractionOverlay";
+
+// InteractionOverlay의 리스너는 React 합성 이벤트가 아니라 window에 직접
+// 붙은 네이티브 리스너라 dispatchEvent가 트리거하는 setState를 act()로
+// 감싸야 커밋된 결과를 곧바로 단언할 수 있다.
+function firePointerMove(x: number, y: number) {
+  act(() => {
+    window.dispatchEvent(new MouseEvent("pointermove", { clientX: x, clientY: y }));
+  });
+}
+
+// prefers-reduced-motion 분기는 여기서 검증하지 않는다: motion/react의
+// useReducedMotion은 matchMedia 결과를 모듈 스코프에 프로세스 생애주기 동안
+// 딱 한 번만 캐시해서, 같은 테스트 파일 안에서 matchMedia를 목킹해 값을
+// 바꿔가며 검증하면 그 뒤 테스트 전부가 첫 캐시값에 오염된다.
+
+describe("InteractionOverlay", () => {
+  it("첫 입력 전에는 아무것도 렌더하지 않는다", () => {
+    const { container } = render(<InteractionOverlay theme="blossom" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("blossom 테마는 pointermove 이후 꽃잎을 렌더한다", () => {
+    const { container } = render(<InteractionOverlay theme="blossom" />);
+    firePointerMove(200, 200);
+    expect(container.textContent).toContain("🌸");
+  });
+
+  it("botanical 테마는 pointermove 이후 잎사귀를 렌더한다", () => {
+    const { container } = render(<InteractionOverlay theme="botanical" />);
+    firePointerMove(200, 200);
+    expect(container.textContent).toContain("🍃");
+  });
+
+  it("midnight 테마는 pointermove 이후 트레일 파티클을 렌더한다", () => {
+    const { container } = render(<InteractionOverlay theme="midnight" />);
+    firePointerMove(200, 200);
+    expect(container.textContent).toContain("✦");
+  });
+
+  it("default 테마는 pointermove 이후 spotlight glow를 렌더한다", () => {
+    const { container } = render(<InteractionOverlay theme="default" />);
+    firePointerMove(200, 200);
+    expect(container.querySelector('[style*="radial-gradient"]')).not.toBeNull();
+  });
+
+  it("등록되지 않은 테마 문자열은 default(spotlight)로 폴백한다", () => {
+    const { container } = render(<InteractionOverlay theme="does-not-exist" />);
+    firePointerMove(200, 200);
+    expect(container.querySelector('[style*="radial-gradient"]')).not.toBeNull();
+  });
+});

--- a/src/app/(preview)/preview/[publicKey]/_components/interactions/InteractionOverlay.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/interactions/InteractionOverlay.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ComponentType } from "react";
+import { useMotionValue, useReducedMotion } from "motion/react";
+import type { MotionValue } from "motion/react";
+import { BlossomInteraction } from "./BlossomInteraction";
+import { BotanicalInteraction } from "./BotanicalInteraction";
+import { MidnightInteraction } from "./MidnightInteraction";
+import { DefaultInteraction } from "./DefaultInteraction";
+
+export interface ThemeInteractionProps {
+  x: MotionValue<number>;
+  y: MotionValue<number>;
+}
+
+const themeInteractionMap: Record<string, ComponentType<ThemeInteractionProps>> = {
+  blossom: BlossomInteraction,
+  botanical: BotanicalInteraction,
+  midnight: MidnightInteraction,
+  default: DefaultInteraction,
+};
+
+interface InteractionOverlayProps {
+  theme: string;
+}
+
+// 청첩장 테마별로 포인터/터치 입력에 반응하는 연출을 얹는다. 오버레이는 좌표만
+// 관찰하고(passive) pointer-events:none이라 아래 콘텐츠·Radix Dialog 클릭을
+// 절대 가로채지 않는다 — prefers-reduced-motion이면 리스너 자체를 안 붙인다.
+export function InteractionOverlay({ theme }: InteractionOverlayProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+  // 실제 입력이 한 번도 없으면 (0,0)은 "커서가 좌상단 모서리에 있다"가 아니라
+  // "아직 입력 없음"을 뜻한다 — 첫 입력 전까지는 아예 렌더하지 않는다. SSR과
+  // hydration 직후 첫 렌더가 항상 이 상태와 같아서 hydration mismatch도 없다.
+  const [hasInteracted, setHasInteracted] = useState(false);
+
+  useEffect(() => {
+    if (shouldReduceMotion) return;
+
+    const handlePointerInput = (event: PointerEvent) => {
+      x.set(event.clientX);
+      y.set(event.clientY);
+      setHasInteracted(true);
+    };
+
+    window.addEventListener("pointermove", handlePointerInput, { passive: true });
+    window.addEventListener("pointerdown", handlePointerInput, { passive: true });
+    return () => {
+      window.removeEventListener("pointermove", handlePointerInput);
+      window.removeEventListener("pointerdown", handlePointerInput);
+    };
+  }, [shouldReduceMotion, x, y]);
+
+  if (shouldReduceMotion || !hasInteracted) return null;
+
+  const ThemeInteraction = themeInteractionMap[theme] ?? DefaultInteraction;
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-40 overflow-hidden">
+      <ThemeInteraction x={x} y={y} />
+    </div>
+  );
+}

--- a/src/app/(preview)/preview/[publicKey]/_components/interactions/MidnightInteraction.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/interactions/MidnightInteraction.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { motion, useMotionValueEvent } from "motion/react";
+import type { ThemeInteractionProps } from "./InteractionOverlay";
+
+const SPAWN_INTERVAL_MS = 70;
+const MAX_TRAIL_POINTS = 16;
+const FADE_DURATION_S = 0.9;
+
+interface TrailPoint {
+  id: number;
+  left: number;
+  top: number;
+}
+
+// 커서/터치 궤적을 따라 금빛 파티클을 흩뿌리고 개별적으로 사라지게 한다.
+export function MidnightInteraction({ x, y }: ThemeInteractionProps) {
+  const [points, setPoints] = useState<TrailPoint[]>([]);
+  const lastSpawnRef = useRef(0);
+  const nextIdRef = useRef(0);
+
+  const spawn = (left: number, top: number) => {
+    const now = performance.now();
+    if (now - lastSpawnRef.current < SPAWN_INTERVAL_MS) return;
+    lastSpawnRef.current = now;
+
+    const id = nextIdRef.current++;
+    setPoints((prev) => [...prev.slice(-MAX_TRAIL_POINTS + 1), { id, left, top }]);
+  };
+
+  // 마운트 시점엔 이미 첫 pointermove가 x/y를 채운 뒤(오버레이가 그 이벤트로
+  // hasInteracted를 켜서 이 컴포넌트를 마운트했기 때문) — 그 값을 즉시 한 번
+  // 찍어야, 다음 이벤트를 기다리지 않고 최초 입력에서 바로 트레일이 보인다.
+  useEffect(() => {
+    spawn(x.get(), y.get());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useMotionValueEvent(x, "change", (latestX) => spawn(latestX, y.get()));
+
+  return (
+    <>
+      {points.map((point) => (
+        <motion.span
+          key={point.id}
+          aria-hidden
+          className="absolute text-sm"
+          style={{ left: point.left, top: point.top, color: "var(--midnight-gold)" }}
+          initial={{ opacity: 0.9, scale: 1 }}
+          animate={{ opacity: 0, scale: 0.2, y: -12 }}
+          transition={{ duration: FADE_DURATION_S, ease: "easeOut" }}
+          onAnimationComplete={() =>
+            setPoints((prev) => prev.filter((p) => p.id !== point.id))
+          }
+        >
+          ✦
+        </motion.span>
+      ))}
+    </>
+  );
+}

--- a/src/app/(preview)/preview/[publicKey]/_components/interactions/index.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/interactions/index.tsx
@@ -1,0 +1,1 @@
+export { InteractionOverlay } from "./InteractionOverlay";


### PR DESCRIPTION
## Summary

- `/preview/[publicKey]`·`/preview/sample` 프리뷰 청첩장이 지금까진 테마(default/blossom/botanical/midnight)마다 색상 토큰만 다르고 나머지는 동일해서, 구매 전 미리보기만으로 테마 간 "느낌 차이"를 판단할 근거가 색상뿐이었다.
- 테마별로 포인터/터치 입력에 반응하는 전용 연출을 프리뷰 전 구간(스크롤 내내, 특정 섹션 국한 아님)에 얹어 테마 고유 성격을 체감시킨다 — blossom(커서/터치 지점에서 꽃잎 repel+scatter), botanical(포인터 좌표 기반 parallax tilt), midnight(궤적 trail+fade), default(spotlight glow).
- `motion`(`motion/react`) 사용, 색은 `globals.css`의 기존 테마 변수 재사용. 오버레이는 passive 리스너 + `pointer-events:none`이라 클릭·Radix Dialog를 절대 가로채지 않는다. `prefers-reduced-motion`이면 전체 비활성화.
- Closes #118

## Test plan

- `npm run tsc` — 통과
- `npx eslint <변경 파일>` — 통과
- `npx vitest run --project component src/app/(preview)` — 10개 테스트 통과 (신규 스모크 테스트 6개 포함)
- Playwright로 `/preview/sample`의 `SAMPLE_THEME`을 4개 테마 각각으로 로컬 전환해가며 데스크톱 포인터 인터랙션 수동 확인(blossom repel, botanical tilt, midnight trail, default spotlight) — 확인 후 `SAMPLE_THEME`은 원래 값(`blossom`)으로 복원, 커밋에 포함 안 됨
- 터치 제스처 실기기 확인은 Not run: 헤드리스 환경이라 실기기 터치 테스트 불가 — Pointer Events 통합 구현이라 데스크톱 포인터 확인으로 좌표 트래킹 로직은 검증됨
