### PR TITLE
fix(contact): 모바일 연락처 카드 겹침을 방지한다

### DIFF
--- a/src/app/(preview)/_components/ViewContact.tsx
+++ b/src/app/(preview)/_components/ViewContact.tsx
@@ -33,14 +33,14 @@ const ViewContact = ({ payload }: { payload: Contact[] }) => {
 
   return (
     <div className="w-full">
-      <DialogHeader className="p-6">
+      <DialogHeader className="p-0">
         <DialogTitle className="text-xl">연락처</DialogTitle>
         <DialogDescription>
           아래 연락처를 통해 축하의 마음을 전해보세요.
         </DialogDescription>
       </DialogHeader>
 
-      <div className="mt-2 space-y-3 p-6 pt-0">
+      <div className="mt-2 space-y-3 p-0">
         {payload.map((contact) => (
           <PersonValueCard
             key={contact.relation}

--- a/src/ui/components/molecules/PersonValueCard.tsx
+++ b/src/ui/components/molecules/PersonValueCard.tsx
@@ -29,26 +29,33 @@ export function PersonValueCard({
 }: PersonValueCardProps) {
   return (
     <Card
-      className="p-4 shadow-sm transition-all hover:shadow-md sm:p-5"
+      className="p-2 shadow-sm transition-all hover:shadow-md sm:p-5"
       role="article"
       aria-label={ariaLabel}
     >
-      <div className="grid grid-cols-[1fr_1.35fr] items-center gap-3">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 sm:grid-cols-[1fr_1.35fr] sm:gap-3">
         <div className="flex min-w-0 flex-col items-start gap-1 text-left">
-          <Badge variant="outline" className="font-normal opacity-80">
+          <Badge
+            variant="outline"
+            className="px-1.5 text-[10px] font-normal opacity-80 sm:px-2 sm:text-xs"
+          >
             {relation}
           </Badge>
-          <TypographyLarge className="[word-break:keep-all] font-bold">
+          <TypographyLarge className="text-sm [word-break:keep-all] font-bold sm:text-lg">
             {name}
           </TypographyLarge>
           {subLabel && <TypographyMuted className="text-sm">{subLabel}</TypographyMuted>}
         </div>
 
-        <div className="flex min-w-0 items-center justify-end gap-2">
-          <TypographyLarge className="whitespace-nowrap text-right font-mono text-sm tracking-tighter sm:text-base">
+        <div className="flex min-w-0 items-center justify-end gap-1 sm:gap-2">
+          <TypographyLarge className="whitespace-nowrap text-right font-mono text-[11px] tracking-tighter sm:text-base">
             {value}
           </TypographyLarge>
-          <ClipboardButton isCopied={isCopied} onCopy={onCopy} />
+          <ClipboardButton
+            isCopied={isCopied}
+            onCopy={onCopy}
+            className="size-7 p-0 sm:size-8"
+          />
         </div>
       </div>
     </Card>


### PR DESCRIPTION
## Summary

- 좁은 프리뷰 연락처 모달에서 중첩 패딩을 제거해 카드의 가용 너비를 확보합니다.
- 모바일에서는 카드 콘텐츠와 복사 버튼 크기를 줄이고 값 영역에 필요한 폭을 우선 배정해 전화번호를 줄바꿈 없이 표시합니다.

## Test plan

- Not run: 사용자 요청에 따라 로컬 검증을 생략하고 CI에서 검증합니다.

Closes #121