### PR TITLE
fix(product): 상품 가격을 원 단위 정수로 입력하게 한다

### DIFF
--- a/src/core/schemas/request/product.schema.test.ts
+++ b/src/core/schemas/request/product.schema.test.ts
@@ -122,6 +122,17 @@ describe("productSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("price가 소수면 원 단위 정수 안내와 함께 실패한다", () => {
+    const result = productSchema.safeParse(buildValidInput({ price: 9900.5 }));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "가격은 원 단위 정수로 입력해주세요.",
+      );
+    }
+  });
+
   it("discount.value가 음수면 실패한다", () => {
     const result = productSchema.safeParse(
       buildValidInput({ discount: { discountType: "rate", value: -1 } }),
@@ -151,6 +162,19 @@ describe("productSchema", () => {
     );
 
     expect(result.success).toBe(true);
+  });
+
+  it("amount 할인액이 소수면 원 단위 정수 안내와 함께 실패한다", () => {
+    const result = productSchema.safeParse(
+      buildValidInput({ discount: { discountType: "amount", value: 1000.5 } }),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "할인액은 원 단위 정수로 입력해주세요.",
+      );
+    }
   });
 
   it("discount.discountType이 rate/amount가 아니면 실패한다", () => {

--- a/src/core/schemas/request/product.schema.ts
+++ b/src/core/schemas/request/product.schema.ts
@@ -8,7 +8,10 @@ export const productSchema = z
     category: z.enum(PRODUCT_CATEGORIES),
     subCategory: z.string().min(1, "서브 카테고리를 선택해주세요."),
     theme: z.enum(INVITATION_THEMES).optional(),
-    price: z.number().min(0, "가격은 0 이상이어야 합니다."),
+    price: z
+      .number()
+      .int("가격은 원 단위 정수로 입력해주세요.")
+      .min(0, "가격은 0 이상이어야 합니다."),
     isPremium: z.boolean(),
     featureIds: z.array(z.string()).optional(),
     isFeatured: z.boolean(),
@@ -21,7 +24,7 @@ export const productSchema = z
         }),
         z.object({
           discountType: z.literal("amount"),
-          value: z.number().min(0),
+          value: z.number().int("할인액은 원 단위 정수로 입력해주세요.").min(0),
         }),
       ])
       .optional(),

--- a/src/ui/components/organisms/ProductRegistrationForm.test.tsx
+++ b/src/ui/components/organisms/ProductRegistrationForm.test.tsx
@@ -183,6 +183,34 @@ describe("ProductRegistrationForm", () => {
     expect(screen.getByText("차감 금액 입력")).toBeInTheDocument();
   });
 
