### PR TITLE
fix(cloudinary-widget): 업로드 위젯 오픈 시 postMessage DataCloneError를 해결한다

### DIFF
--- a/src/ui/components/molecules/ImageField.tsx
+++ b/src/ui/components/molecules/ImageField.tsx
@@ -38,7 +38,7 @@ const ImageField = ({
               id={id}
               type="button"
               disabled={isLoading}
-              onClick={open}
+              onClick={() => open()}
               className="border-border hover:bg-accent/50 flex h-40 w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed transition-colors disabled:cursor-wait disabled:opacity-60"
             >
               <Upload className="text-muted-foreground mb-2 h-8 w-8" />
@@ -67,7 +67,7 @@ const ImageField = ({
                   type="button"
                   variant="outline"
                   disabled={isLoading}
-                  onClick={open}
+                  onClick={() => open()}
                   className="aspect-square h-full w-full border-dashed"
                   aria-label="이미지 추가"
                 >


### PR DESCRIPTION
## Summary

- 관리자 상품 수정 화면에서 이미지 업로드 위젯을 열 때마다 콘솔에 `DataCloneError: Failed to execute 'postMessage' ... PointerEvent object could not be cloned` 에러가 발생했다(#137).
- 원인: `next-cloudinary`의 `open`은 `(widgetSource?, options?) => void` 시그니처인데, `ImageField.tsx`에서 `onClick={open}`으로 그대로 넘겨 React가 클릭의 네이티브 `PointerEvent`를 `widgetSource` 인자로 전달했다. Cloudinary 위젯이 이 값을 iframe에 `postMessage`하려다 직렬화 실패로 에러를 던졌다.
- `onClick={() => open()}`으로 바꿔 이벤트 객체가 전달되지 않게 했다.

## Test plan

- `npx vitest run src/ui/components/molecules/ImageField.test.tsx` — 통과 (5/5)
- `npx vitest run` (ImageField/ProductEditDialog/ProductRegistrationForm 관련 4개 테스트 파일) — 통과 (35/35)
- dev 서버 + playwright-cli 헤디드 브라우저로 admin 상품 수정 다이얼로그에서 "이미지 추가" 클릭 → 위젯 정상 오픈, 콘솔 에러 0건 확인

Closes #137