### PR TITLE
fix(preview): 부모 관계 표기에 측 구분과 존칭을 적용한다

### DIFF
--- a/src/app/(preview)/preview/[publicKey]/_utils/accountSection.mapper.test.ts
+++ b/src/app/(preview)/preview/[publicKey]/_utils/accountSection.mapper.test.ts
@@ -4,29 +4,35 @@ import type { InvitationContent } from "@/core/domain";
 
 import { mapCoupleInfoToAccountProps } from "./accountSection.mapper";
 
-const invitationContent = {
+const invitationContent: InvitationContent = {
   groom: {
     name: "신랑",
+    phone: "010-0000-0001",
     father: {
       name: "김철수",
+      phone: "010-1111-1111",
       bankName: "은행",
       accountNumber: "1",
     },
     mother: {
       name: "이영희",
+      phone: "010-2222-2222",
       bankName: "은행",
       accountNumber: "2",
     },
   },
   bride: {
     name: "신부",
+    phone: "010-0000-0002",
     father: {
       name: "박민수",
+      phone: "010-3333-3333",
       bankName: "은행",
       accountNumber: "3",
     },
     mother: {
       name: "최지은",
+      phone: "010-4444-4444",
       bankName: "은행",
       accountNumber: "4",
     },
@@ -38,7 +44,7 @@ const invitationContent = {
   guestbookEnabled: true,
   thumbnailImages: [],
   galleryImages: [],
-} satisfies InvitationContent;
+};
 
 describe("계좌 정보 매퍼", () => {
   it("부모 계좌 관계를 측과 존칭을 포함해 표시한다", () => {

--- a/src/app/(preview)/preview/[publicKey]/_utils/accountSection.mapper.test.ts
+++ b/src/app/(preview)/preview/[publicKey]/_utils/accountSection.mapper.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import type { InvitationContent } from "@/core/domain";
+
+import { mapCoupleInfoToAccountProps } from "./accountSection.mapper";
+
+const invitationContent = {
+  groom: {
+    name: "신랑",
+    father: {
+      name: "김철수",
+      bankName: "은행",
+      accountNumber: "1",
+    },
+    mother: {
+      name: "이영희",
+      bankName: "은행",
+      accountNumber: "2",
+    },
+  },
+  bride: {
+    name: "신부",
+    father: {
+      name: "박민수",
+      bankName: "은행",
+      accountNumber: "3",
+    },
+    mother: {
+      name: "최지은",
+      bankName: "은행",
+      accountNumber: "4",
+    },
+  },
+  weddingDate: new Date("2099-01-01"),
+  venue: "예식장",
+  address: "주소",
+  addressDetail: "상세 주소",
+  guestbookEnabled: true,
+  thumbnailImages: [],
+  galleryImages: [],
+} satisfies InvitationContent;
+
+describe("계좌 정보 매퍼", () => {
+  it("부모 계좌 관계를 측과 존칭을 포함해 표시한다", () => {
+    const result = mapCoupleInfoToAccountProps(invitationContent);
+
+    expect(result.groomAccounts.map(({ relation }) => relation)).toEqual([
+      "신랑측 아버님",
+      "신랑측 어머님",
+    ]);
+    expect(result.brideAccounts.map(({ relation }) => relation)).toEqual([
+      "신부측 아버님",
+      "신부측 어머님",
+    ]);
+  });
+});

--- a/src/app/(preview)/preview/[publicKey]/_utils/accountSection.mapper.ts
+++ b/src/app/(preview)/preview/[publicKey]/_utils/accountSection.mapper.ts
@@ -43,15 +43,15 @@ export function mapCoupleInfoToAccountProps(
   // 1. 신랑측 계좌 정보 배열 생성
   const groomAccounts = [
     createAccountInfo(coupleInfoData.groom, "신랑"),
-    createAccountInfo(coupleInfoData.groom.father, "신랑 아버지"),
-    createAccountInfo(coupleInfoData.groom.mother, "신랑 어머니"),
+    createAccountInfo(coupleInfoData.groom.father, "신랑측 아버님"),
+    createAccountInfo(coupleInfoData.groom.mother, "신랑측 어머님"),
   ].filter((account): account is AccountInfo => !!account);
 
   // 2. 신부측 계좌 정보 배열 생성
   const brideAccounts = [
     createAccountInfo(coupleInfoData.bride, "신부"),
-    createAccountInfo(coupleInfoData.bride.father, "신부 아버지"),
-    createAccountInfo(coupleInfoData.bride.mother, "신부 어머니"),
+    createAccountInfo(coupleInfoData.bride.father, "신부측 아버님"),
+    createAccountInfo(coupleInfoData.bride.mother, "신부측 어머님"),
   ].filter((account): account is AccountInfo => !!account);
 
   return { groomAccounts, brideAccounts };

--- a/src/app/(preview)/preview/[publicKey]/_utils/invitationMessage.mapper.test.ts
+++ b/src/app/(preview)/preview/[publicKey]/_utils/invitationMessage.mapper.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { InvitationContent } from "@/core/domain";
+
+import { mapCoupleInfoToInvitationProps } from "./invitationMessage.mapper";
+
+const invitationContent = {
+  groom: {
+    name: "신랑",
+    father: { name: "김철수", phone: "010-1111-1111" },
+    mother: { name: "이영희", phone: "010-2222-2222" },
+  },
+  bride: {
+    name: "신부",
+    father: { name: "박민수", phone: "010-3333-3333" },
+    mother: { name: "최지은", phone: "010-4444-4444" },
+  },
+  weddingDate: new Date("2099-01-01"),
+  venue: "예식장",
+  address: "주소",
+  addressDetail: "상세 주소",
+  guestbookEnabled: true,
+  thumbnailImages: [],
+  galleryImages: [],
+} satisfies InvitationContent;
+
+describe("초대 문구 매퍼", () => {
+  it("부모 연락처 관계를 측과 존칭을 포함해 표시한다", () => {
+    const { parties } = mapCoupleInfoToInvitationProps(invitationContent);
+
+    expect(parties[0].contacts.map(({ relation }) => relation)).toEqual([
+      "신랑측 아버님",
+      "신랑측 어머님",
+    ]);
+    expect(parties[1].contacts.map(({ relation }) => relation)).toEqual([
+      "신부측 아버님",
+      "신부측 어머님",
+    ]);
+  });
+
+  it("부모 이름 라벨에는 측 접두사 없이 존칭만 표시한다", () => {
+    const { parties } = mapCoupleInfoToInvitationProps(invitationContent);
+
+    expect(parties[0].parents.map(({ label }) => label)).toEqual([
+      "아버님",
+      "어머님",
+    ]);
+    expect(parties[1].parents.map(({ label }) => label)).toEqual([
+      "아버님",
+      "어머님",
+    ]);
+  });
+});

--- a/src/app/(preview)/preview/[publicKey]/_utils/invitationMessage.mapper.test.ts
+++ b/src/app/(preview)/preview/[publicKey]/_utils/invitationMessage.mapper.test.ts
@@ -4,14 +4,16 @@ import type { InvitationContent } from "@/core/domain";
 
 import { mapCoupleInfoToInvitationProps } from "./invitationMessage.mapper";
 
-const invitationContent = {
+const invitationContent: InvitationContent = {
   groom: {
     name: "신랑",
+    phone: "010-0000-0001",
     father: { name: "김철수", phone: "010-1111-1111" },
     mother: { name: "이영희", phone: "010-2222-2222" },
   },
   bride: {
     name: "신부",
+    phone: "010-0000-0002",
     father: { name: "박민수", phone: "010-3333-3333" },
     mother: { name: "최지은", phone: "010-4444-4444" },
   },
@@ -22,7 +24,7 @@ const invitationContent = {
   guestbookEnabled: true,
   thumbnailImages: [],
   galleryImages: [],
-} satisfies InvitationContent;
+};
 
 describe("초대 문구 매퍼", () => {
   it("부모 연락처 관계를 측과 존칭을 포함해 표시한다", () => {

--- a/src/app/(preview)/preview/[publicKey]/_utils/invitationMessage.mapper.ts
+++ b/src/app/(preview)/preview/[publicKey]/_utils/invitationMessage.mapper.ts
@@ -44,10 +44,10 @@ function createContact(
 function getParentNames(parents: CoupleSide): ParentName[] {
   const list: ParentName[] = [];
   if (parents.father?.name) {
-    list.push({ label: "아버지", name: parents.father.name });
+    list.push({ label: "아버님", name: parents.father.name });
   }
   if (parents.mother?.name) {
-    list.push({ label: "어머니", name: parents.mother.name });
+    list.push({ label: "어머님", name: parents.mother.name });
   }
   return list;
 }
@@ -63,15 +63,15 @@ export function mapCoupleInfoToInvitationProps(
   // 1. 신랑측 연락처 배열 생성
   const groomSideContacts = [
     createContact(coupleInfoData.groom, "신랑"),
-    createContact(coupleInfoData.groom.father, "신랑 아버지"),
-    createContact(coupleInfoData.groom.mother, "신랑 어머니"),
+    createContact(coupleInfoData.groom.father, "신랑측 아버님"),
+    createContact(coupleInfoData.groom.mother, "신랑측 어머님"),
   ].filter((contact): contact is Contact => !!contact);
 
   // 2. 신부측 연락처 배열 생성
   const brideSideContacts = [
     createContact(coupleInfoData.bride, "신부"),
-    createContact(coupleInfoData.bride.father, "신부 아버지"),
-    createContact(coupleInfoData.bride.mother, "신부 어머니"),
+    createContact(coupleInfoData.bride.father, "신부측 아버님"),
+    createContact(coupleInfoData.bride.mother, "신부측 어머님"),
   ].filter((contact): contact is Contact => !!contact);
 
   // 3. UI 표시에 필요한 최종 데이터 배열 조립


### PR DESCRIPTION
## Summary

- 계좌 및 연락처 카드의 부모 관계를 `신랑측/신부측 아버님/어머님` 형식으로 표시합니다.
- 초대 문구의 부모 이름 라벨에는 측 접두사 없이 `아버님/어머님` 존칭을 적용합니다.
- 두 매퍼의 관계 라벨 계약을 회귀 테스트로 고정합니다.

## Test plan

- `git diff --check origin/dev...HEAD` — 통과
- Not run: 사용자 요청에 따라 자동화 테스트는 PR CI에서 검증

Closes #123