+  it("가격과 금액 할인은 원 단위로 입력하고 소수 입력 오류를 표시한다", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const priceInput = screen.getByLabelText(/기본 가격/);
+    expect(priceInput).toHaveAttribute("step", "1");
+
+    await user.type(priceInput, "9900.5");
+    expect(
+      screen.getByText("가격은 원 단위 정수로 입력해주세요."),
+    ).toBeInTheDocument();
+
+    const discountTrigger = screen
+      .getAllByRole("combobox")
+      .find((el) => el.textContent?.includes("비율"));
+    await user.click(discountTrigger!);
+    await user.click(await screen.findByRole("option", { name: "금액 (원)" }));
+
+    const discountInput = screen.getByLabelText("할인");
+    expect(discountInput).toHaveAttribute("step", "1");
+
+    await user.clear(discountInput);
+    await user.type(discountInput, "1000.5");
+    expect(
+      screen.getByText("할인액은 원 단위 정수로 입력해주세요."),
+    ).toBeInTheDocument();
+  });
+
   it("추천 상품 스위치를 켜면 hidden input isFeatured가 true로 바뀐다", async () => {
     const user = userEvent.setup();
     const { container } = renderForm();

--- a/src/ui/components/organisms/ProductRegistrationForm.tsx
+++ b/src/ui/components/organisms/ProductRegistrationForm.tsx
@@ -41,6 +41,8 @@ export function ProductRegistrationForm({
   const [previewPreview, setPreviewPreview] = useState<string | null>(null);
   const [selectedFeatureIds, setSelectedFeatureIds] = useState<string[]>([]);
   const [discountType, setDiscountType] = useState<"rate" | "amount">("rate");
+  const [priceInputError, setPriceInputError] = useState<string | null>(null);
+  const [discountInputError, setDiscountInputError] = useState<string | null>(null);
 
   const images = useImageList();
   // 등록 폼 초기값 1 — 서버 defaultValue와 일치.
@@ -201,13 +203,23 @@ export function ProductRegistrationForm({
                       type="number"
                       placeholder="0"
                       min="0"
-                      step="1000"
+                      step="1"
                       required
                       className="pr-12"
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setPriceInputError(
+                          value !== "" && !Number.isInteger(Number(value))
+                            ? "가격은 원 단위 정수로 입력해주세요."
+                            : null,
+                        );
+                      }}
                     />
                     <span className="text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2 text-sm">원</span>
                   </div>
-                  {priceError && <Alert type="error">{priceError}</Alert>}
+                  {(priceInputError || priceError) && (
+                    <Alert type="error">{priceInputError || priceError}</Alert>
+                  )}
                 </div>
 
                 <div className="space-y-2">
@@ -217,7 +229,10 @@ export function ProductRegistrationForm({
                       id="discountType"
                       name="discount.discountType"
                       defaultValue={discountType}
-                      onValueChange={(v) => setDiscountType(v as "rate" | "amount")}
+                      onValueChange={(v) => {
+                        setDiscountType(v as "rate" | "amount");
+                        setDiscountInputError(null);
+                      }}
                       placeholder=""
                       data={[
                         { value: "rate", label: "비율 (%)" },
@@ -233,10 +248,20 @@ export function ProductRegistrationForm({
                         type="number"
                         placeholder="0"
                         min="0"
-                        step={discountType === "rate" ? "0.01" : "1000"}
+                        step={discountType === "rate" ? "0.01" : "1"}
                         max={discountType === "rate" ? "1" : undefined}
                         defaultValue="0"
                         className="pr-12"
+                        onChange={(event) => {
+                          const value = event.target.value;
+                          setDiscountInputError(
+                            discountType === "amount" &&
+                              value !== "" &&
+                              !Number.isInteger(Number(value))
+                              ? "할인액은 원 단위 정수로 입력해주세요."
+                              : null,
+                          );
+                        }}
                       />
                       <span className="text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2 text-sm">
                         {discountType === "rate" ? "율" : "원"}
@@ -246,6 +271,7 @@ export function ProductRegistrationForm({
                   <TypographyMuted>
                     {discountType === "rate" ? "0~1 사이 소수 입력 (예: 0.1 = 10% 할인)" : "차감 금액 입력"}
                   </TypographyMuted>
+                  {discountInputError && <Alert type="error">{discountInputError}</Alert>}
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary

- 상품 가격과 금액 할인 입력의 1,000원 단위 제한을 제거하고 원 단위 정수만 허용합니다.
- 소수 입력 시 필드 아래에 원 단위 정수 안내를 표시하고 서버 스키마에서도 동일하게 검증합니다.
- 가격 및 금액 할인 입력의 단위와 오류 표시를 회귀 테스트로 고정합니다.

## Test plan

- `npm test -- src/core/schemas/request/product.schema.test.ts` — 37개 테스트 통과
- `JWT_SECRET=test-only-secret-key ENTRY_JWT_SECRET=test-only-entry-secret PORTONE_API_SECRET=test-only-portone-secret npm test -- src/ui/components/organisms/ProductRegistrationForm.test.tsx` — 15개 테스트 통과
- `npx eslint src/ui/components/organisms/ProductRegistrationForm.tsx src/ui/components/organisms/ProductRegistrationForm.test.tsx src/core/schemas/request/product.schema.ts src/core/schemas/request/product.schema.test.ts` — 통과
- `npm run tsc` — 통과

Closes #50