### PR TITLE
fix(preview): 복사 완료 상태를 카드별로 분리한다

### DIFF
--- a/src/app/(preview)/_components/ViewContact.test.tsx
+++ b/src/app/(preview)/_components/ViewContact.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { Dialog, DialogContent } from "@/ui/components/atoms";
+
+import { ViewContact } from "./ViewContact";
+
+describe("ViewContact", () => {
+  it("복사한 연락처 카드에만 복사 완료 상태를 표시한다", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText");
+
+    render(
+      <Dialog open>
+        <DialogContent>
+          <ViewContact
+            payload={[
+              { relation: "신랑", name: "김철수", phone: "010-1111-1111" },
+              { relation: "신부", name: "이영희", phone: "010-2222-2222" },
+            ]}
+          />
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const copiedCard = screen.getByRole("article", {
+      name: "신랑 김철수의 연락처",
+    });
+    const untouchedCard = screen.getByRole("article", {
+      name: "신부 이영희의 연락처",
+    });
+
+    await user.click(within(copiedCard).getByRole("button"));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("010-1111-1111");
+      expect(copiedCard.querySelector(".text-success")).not.toBeNull();
+    });
+    expect(untouchedCard.querySelector(".text-success")).toBeNull();
+  });
+});

--- a/src/app/(preview)/_components/ViewContact.tsx
+++ b/src/app/(preview)/_components/ViewContact.tsx
@@ -14,9 +14,22 @@ interface Contact {
   phone: string;
 }
 
-const ViewContact = ({ payload }: { payload: Contact[] }) => {
+const ContactCard = ({ contact }: { contact: Contact }) => {
   const { isCopied, copyToClipboard } = useCopy();
 
+  return (
+    <PersonValueCard
+      relation={contact.relation}
+      name={contact.name}
+      value={contact.phone}
+      isCopied={isCopied}
+      onCopy={() => copyToClipboard(contact.phone)}
+      ariaLabel={`${contact.relation} ${contact.name}의 연락처`}
+    />
+  );
+};
+
+const ViewContact = ({ payload }: { payload: Contact[] }) => {
   if (!payload || payload.length === 0) {
     return (
       <div className="p-6 text-center">
@@ -42,15 +55,7 @@ const ViewContact = ({ payload }: { payload: Contact[] }) => {
 
       <div className="mt-2 space-y-3 p-0">
         {payload.map((contact) => (
-          <PersonValueCard
-            key={contact.relation}
-            relation={contact.relation}
-            name={contact.name}
-            value={contact.phone}
-            isCopied={isCopied}
-            onCopy={() => copyToClipboard(contact.phone)}
-            ariaLabel={`${contact.relation} ${contact.name}의 연락처`}
-          />
+          <ContactCard key={contact.relation} contact={contact} />
         ))}
       </div>
     </div>

--- a/src/app/(preview)/preview/[publicKey]/_components/AccountSection.test.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/AccountSection.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type * as HooksModule from "@/ui/hooks";
+
+vi.mock("@/ui/hooks", async (importOriginal) => {
+  const hooks = await importOriginal<typeof HooksModule>();
+
+  return {
+    ...hooks,
+    useBanks: () => ({ banks: undefined, isLoading: false, isError: undefined }),
+  };
+});
+
+import { AccountSection } from "./AccountSection";
+
+describe("AccountSection", () => {
+  it("복사한 계좌 카드에만 복사 완료 상태를 표시한다", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText");
+
+    render(
+      <AccountSection
+        groomAccounts={[
+          {
+            relation: "신랑",
+            name: "김철수",
+            bankName: "bank-a",
+            accountNumber: "111-111",
+          },
+          {
+            relation: "신랑 아버지",
+            name: "김영수",
+            bankName: "bank-b",
+            accountNumber: "222-222",
+          },
+        ]}
+        brideAccounts={[]}
+      />,
+    );
+
+    const copiedCard = screen.getByRole("article", {
+      name: "신랑 김철수의 계좌 정보",
+    });
+    const untouchedCard = screen.getByRole("article", {
+      name: "신랑 아버지 김영수의 계좌 정보",
+    });
+
+    await user.click(within(copiedCard).getByRole("button"));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("111-111");
+      expect(copiedCard.querySelector(".text-success")).not.toBeNull();
+    });
+    expect(untouchedCard.querySelector(".text-success")).toBeNull();
+  });
+});

--- a/src/app/(preview)/preview/[publicKey]/_components/AccountSection.test.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/AccountSection.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+import type { BanksResponse } from "@/core/schemas";
 import type * as HooksModule from "@/ui/hooks";
 
 vi.mock("@/ui/hooks", async (importOriginal) => {
@@ -9,7 +10,7 @@ vi.mock("@/ui/hooks", async (importOriginal) => {
 
   return {
     ...hooks,
-    useBanks: () => ({ banks: undefined, isLoading: false, isError: undefined }),
+    useBanks: () => ({ banks: [] as BanksResponse, isLoading: false, isError: false }),
   };
 });
 

--- a/src/app/(preview)/preview/[publicKey]/_components/AccountSection.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/AccountSection.tsx
@@ -14,6 +14,26 @@ import type {
   AccountSectionMappedProps,
 } from "../_utils/accountSection.mapper";
 
+interface AccountCardProps {
+  account: AccountInfo;
+  bankName: string;
+}
+
+const AccountCard = ({ account, bankName }: AccountCardProps) => {
+  const { isCopied, copyToClipboard } = useCopy();
+
+  return (
+    <PersonValueCard
+      relation={account.relation}
+      name={account.name}
+      subLabel={bankName}
+      value={account.accountNumber}
+      isCopied={isCopied}
+      onCopy={() => copyToClipboard(account.accountNumber)}
+      ariaLabel={`${account.relation} ${account.name}의 계좌 정보`}
+    />
+  );
+};
 
 const AccountSection = ({
   groomAccounts,
@@ -21,7 +41,6 @@ const AccountSection = ({
 }: AccountSectionMappedProps) => {
   const [selectedSide, setSelectedSide] = useState<"groom" | "bride">("groom");
   const { banks } = useBanks();
-  const { isCopied, copyToClipboard } = useCopy();
 
   const bankNameMap = useMemo(() => {
     if (!banks) return {};
@@ -44,15 +63,10 @@ const AccountSection = ({
     }
 
     return accounts.map((account) => (
-      <PersonValueCard
+      <AccountCard
         key={account.relation}
-        relation={account.relation}
-        name={account.name}
-        subLabel={bankNameMap[account.bankName] || account.bankName}
-        value={account.accountNumber}
-        isCopied={isCopied}
-        onCopy={() => copyToClipboard(account.accountNumber)}
-        ariaLabel={`${account.relation} ${account.name}의 계좌 정보`}
+        account={account}
+        bankName={bankNameMap[account.bankName] || account.bankName}
       />
     ));
   };


### PR DESCRIPTION
## Summary

- 계좌 및 연락처 카드가 섹션 단위의 복사 완료 상태를 공유해 여러 카드가 동시에 완료로 표시되던 문제를 수정합니다.
- 각 카드가 독립적인 복사 상태를 관리하도록 분리하고 양쪽 흐름에 회귀 테스트를 추가합니다.
- Closes #122

## Test plan

- Not run: 요청에 따라 로컬 검증은 생략하고 CI에 위임합니다.