### PR TITLE
fix(product): 영구 삭제 시 Cloudinary 이미지를 정리한다

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -13,6 +13,7 @@ export * from "./findUserEmail";
 export * from "./incrementProductViews";
 export * from "./loginUser";
 export * from "./logoutUser";
+export * from "./permanentlyDeleteProduct";
 export * from "./requestPasswordReset";
 export * from "./restoreProduct";
 export * from "./signupUser";

--- a/src/actions/permanentlyDeleteProduct.ts
+++ b/src/actions/permanentlyDeleteProduct.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import type { APIResponse } from "@/core/domain";
+import { permanentlyDeleteProductAsAdminService } from "@/services";
+import { actionError } from "@/boundary";
+import { routes } from "@/core/domain";
+
+import { revalidatePath } from "next/cache";
+
+export const permanentlyDeleteProduct = async (
+  productId: string,
+): Promise<APIResponse<{ message: string }>> => {
+  try {
+    await permanentlyDeleteProductAsAdminService(productId);
+
+    revalidatePath(routes.admin.products.root);
+
+    return {
+      success: true,
+      data: { message: "상품이 영구적으로 삭제되었습니다." },
+    };
+  } catch (e) {
+    return actionError(e);
+  }
+};

--- a/src/actions/workflow-delegation.test.ts
+++ b/src/actions/workflow-delegation.test.ts
@@ -7,6 +7,7 @@ const services = vi.hoisted(() => ({
   completePaymentService: vi.fn(),
   deleteProductAsAdminService: vi.fn(),
   restoreProductAsAdminService: vi.fn(),
+  permanentlyDeleteProductAsAdminService: vi.fn(),
   toggleProductLikeForCurrentUserService: vi.fn(),
 }));
 const revalidatePath = vi.hoisted(() => vi.fn());
@@ -19,6 +20,7 @@ import { signupUser } from "./signupUser";
 import { completePayment } from "./completePayment";
 import { deleteProduct } from "./deleteProduct";
 import { restoreProduct } from "./restoreProduct";
