### PR TITLE
feat(admin-products): 삭제된 상품 조회·복구(휴지통)를 추가한다

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -14,6 +14,7 @@ export * from "./incrementProductViews";
 export * from "./loginUser";
 export * from "./logoutUser";
 export * from "./requestPasswordReset";
+export * from "./restoreProduct";
 export * from "./signupUser";
 export * from "./updatePremiumFeature";
 export * from "./updateProduct";

--- a/src/actions/restoreProduct.ts
+++ b/src/actions/restoreProduct.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import type { APIResponse } from "@/core/domain";
+import { restoreProductAsAdminService } from "@/services";
+import { actionError } from "@/boundary";
+import { routes } from "@/core/domain";
+
+import { revalidatePath } from "next/cache";
+
+export const restoreProduct = async (
+  productId: string,
+): Promise<APIResponse<{ message: string }>> => {
+  try {
+    await restoreProductAsAdminService(productId);
+
+    revalidatePath(routes.admin.products.root);
+    revalidatePath(routes.products.root);
+
+    return {
+      success: true,
+      data: { message: "상품이 성공적으로 복구되었습니다." },
+    };
+  } catch (e) {
+    return actionError(e);
+  }
+};

--- a/src/actions/workflow-delegation.test.ts
+++ b/src/actions/workflow-delegation.test.ts
@@ -6,6 +6,7 @@ const services = vi.hoisted(() => ({
   signupUserService: vi.fn(),
   completePaymentService: vi.fn(),
   deleteProductAsAdminService: vi.fn(),
+  restoreProductAsAdminService: vi.fn(),
   toggleProductLikeForCurrentUserService: vi.fn(),
 }));
 const revalidatePath = vi.hoisted(() => vi.fn());
@@ -17,6 +18,7 @@ import { loginUser } from "./loginUser";
 import { signupUser } from "./signupUser";
 import { completePayment } from "./completePayment";
 import { deleteProduct } from "./deleteProduct";
+import { restoreProduct } from "./restoreProduct";
 import { toggleProductLike } from "./toggleProductLike";
 
 const formData = (data: Record<string, string>) => {
@@ -78,6 +80,16 @@ describe("Action 유스케이스 위임", () => {
     const result = await deleteProduct("product-1");
 
     expect(services.deleteProductAsAdminService).toHaveBeenCalledWith("product-1");
+    expect(revalidatePath).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+  });
+
+  it("상품 복구 성공 후 관련 캐시를 갱신한다", async () => {
+    services.restoreProductAsAdminService.mockResolvedValue(undefined);
+
+    const result = await restoreProduct("product-1");
+
+    expect(services.restoreProductAsAdminService).toHaveBeenCalledWith("product-1");
     expect(revalidatePath).toHaveBeenCalledTimes(2);
     expect(result.success).toBe(true);
   });

--- a/src/app/(admin)/admin/products/_components/AdminProductsTemplate.test.tsx
+++ b/src/app/(admin)/admin/products/_components/AdminProductsTemplate.test.tsx
@@ -32,4 +32,19 @@ describe("AdminProductsTemplate", () => {
 
     expect(screen.getByText("등록된 상품이 없습니다.")).toBeInTheDocument();
   });
+
+  it("상품 목록/휴지통 탭 링크를 렌더링한다", () => {
+    render(<AdminProductsTemplate products={[buildProduct()]} />);
+
+    const trashLink = screen.getByRole("link", { name: "휴지통" });
+    expect(trashLink).toHaveAttribute("href", "/admin/products?view=trash");
+  });
+
+  it("view가 trash면 휴지통 제목과 빈 상태 문구를 렌더링하고 상품 등록 버튼을 숨긴다", () => {
+    render(<AdminProductsTemplate products={[]} view="trash" />);
+
+    expect(screen.getByRole("heading", { name: "휴지통" })).toBeInTheDocument();
+    expect(screen.getByText("삭제된 상품이 없습니다.")).toBeInTheDocument();
+    expect(screen.queryByText("상품 등록")).not.toBeInTheDocument();
+  });
 });

