### PR TITLE
feat(product): favor·accessory·예식용품 카테고리에 신규 서브카테고리 5종 추가

### DIFF
--- a/src/app/(main)/_constants/subCategoryIcons.ts
+++ b/src/app/(main)/_constants/subCategoryIcons.ts
@@ -15,6 +15,11 @@ import {
   Ticket,
   BookOpenText,
   Route,
+  Cookie,
+  Sparkles,
+  ShoppingBasket,
+  Mail,
+  BookHeart,
   type LucideIcon,
 } from "lucide-react";
 import type { SubCategory } from "@/core/domain";
@@ -38,4 +43,9 @@ export const subCategoryIcons: Record<SubCategory, LucideIcon> = {
   "escort-card": Ticket, // 예식 용품 — 에스코트 카드
   "program-book": BookOpenText, // 예식 용품 — 예식 순서지
   "aisle-runner": Route, // 예식 용품 — 아일 러너
+  cookie: Cookie, // 답례품 — 쿠키
+  hairpin: Sparkles, // 웨딩소품 — 헤어핀
+  "flower-basket": ShoppingBasket, // 예식 용품 — 플라워걸 바구니
+  "envelope-set": Mail, // 예식 용품 — 축의금 봉투 세트
+  "vow-book": BookHeart, // 예식 용품 — 혼인서약서 북
 };

--- a/src/core/domain/product-category.ts
+++ b/src/core/domain/product-category.ts
@@ -9,10 +9,18 @@ export const PRODUCT_CATEGORIES = [
 
 export const SUB_CATEGORY_MAP = {
   invitation: ["wedding", "first-birthday"],
-  favor: ["candle", "diffuser", "soap", "magnet", "handkerchief"],
-  accessory: ["ring-pillow", "welcome-board", "polaroid-frame"],
+  favor: ["candle", "diffuser", "soap", "magnet", "handkerchief", "cookie"],
+  accessory: ["ring-pillow", "welcome-board", "polaroid-frame", "hairpin"],
   guestbook: ["book", "stamp"],
-  ceremony: ["candle-holder", "escort-card", "program-book", "aisle-runner"],
+  ceremony: [
+    "candle-holder",
+    "escort-card",
+    "program-book",
+    "aisle-runner",
+    "flower-basket",
+    "envelope-set",
+    "vow-book",
+  ],
 } as const satisfies Record<ProductCategory, readonly string[]>;
 
 export const productCategoryLabels: Record<ProductCategory, string> = {
@@ -40,6 +48,11 @@ export const subCategoryLabels: Record<SubCategory, string> = {
   "escort-card": "에스코트 카드",
   "program-book": "예식 순서지",
   "aisle-runner": "아일 러너",
+  cookie: "수제 쿠키 세트",
+  hairpin: "진주 헤어핀 세트",
+  "flower-basket": "화동 바구니",
+  "envelope-set": "축의금 봉투 세트",
+  "vow-book": "예식 문서 케이스 세트",
 };
 
 // ---- 타입은 파생 ----


### PR DESCRIPTION
## Summary

- 이슈 #115에서 invitation 외 카테고리에도 실 상품 최소 1개씩 투입을 요청했는데, favor/accessory/ceremony용으로 준비된 이미지(쿠키, 진주 헤어핀, 화동 바구니, 축의금 봉투 세트, 혼인서약서 문서 케이스)가 기존 subCategory 어느 값과도 맞지 않았다.
- 억지로 기존 값에 끼워맞추지 않고 실제 상품 라인업에 맞는 subCategory 5종(`cookie`, `hairpin`, `flower-basket`, `envelope-set`, `vow-book`)을 `SUB_CATEGORY_MAP`에 추가하고 라벨·아이콘을 채웠다.
- `subCategoryIcons.ts`가 `Record<SubCategory, LucideIcon>`으로 완전 매핑을 강제하므로, 아이콘 누락 시 컴파일 에러로 잡힌다.

## Test plan

- `npx tsc --noEmit` — 통과
- `npx eslint src/core/domain/product-category.ts src/app/(main)/_constants/subCategoryIcons.ts` — 통과
- 관리자 상품 등록 폼에서 5개 신규 subCategory 전부로 실제 상품(썸네일+상세이미지 8장씩) 등록해 정상 저장·목록 노출 확인