+import { permanentlyDeleteProduct } from "./permanentlyDeleteProduct";
 import { toggleProductLike } from "./toggleProductLike";
 
 const formData = (data: Record<string, string>) => {
@@ -91,6 +93,18 @@ describe("Action 유스케이스 위임", () => {
 
     expect(services.restoreProductAsAdminService).toHaveBeenCalledWith("product-1");
     expect(revalidatePath).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+  });
+
+  it("상품 영구 삭제 성공 후 관련 캐시를 갱신한다", async () => {
+    services.permanentlyDeleteProductAsAdminService.mockResolvedValue(undefined);
+
+    const result = await permanentlyDeleteProduct("product-1");
+
+    expect(services.permanentlyDeleteProductAsAdminService).toHaveBeenCalledWith(
+      "product-1",
+    );
+    expect(revalidatePath).toHaveBeenCalledTimes(1);
     expect(result.success).toBe(true);
   });
 

--- a/src/adapters/server/cloudinary/cleanup.test.ts
+++ b/src/adapters/server/cloudinary/cleanup.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-const { destroy } = vi.hoisted(() => ({ destroy: vi.fn() }));
-vi.mock("cloudinary", () => ({ v2: { uploader: { destroy } } }));
+const { destroy, config } = vi.hoisted(() => ({ destroy: vi.fn(), config: vi.fn() }));
+vi.mock("cloudinary", () => ({ v2: { config, uploader: { destroy } } }));
 
 import { deleteProductAsset } from "./cleanup";
 

--- a/src/adapters/server/cloudinary/cleanup.ts
+++ b/src/adapters/server/cloudinary/cleanup.ts
@@ -2,6 +2,16 @@ import "server-only";
 import { v2 as cloudinary } from "cloudinary";
 import { AppError } from "@/core/domain";
 
+// sign.ts는 API secret을 요청마다 직접 인자로 넘겨 서명하므로 전역 config 없이도
+// 동작하지만, uploader.destroy()는 SDK 전역 config(cloud_name/api_key/api_secret)에
+// 의존한다 — CLOUDINARY_URL 형태의 단일 env var를 안 쓰는 이 프로젝트 구성상 명시
+// config 없이는 "Must supply api_key"로 실패한다(#135에서 실사용 중 발견).
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
 export async function deleteProductAsset(publicId: string): Promise<void> {
   if (!publicId) return;
   const result = await cloudinary.uploader.destroy(publicId, {

--- a/src/adapters/server/cloudinary/publicId.test.ts
+++ b/src/adapters/server/cloudinary/publicId.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { extractPublicId } from "./publicId";
+
+describe("extractPublicId", () => {
+  it("버전 세그먼트가 있는 URL에서 publicId를 추출한다", () => {
+    const url =
+      "https://res.cloudinary.com/demo/image/upload/v1690000000/products/thumbnails/abc123.jpg";
+
+    expect(extractPublicId(url)).toBe("products/thumbnails/abc123");
+  });
+
+  it("버전 세그먼트가 없는 URL도 처리한다", () => {
+    const url = "https://res.cloudinary.com/demo/image/upload/products/images/xyz.png";
+
+    expect(extractPublicId(url)).toBe("products/images/xyz");
+  });
+
+  it("/upload/가 없는 URL이면 null을 리턴한다", () => {
+    expect(extractPublicId("https://example.com/products/images/xyz.png")).toBeNull();
+  });
+
+  it("빈 문자열이면 null을 리턴한다", () => {
+    expect(extractPublicId("")).toBeNull();
+  });
+});

--- a/src/adapters/server/cloudinary/publicId.ts
+++ b/src/adapters/server/cloudinary/publicId.ts
@@ -1,0 +1,16 @@
+// Cloudinary 업로드 응답의 secure_url(DB에 저장되는 형태)에서 publicId를 역산한다 —
+// 이 프로젝트 업로드 위젯은 public_id를 직접 지정하지 않아(widget.tsx) Cloudinary가
+// "v{version}/{folder}/{자동생성 파일명}.{ext}" 형태로 발급한다. deleteProductAsset은
+// publicId를 받으므로 삭제 전 이 형태를 역산해야 한다.
+export const extractPublicId = (url: string): string | null => {
+  const marker = "/upload/";
+  const idx = url.indexOf(marker);
+  if (idx === -1) return null;
+
+  const publicId = url
+    .slice(idx + marker.length)
+    .replace(/^v\d+\//, "")
+    .replace(/\.[a-zA-Z0-9]+$/, "");
+
+  return publicId || null;
+};

--- a/src/app/(admin)/admin/products/_components/ProductTableRowAction.test.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRowAction.test.tsx
@@ -11,9 +11,10 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/actions", () => ({
   deleteProduct: vi.fn(),
   restoreProduct: vi.fn(),
+  permanentlyDeleteProduct: vi.fn(),
 }));
 
-import { deleteProduct, restoreProduct } from "@/actions";
+import { deleteProduct, restoreProduct, permanentlyDeleteProduct } from "@/actions";
 import type { Product } from "@/core/domain";
 import { ProductTableRowAction } from "./ProductTableRowAction";
 
@@ -53,16 +54,18 @@ describe("ProductTableRowAction", () => {
     vi.spyOn(window, "confirm").mockReturnValue(true);
   });
 
-  it("view가 active(기본값)면 수정/삭제 버튼만 렌더링하고 복구 버튼은 없다", () => {
+  it("view가 active(기본값)면 복구/영구 삭제 버튼은 없다", () => {
     render(<ProductTableRowAction product={buildProduct()} />);
 
     expect(screen.queryByText("복구")).not.toBeInTheDocument();
+    expect(screen.queryByText("영구 삭제")).not.toBeInTheDocument();
   });
 
-  it("view가 trash면 복구 버튼만 렌더링하고 수정/삭제 버튼은 없다", () => {
+  it("view가 trash면 복구/영구 삭제 버튼을 렌더링한다", () => {
     render(<ProductTableRowAction product={buildProduct()} view="trash" />);
 
     expect(screen.getByText("복구")).toBeInTheDocument();
+    expect(screen.getByText("영구 삭제")).toBeInTheDocument();
   });
 
   it("복구 확인 후 restoreProduct를 호출하고 성공하면 라우터를 refresh한다", async () => {
@@ -93,6 +96,21 @@ describe("ProductTableRowAction", () => {
     await user.click(buttons[1]);
 
     expect(deleteProduct).toHaveBeenCalledWith("507f1f77bcf86cd799439011");
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+
+  it("영구 삭제 확인 후 permanentlyDeleteProduct를 호출하고 성공하면 라우터를 refresh한다", async () => {
+    const user = userEvent.setup();
+    vi.mocked(permanentlyDeleteProduct).mockResolvedValue({
+      success: true,
+      data: { message: "상품이 영구적으로 삭제되었습니다." },
+    });
+
+    render(<ProductTableRowAction product={buildProduct()} view="trash" />);
+
+    await user.click(screen.getByText("영구 삭제"));
+
+    expect(permanentlyDeleteProduct).toHaveBeenCalledWith("507f1f77bcf86cd799439011");
     expect(refreshMock).toHaveBeenCalledOnce();
   });
 });

--- a/src/app/(admin)/admin/products/_components/ProductTableRowAction.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRowAction.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { deleteProduct, restoreProduct } from "@/actions";
+import { deleteProduct, permanentlyDeleteProduct, restoreProduct } from "@/actions";
 import type { ProductTableRowProps } from "./ProductTableRow";
 import { Button } from "@/ui/components/atoms";
 import { useAdminModalStore } from "@/ui/stores";
@@ -13,6 +13,7 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
   const router = useRouter();
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRestoring, setIsRestoring] = useState(false);
+  const [isPurging, setIsPurging] = useState(false);
 
   const handleDelete = async () => {
     if (!confirm(`"${product.title}" 상품을 삭제하시겠습니까?`)) {
@@ -62,6 +63,34 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
     }
   };
 
+  const handlePurge = async () => {
+    if (
+      !confirm(
+        `"${product.title}" 상품을 영구 삭제하시겠습니까? 이미지 포함 모든 데이터가 사라지며 되돌릴 수 없습니다.`,
+      )
+    ) {
+      return;
+    }
+
+    setIsPurging(true);
+
+    try {
+      const result = await permanentlyDeleteProduct(product._id);
+
+      if (result.success === false) {
+        toast.error(result.error.message || "영구 삭제에 실패했습니다.");
+        return;
+      }
+
+      toast.success(result.data.message);
+      router.refresh();
+    } catch {
+      toast.error("영구 삭제 중 오류가 발생했습니다.");
+    } finally {
+      setIsPurging(false);
+    }
+  };
+
   if (view === "trash") {
     return (
       <div className="flex items-center justify-center gap-2">
@@ -69,10 +98,19 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
           size="sm"
           variant="outline"
           onClick={handleRestore}
-          disabled={isRestoring}
+          disabled={isRestoring || isPurging}
         >
           <RotateCcw className="h-4 w-4" />
           복구
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handlePurge}
+          disabled={isRestoring || isPurging}
+        >
+          <Trash2 className="h-4 w-4" />
+          영구 삭제
         </Button>
       </div>
     );

--- a/src/services/product.integration.test.ts
+++ b/src/services/product.integration.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import mongoose from "mongoose";
 import { dbConnect } from "@/db";
 import { buildProductInput, clearCollections } from "@testing/support";
 import { AppError } from "@/core/domain";
 import { ProductModel, InvitationProductModel } from "@/models";
+
+const { deleteProductAsset } = vi.hoisted(() => ({ deleteProductAsset: vi.fn() }));
+vi.mock("@/adapters/server/cloudinary/cleanup", () => ({ deleteProductAsset }));
+
 import {
   createProductService,
   getProductService,
@@ -14,6 +18,7 @@ import {
   updateProductService,
   deleteProductService,
   restoreProductService,
+  permanentlyDeleteProductService,
   updateProductLikeService,
   searchProductsService,
   getProductQuantityBoundsService,
@@ -52,6 +57,7 @@ describe("product", () => {
   beforeEach(async () => {
     await dbConnect();
     await clearCollections();
+    deleteProductAsset.mockReset().mockResolvedValue(undefined);
   });
 
   afterAll(async () => {
@@ -634,6 +640,74 @@ describe("product", () => {
       const result = await restoreProductService("not-a-valid-id");
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe("permanentlyDeleteProductService", () => {
+    it("소프트 삭제된 상품을 영구 삭제하면 true를 리턴하고 문서를 지우고 Cloudinary 이미지를 정리한다", async () => {
+      const input = buildProductInput({
+        title: "영구삭제될상품",
+        thumbnail:
+          "https://res.cloudinary.com/demo/image/upload/v1690000000/products/thumbnails/thumb1.jpg",
+        images: [
+          "https://res.cloudinary.com/demo/image/upload/v1690000000/products/images/img1.jpg",
+        ],
+      });
+      await createProductService(input);
+      const saved = await ProductModel.findOne({ title: input.title }).lean();
+      await deleteProductService(saved!._id.toString());
+
+      const result = await permanentlyDeleteProductService(saved!._id.toString());
+
+      expect(result).toBe(true);
+      expect(await ProductModel.findById(saved!._id).lean()).toBeNull();
+      expect(deleteProductAsset).toHaveBeenCalledWith("products/thumbnails/thumb1");
+      expect(deleteProductAsset).toHaveBeenCalledWith("products/images/img1");
+    });
+
+    it("삭제되지 않은(deletedAt이 null인) 상품이면 false를 리턴하고 문서/이미지를 건드리지 않는다", async () => {
+      const input = buildProductInput({ title: "정상상품" });
+      await createProductService(input);
+      const saved = await ProductModel.findOne({ title: input.title }).lean();
+
+      const result = await permanentlyDeleteProductService(saved!._id.toString());
+
+      expect(result).toBe(false);
+      expect(await ProductModel.findById(saved!._id).lean()).not.toBeNull();
+      expect(deleteProductAsset).not.toHaveBeenCalled();
+    });
+
+    it("존재하지 않는 id면 false를 리턴한다", async () => {
+      const missingId = new mongoose.Types.ObjectId().toString();
+
+      const result = await permanentlyDeleteProductService(missingId);
+
+      expect(result).toBe(false);
+    });
+
+    it("id 형식이 잘못되면 false를 리턴한다", async () => {
+      const result = await permanentlyDeleteProductService("not-a-valid-id");
+
+      expect(result).toBe(false);
+    });
+
+    it("Cloudinary 정리가 실패하면 AppError로 전파하고 문서를 지우지 않는다", async () => {
+      const input = buildProductInput({
+        title: "정리실패상품",
+        thumbnail:
+          "https://res.cloudinary.com/demo/image/upload/v1690000000/products/thumbnails/broken.jpg",
+      });
+      await createProductService(input);
+      const saved = await ProductModel.findOne({ title: input.title }).lean();
+      await deleteProductService(saved!._id.toString());
+      deleteProductAsset.mockRejectedValue(
+        new AppError("EXTERNAL_SERVICE", "이미지 정리에 실패했습니다."),
+      );
+
+      await expect(
+        permanentlyDeleteProductService(saved!._id.toString()),
+      ).rejects.toMatchObject({ category: "EXTERNAL_SERVICE" });
+      expect(await ProductModel.findById(saved!._id).lean()).not.toBeNull();
     });
   });
 

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -10,6 +10,8 @@ import { POPULAR_PRODUCTS_LIMIT } from "@/core/domain";
 import type { Model, Types } from "mongoose";
 import mongoose from "mongoose";
 import { requireAdmin, requireAuth } from "./auth";
+import { deleteProductAsset } from "@/adapters/server/cloudinary/cleanup";
+import { extractPublicId } from "@/adapters/server/cloudinary/publicId";
 
 // Product 타입을 export (다른 파일에서 사용)
 export type Product = ProductJSON;
@@ -360,6 +362,50 @@ export const restoreProductService = async (
   return !!restoredProduct;
 };
 
+// 상품 영구 삭제(휴지통 전용) — 소프트 삭제(deletedAt 존재)된 상품만 대상이다.
+// 복구 가능한 활성 상품의 이미지를 실수로 지우면 안 되므로, 소프트 삭제 시점이
+// 아니라 이 시점에 Cloudinary 이미지 정리를 건다(#135, #136 관계 정의 참고).
+// Cloudinary 정리가 실패하면 DB 문서를 지우지 않는다 — 고아 에셋보다 고아 문서(다시
+// 삭제를 시도할 수 있음)가 낫다.
+export const permanentlyDeleteProductService = async (
+  productId: string,
+): Promise<boolean> => {
+  await dbConnect();
+
+  if (!mongoose.isObjectIdOrHexString(productId)) {
+    return false;
+  }
+
+  const product = await ProductModel.findOne({
+    _id: productId,
+    deletedAt: { $ne: null },
+  })
+    .select("thumbnail images")
+    .lean();
+
+  if (!product) return false;
+
+  const publicIds = [...new Set(
+    [product.thumbnail, ...product.images]
+      .map((url) => extractPublicId(url))
+      .filter((id): id is string => !!id),
+  )];
+
+  await Promise.all(publicIds.map((id) => deleteProductAsset(id)));
+
+  const { deletedCount } = await ProductModel.deleteOne({
+    _id: productId,
+    deletedAt: { $ne: null },
+  }).catch((err) => {
+    throw new AppError(
+      "INTERNAL",
+      err instanceof Error ? err.message : "상품 영구 삭제에 실패했습니다.",
+    );
+  });
+
+  return deletedCount === 1;
+};
+
 // 상품 좋아요 토글
 export const updateProductLikeService = async (
   productId: string,
@@ -428,6 +474,15 @@ export async function deleteProductAsAdminService(productId: string): Promise<vo
 export async function restoreProductAsAdminService(productId: string): Promise<void> {
   await requireAdmin();
   if (!(await restoreProductService(productId))) {
+    throw new AppError("NOT_FOUND", "삭제된 상품을 찾을 수 없습니다.");
+  }
+}
+
+export async function permanentlyDeleteProductAsAdminService(
+  productId: string,
+): Promise<void> {
+  await requireAdmin();
+  if (!(await permanentlyDeleteProductService(productId))) {
     throw new AppError("NOT_FOUND", "삭제된 상품을 찾을 수 없습니다.");
   }
 }


### PR DESCRIPTION
## Summary

- `deleteProductAsset`(Cloudinary 이미지 삭제)가 구현은 돼 있었지만 실제 서비스/액션 어디서도 호출되지 않아, 상품을 지워도 Cloudinary에 이미지가 고아로 남았다(#135).
- 소프트 삭제 시점에 바로 이미지를 지우면 #136의 복구 기능이 깨진다(복구했는데 이미지가 없음) — 그래서 정리 시점을 소프트 삭제가 아니라 **휴지통에서의 영구 삭제**로 재정의했다. 이 PR은 `feat/admin-product-trash`(#136, 미머지) 위에 쌓은 스택 PR이다 — 휴지통 뷰/복구 인프라가 먼저 존재해야 영구 삭제 버튼을 붙일 자리가 생긴다.
- `extractPublicId`를 추가해 DB에 저장된 secure_url(예: `.../upload/v169.../products/thumbnails/abc.jpg`)에서 Cloudinary publicId(`products/thumbnails/abc`)를 역산한다 — 업로드 위젯이 public_id를 직접 지정하지 않기 때문에 필요하다.
- `permanentlyDeleteProductService`/`permanentlyDeleteProductAsAdminService`/`permanentlyDeleteProduct` action을 추가했다 — 이미 소프트 삭제된(`deletedAt` 존재) 상품만 대상으로, thumbnail+images를 Cloudinary에서 정리한 뒤 문서를 하드 삭제한다. Cloudinary 정리가 실패하면 DB 문서를 지우지 않는다(재시도 가능하게).
- 휴지통 행 액션에 "영구 삭제" 버튼을 추가했다(복구와 나란히, 되돌릴 수 없다는 경고 문구 포함).
- **부수 발견/수정**: `cleanup.ts`가 `cloudinary.config()`를 호출한 적이 없어서 실제 자격증명으로 `uploader.destroy()`를 처음 실행하는 순간 `Error: Must supply api_key`로 무조건 실패했다 — 기존 단위 테스트가 SDK 전체를 mock해서 이 버그가 드러난 적이 없었다. 이번에 실제 dev Cloudinary 계정에 붙여보면서 발견해 같이 고쳤다.

## Test plan

- `npx vitest run` (product.integration/publicId/cleanup/sign/workflow-delegation/ProductTableRowAction) — 전체 통과 (88/88)
- `npx tsc --noEmit`, `npx eslint`(변경 파일) — 통과
- dev 서버 + playwright-cli 헤드리스로 admin 로그인 → 휴지통 → 상품 "영구 삭제" 클릭 → 목록에서 사라짐(18→17) 확인
- Cloudinary Admin API(`/resources/image/upload?public_ids[]=...`)로 실제 자격증명 계정 조회 — 삭제 후 `{"resources":[]}` 확인(진짜로 지워짐)

## 참고

- Base 브랜치가 `dev`가 아니라 `feat/admin-product-trash`(#136)입니다 — #136이 먼저 머지된 뒤 이 PR의 base를 `dev`로 재조정하거나, #136 머지 시 자동으로 diff가 이 PR분만 남는 것을 확인해주세요.

Closes #135