--- a/src/app/(admin)/admin/products/_components/AdminProductsTemplate.tsx
+++ b/src/app/(admin)/admin/products/_components/AdminProductsTemplate.tsx
@@ -8,22 +8,47 @@ import { ProductTableRow } from "./ProductTableRow";
 
 interface AdminProductsTemplateProps {
   products: ProductJSON[];
+  view?: "active" | "trash";
 }
 
-const AdminProductsTemplate = ({ products }: AdminProductsTemplateProps) => {
+const AdminProductsTemplate = ({
+  products,
+  view = "active",
+}: AdminProductsTemplateProps) => {
+  const isTrash = view === "trash";
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <TypographyH1 className="text-left mb-2 text-3xl font-bold">상품 목록</TypographyH1>
+          <TypographyH1 className="text-left mb-2 text-3xl font-bold">
+            {isTrash ? "휴지통" : "상품 목록"}
+          </TypographyH1>
           <TypographyMuted>
-            등록된 템플릿 상품을 관리합니다. (총 {products.length}개)
+            {isTrash
+              ? `삭제된 상품을 조회하고 복구합니다. (총 ${products.length}개)`
+              : `등록된 템플릿 상품을 관리합니다. (총 ${products.length}개)`}
           </TypographyMuted>
         </div>
-        <Link href={routes.admin.products.new}>
-          <Button size="lg">
-            <Plus className="mr-2 h-5 w-5" />
-            상품 등록
+        {!isTrash && (
+          <Link href={routes.admin.products.new}>
+            <Button size="lg">
+              <Plus className="mr-2 h-5 w-5" />
+              상품 등록
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <Link href={routes.admin.products.root}>
+          <Button variant={isTrash ? "outline" : "default"} size="sm">
+            상품 목록
+          </Button>
+        </Link>
+        <Link href={`${routes.admin.products.root}?view=trash`}>
+          <Button variant={isTrash ? "default" : "outline"} size="sm">
+            휴지통
           </Button>
         </Link>
       </div>
@@ -45,7 +70,7 @@ const AdminProductsTemplate = ({ products }: AdminProductsTemplateProps) => {
             </thead>
             <tbody className="divide-y">
               {products.map((product) => (
-                <ProductTableRow key={product._id} product={product} />
+                <ProductTableRow key={product._id} product={product} view={view} />
               ))}
             </tbody>
           </table>
@@ -53,7 +78,9 @@ const AdminProductsTemplate = ({ products }: AdminProductsTemplateProps) => {
 
         {products.length === 0 && (
           <div className="py-12 text-center">
-            <TypographyMuted>등록된 상품이 없습니다.</TypographyMuted>
+            <TypographyMuted>
+              {isTrash ? "삭제된 상품이 없습니다." : "등록된 상품이 없습니다."}
+            </TypographyMuted>
           </div>
         )}
       </div>

--- a/src/app/(admin)/admin/products/_components/ProductEditDialog.test.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductEditDialog.test.tsx
@@ -85,4 +85,21 @@ describe("ProductEditDialog", () => {
 
     expect(themeTrigger!.textContent).toContain("벚꽃");
   });
+
+  it("판매 상태 드롭다운에 삭제 옵션을 제공하지 않는다 (#136 — 삭제는 삭제/복구 버튼 전용 경로)", async () => {
+    const user = userEvent.setup();
+    render(<ProductEditDialog product={buildProduct({ status: "active" })} />);
+
+    const statusTrigger = screen
+      .getAllByRole("combobox")
+      .find((el) => el.textContent?.includes("판매중"));
+    expect(statusTrigger).toBeDefined();
+
+    await user.click(statusTrigger!);
+
+    expect(screen.getByRole("option", { name: "판매중" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "비활성" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "품절" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "삭제" })).not.toBeInTheDocument();
+  });
 });

--- a/src/app/(admin)/admin/products/_components/ProductEditDialog.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductEditDialog.tsx
@@ -115,11 +115,14 @@ export function ProductEditDialog({ product }: ProductEditDialogProps) {
   const error =
     state && !state.success && "errors" in state.error && state.error.errors;
 
+  // "deleted"는 여기서 선택할 수 없다 — 삭제는 이 드롭다운이 아니라 삭제/복구
+  // 버튼(ProductTableRowAction) 전용 경로이며, deletedAt과 함께 세팅된다.
+  // 드롭다운으로 status만 "deleted"로 바꾸면 deletedAt이 안 바뀌어 목록 필터
+  // (deletedAt 기준)와 상태 표시가 어긋난다(#136).
   const statusOptions = [
     { value: "active", label: "판매중" },
     { value: "inactive", label: "비활성" },
     { value: "soldOut", label: "품절" },
-    { value: "deleted", label: "삭제" },
   ];
 
   return (
@@ -234,7 +237,7 @@ export function ProductEditDialog({ product }: ProductEditDialogProps) {
             name="status"
             defaultValue={status}
             onValueChange={(value) =>
-              setStatus(value as "active" | "inactive" | "soldOut" | "deleted")
+              setStatus(value as "active" | "inactive" | "soldOut")
             }
             placeholder="판매 상태를 선택하세요"
             data={statusOptions}

--- a/src/app/(admin)/admin/products/_components/ProductTableRow.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRow.tsx
@@ -9,9 +9,10 @@ import { productCategoryLabels, subCategoryLabels } from "@/core/domain";
 
 export interface ProductTableRowProps {
   product: Product;
+  view?: "active" | "trash";
 }
 
-export function ProductTableRow({ product }: ProductTableRowProps) {
+export function ProductTableRow({ product, view = "active" }: ProductTableRowProps) {
   return (
     <tr className="hover:bg-muted/50 transition-colors">
       <td className="px-4 py-3">
@@ -61,7 +62,20 @@ export function ProductTableRow({ product }: ProductTableRowProps) {
         </div>
       </td>
       <td className="px-4 py-3">
-        <ProductTableRowSelect product={product} />
+        {view === "trash" ? (
+          <div className="flex flex-col gap-1">
+            <Badge variant="outline" className="w-fit">
+              삭제됨
+            </Badge>
+            {product.deletedAt && (
+              <TypographyMuted>
+                {new Date(product.deletedAt).toLocaleDateString("ko-KR")}
+              </TypographyMuted>
+            )}
+          </div>
+        ) : (
+          <ProductTableRowSelect product={product} />
+        )}
       </td>
       <td className="px-4 py-3">
         <div className="text-muted-foreground flex flex-col gap-1 text-sm">
@@ -83,7 +97,7 @@ export function ProductTableRow({ product }: ProductTableRowProps) {
         <span className="font-mono text-sm">{product.priority}</span>
       </td>
       <td className="px-4 py-3">
-        <ProductTableRowAction product={product} />
+        <ProductTableRowAction product={product} view={view} />
       </td>
     </tr>
   );

--- a/src/app/(admin)/admin/products/_components/ProductTableRowAction.test.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRowAction.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const refreshMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: refreshMock }),
+}));
+
+vi.mock("@/actions", () => ({
+  deleteProduct: vi.fn(),
+  restoreProduct: vi.fn(),
+}));
+
+import { deleteProduct, restoreProduct } from "@/actions";
+import type { Product } from "@/core/domain";
+import { ProductTableRowAction } from "./ProductTableRowAction";
+
+const buildProduct = (overrides?: Partial<Product>): Product => ({
+  _id: "507f1f77bcf86cd799439011",
+  authorId: "507f1f77bcf86cd799439012",
+  title: "봄맞이 청첩장",
+  description: "봄 시즌 한정 모바일 청첩장 템플릿입니다.",
+  thumbnail: "https://example.com/thumbnail.jpg",
+  price: 9900,
+  category: "invitation",
+  subCategory: "wedding",
+  isPremium: false,
+  featureIds: [],
+  isFeatured: false,
+  priority: 0,
+  likes: [],
+  views: 0,
+  salesCount: 0,
+  discount: { discountType: "rate", value: 0 },
+  status: "active",
+  theme: "default",
+  isLiked: false,
+  discountedPrice: 9900,
+  images: [],
+  minQuantity: 1,
+  maxQuantity: 0,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  deletedAt: null,
+  ...overrides,
+});
+
+describe("ProductTableRowAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  it("view가 active(기본값)면 수정/삭제 버튼만 렌더링하고 복구 버튼은 없다", () => {
+    render(<ProductTableRowAction product={buildProduct()} />);
+
+    expect(screen.queryByText("복구")).not.toBeInTheDocument();
+  });
+
+  it("view가 trash면 복구 버튼만 렌더링하고 수정/삭제 버튼은 없다", () => {
+    render(<ProductTableRowAction product={buildProduct()} view="trash" />);
+
+    expect(screen.getByText("복구")).toBeInTheDocument();
+  });
+
+  it("복구 확인 후 restoreProduct를 호출하고 성공하면 라우터를 refresh한다", async () => {
+    const user = userEvent.setup();
+    vi.mocked(restoreProduct).mockResolvedValue({
+      success: true,
+      data: { message: "상품이 성공적으로 복구되었습니다." },
+    });
+
+    render(<ProductTableRowAction product={buildProduct()} view="trash" />);
+
+    await user.click(screen.getByText("복구"));
+
+    expect(restoreProduct).toHaveBeenCalledWith("507f1f77bcf86cd799439011");
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+
+  it("삭제 확인 후 deleteProduct를 호출하고 성공하면 라우터를 refresh한다", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteProduct).mockResolvedValue({
+      success: true,
+      data: { message: "상품이 성공적으로 삭제되었습니다." },
+    });
+
+    render(<ProductTableRowAction product={buildProduct()} />);
+
+    const buttons = screen.getAllByRole("button");
+    await user.click(buttons[1]);
+
+    expect(deleteProduct).toHaveBeenCalledWith("507f1f77bcf86cd799439011");
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/(admin)/admin/products/_components/ProductTableRowAction.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRowAction.tsx
@@ -1,17 +1,18 @@
 "use client";
-import { deleteProduct } from "@/actions";
+import { deleteProduct, restoreProduct } from "@/actions";
 import type { ProductTableRowProps } from "./ProductTableRow";
 import { Button } from "@/ui/components/atoms";
 import { useAdminModalStore } from "@/ui/stores";
-import { Edit, Trash2 } from "lucide-react";
+import { Edit, RotateCcw, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { toast } from "sonner";
 
-const ProductTableRowAction = ({ product }: ProductTableRowProps) => {
+const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProps) => {
   const open = useAdminModalStore((state) => state.openModal);
   const router = useRouter();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
 
   const handleDelete = async () => {
     if (!confirm(`"${product.title}" 상품을 삭제하시겠습니까?`)) {
@@ -36,6 +37,46 @@ const ProductTableRowAction = ({ product }: ProductTableRowProps) => {
       setIsDeleting(false);
     }
   };
+
+  const handleRestore = async () => {
+    if (!confirm(`"${product.title}" 상품을 복구하시겠습니까?`)) {
+      return;
+    }
+
+    setIsRestoring(true);
+
+    try {
+      const result = await restoreProduct(product._id);
+
+      if (result.success === false) {
+        toast.error(result.error.message || "복구에 실패했습니다.");
+        return;
+      }
+
+      toast.success(result.data.message);
+      router.refresh();
+    } catch {
+      toast.error("복구 중 오류가 발생했습니다.");
+    } finally {
+      setIsRestoring(false);
+    }
+  };
+
+  if (view === "trash") {
+    return (
+      <div className="flex items-center justify-center gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleRestore}
+          disabled={isRestoring}
+        >
+          <RotateCcw className="h-4 w-4" />
+          복구
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="flex items-center justify-center gap-2">

--- a/src/app/(admin)/admin/products/page.tsx
+++ b/src/app/(admin)/admin/products/page.tsx
@@ -3,10 +3,18 @@ export const dynamic = "force-dynamic";
 import { getAllProductsService, verifySession } from "@/services";
 import { AdminProductsTemplate } from "./_components";
 
-export default async function ProductsPage() {
+const resolveView = (raw: string | string[] | undefined): "active" | "trash" =>
+  raw === "trash" ? "trash" : "active";
+
+export default async function ProductsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   await verifySession("ADMIN");
 
-  const products = await getAllProductsService();
+  const view = resolveView((await searchParams).view);
+  const products = await getAllProductsService(undefined, undefined, view);
 
-  return <AdminProductsTemplate products={products} />;
+  return <AdminProductsTemplate products={products} view={view} />;
 }

--- a/src/services/product.integration.test.ts
+++ b/src/services/product.integration.test.ts
@@ -13,6 +13,7 @@ import {
   getPopularProductsService,
   updateProductService,
   deleteProductService,
+  restoreProductService,
   updateProductLikeService,
   searchProductsService,
   getProductQuantityBoundsService,
@@ -312,6 +313,32 @@ describe("product", () => {
       expect(result).toHaveLength(2);
       expect(noMatch).toHaveLength(0);
     });
+
+    it("view를 지정하지 않으면 삭제되지 않은 상품만 리턴한다", async () => {
+      const input = buildProductInput({ title: "삭제될상품" });
+      await createProductService(input);
+      const saved = await ProductModel.findOne({ title: input.title }).lean();
+      await deleteProductService(saved!._id.toString());
+      await createProductService(buildProductInput({ title: "정상상품" }));
+
+      const result = await getAllProductsService();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe("정상상품");
+    });
+
+    it("view가 trash면 소프트 삭제된(deletedAt 존재) 상품만 리턴한다", async () => {
+      const input = buildProductInput({ title: "삭제될상품" });
+      await createProductService(input);
+      const saved = await ProductModel.findOne({ title: input.title }).lean();
+      await deleteProductService(saved!._id.toString());
+      await createProductService(buildProductInput({ title: "정상상품" }));
+
+      const result = await getAllProductsService(undefined, undefined, "trash");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe("삭제될상품");
+    });
   });
 
   describe("getFeaturedTemplatesService", () => {
@@ -564,6 +591,47 @@ describe("product", () => {
 
     it("id 형식이 잘못되면 false를 리턴한다", async () => {
       const result = await deleteProductService("not-a-valid-id");
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("restoreProductService", () => {
+    it("삭제된 상품을 복구하면 true를 리턴하고 status를 active로, deletedAt을 null로 되돌린다", async () => {
+      const input = buildProductInput({ title: "복구될상품", status: "soldOut" });
+      await createProductService(input);
+      const saved = await ProductModel.findOne({ title: input.title }).lean();
+      await deleteProductService(saved!._id.toString());
+
+      const result = await restoreProductService(saved!._id.toString());
+
+      expect(result).toBe(true);
+
+      const restored = await ProductModel.findById(saved!._id).lean();
+      expect(restored?.status).toBe("active");
+      expect(restored?.deletedAt).toBeNull();
+    });
+
+    it("삭제되지 않은(deletedAt이 null인) 상품이면 false를 리턴한다", async () => {
+      const input = buildProductInput({ title: "정상상품" });
+      await createProductService(input);
+      const saved = await ProductModel.findOne({ title: input.title }).lean();
+
+      const result = await restoreProductService(saved!._id.toString());
+
+      expect(result).toBe(false);
+    });
+
+    it("존재하지 않는 id면 false를 리턴한다", async () => {
+      const missingId = new mongoose.Types.ObjectId().toString();
+
+      const result = await restoreProductService(missingId);
+
+      expect(result).toBe(false);
+    });
+
+    it("id 형식이 잘못되면 false를 리턴한다", async () => {
+      const result = await restoreProductService("not-a-valid-id");
 
       expect(result).toBe(false);
     });

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -161,14 +161,16 @@ export const incrementProductViewsService = async (
   return !!updated;
 };
 
-// 모든 상품 조회
+// 모든 상품 조회 — view="trash"는 admin 휴지통 전용, 소프트 삭제된(deletedAt 존재) 상품만 리턴한다.
 export const getAllProductsService = async (
   category?: string,
   userId?: string,
+  view: "active" | "trash" = "active",
 ): Promise<ProductJSON[]> => {
   await dbConnect();
 
-  const query: Record<string, unknown> = { deletedAt: null };
+  const query: Record<string, unknown> =
+    view === "trash" ? { deletedAt: { $ne: null } } : { deletedAt: null };
   if (category) {
     query.category = category;
   }
@@ -332,6 +334,32 @@ export const deleteProductService = async (
   return !!deletedProduct;
 };
 
+// 상품 복구(휴지통 → 복원) — 항상 status를 "active"로 되돌린다. 삭제 전 상태
+// (inactive/soldOut)는 보존하지 않는다 — 삭제와 복구를 대칭적인 명시 상태 전이로
+// 고정해 "복구했더니 무슨 상태인지" 추측할 필요가 없게 한다(관계 정의 참고).
+export const restoreProductService = async (
+  productId: string,
+): Promise<boolean> => {
+  await dbConnect();
+
+  if (!mongoose.isObjectIdOrHexString(productId)) {
+    return false;
+  }
+
+  const restoredProduct = await ProductModel.findOneAndUpdate(
+    { _id: productId, deletedAt: { $ne: null } },
+    { status: "active", deletedAt: null },
+    { new: true, runValidators: true },
+  ).catch((err) => {
+    throw new AppError(
+      "INTERNAL",
+      err instanceof Error ? err.message : "상품 복구에 실패했습니다.",
+    );
+  });
+
+  return !!restoredProduct;
+};
+
 // 상품 좋아요 토글
 export const updateProductLikeService = async (
   productId: string,
@@ -394,6 +422,13 @@ export async function deleteProductAsAdminService(productId: string): Promise<vo
   await requireAdmin();
   if (!(await deleteProductService(productId))) {
     throw new AppError("NOT_FOUND", "상품을 찾을 수 없습니다.");
+  }
+}
+
+export async function restoreProductAsAdminService(productId: string): Promise<void> {
+  await requireAdmin();
+  if (!(await restoreProductService(productId))) {
+    throw new AppError("NOT_FOUND", "삭제된 상품을 찾을 수 없습니다.");
   }
 }
 


### PR DESCRIPTION
## Summary

- admin 상품 삭제는 소프트 삭제(`status: "deleted"` + `deletedAt`)만 하고 끝나는 막다른 흐름이었다 — 삭제된 상품을 조회하거나 되살릴 방법이 없었고(#136), `ProductEditDialog`의 상태 드롭다운으로 `deletedAt` 갱신 없이 `status`만 `"deleted"`로 바꿀 수도 있어 "삭제됨"처럼 보이지만 `deletedAt:null` 필터엔 계속 걸리는 상태가 생길 수 있었다.
- `getAllProductsService`에 `view: "active" | "trash"` 파라미터를 추가해 admin이 소프트 삭제된(`deletedAt` 존재) 상품을 조회할 수 있게 했다.
- `restoreProductService`/`restoreProductAsAdminService`/`restoreProduct` action을 추가했다 — 복구 시 항상 `status: "active"`, `deletedAt: null`로 되돌린다(삭제 전 상태를 추측하지 않는 대칭적 전이).
- admin 상품 목록 페이지가 `?view=trash` 쿼리를 읽고, `AdminProductsTemplate`에 "상품 목록"/"휴지통" 탭을 추가했다. 휴지통 뷰에서는 상태 드롭다운 대신 "삭제됨" 배지 + 삭제일, 수정/삭제 버튼 대신 복구 버튼을 보여준다.
- `ProductEditDialog`의 상태 드롭다운에서 "삭제" 옵션을 제거했다 — 이제 삭제/복구 전용 버튼만이 `deletedAt`과 `status`를 함께 바꾸는 유일한 경로다(관계 정의).

## Test plan

- `npx vitest run src/services/product.integration.test.ts src/actions/workflow-delegation.test.ts` 및 관련 admin products 컴포넌트 테스트(`AdminProductsTemplate`/`ProductTableRow`/`ProductTableRowAction`/`ProductTableRowSelect`/`ProductEditDialog`) — 전체 통과 (95/95)
- `npx tsc --noEmit` — 통과
- `npx eslint` (변경 파일 전체) — 통과
- dev 서버 + playwright-cli 헤드리스 브라우저로 admin 로그인 → `/admin/products?view=trash` 조회(19개) → 첫 행 "복구" 클릭 → 다이얼로그 확인 → 휴지통 18개로 감소, 상품 목록 탭에서 해당 상품이 "판매중" 상태로 정상 복귀하는 것을 실제로 확인

Closes #136