### PR TITLE
fix(product-detail): 상세 이미지 UI와 경고를 정리한다

### DIFF
--- a/src/ui/components/molecules/CloudImage.tsx
+++ b/src/ui/components/molecules/CloudImage.tsx
@@ -19,6 +19,7 @@ interface CloudImageProps {
   sizes?: string;
   className?: string;
   priority?: boolean;
+  loading?: "eager" | "lazy";
 }
 
 const CloudImage = ({
@@ -27,6 +28,7 @@ const CloudImage = ({
   sizes = "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw",
   className,
   priority = false,
+  loading,
 }: CloudImageProps) => {
   if (!src) return null;
 
@@ -39,6 +41,7 @@ const CloudImage = ({
       alt={alt}
       className={cn(`object-cover`, className)}
       priority={priority}
+      loading={loading}
     />
   );
 };

--- a/src/ui/components/organisms/LiveDemoSection.tsx
+++ b/src/ui/components/organisms/LiveDemoSection.tsx
@@ -46,6 +46,7 @@ export const LiveDemoSection = () => {
                       src="/assets/images/output.webp"
                       alt="대표 청첩장 샘플 미리보기"
                       fill
+                      sizes="(min-width: 1024px) 50vw, 100vw"
                       className="object-cover"
                     />
                   </div>

--- a/src/ui/components/organisms/ProductFeatures.tsx
+++ b/src/ui/components/organisms/ProductFeatures.tsx
@@ -74,7 +74,7 @@ export function ProductFeatures({ options, images }: ProductFeaturesProps) {
               {visibleImages.map((src, index) => (
                 <div
                   key={src}
-                  className="bg-muted border-border relative aspect-[3/4] w-full overflow-hidden rounded-2xl border"
+                  className="relative aspect-[3/4] w-full overflow-hidden rounded-2xl bg-transparent"
                 >
                   <CloudImage
                     src={src}
@@ -91,7 +91,7 @@ export function ProductFeatures({ options, images }: ProductFeaturesProps) {
                   {restImages.map((src, index) => (
                     <div
                       key={src}
-                      className="bg-muted border-border relative aspect-[3/4] w-full overflow-hidden rounded-2xl border"
+                      className="relative aspect-[3/4] w-full overflow-hidden rounded-2xl bg-transparent"
                     >
                       <CloudImage
                         src={src}
@@ -103,7 +103,7 @@ export function ProductFeatures({ options, images }: ProductFeaturesProps) {
                 </CollapsibleContent>
                 <CollapsibleTrigger asChild>
                   <Button variant="outline" className="mt-4 w-full">
-                    {isExpanded ? "접기" : `더보기 (${restImages.length}장 더 보기)`}
+                    {isExpanded ? "접기" : "더보기"}
                     <ChevronDown
                       className={clsx(
                         "ml-1 h-4 w-4 transition-transform",

--- a/src/ui/components/organisms/ProductFeatures.tsx
+++ b/src/ui/components/organisms/ProductFeatures.tsx
@@ -4,9 +4,6 @@ import { useState } from "react";
 import {
   Button,
   Card,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
   TypographyH2,
   TypographyH3,
   TypographyMuted,
@@ -69,7 +66,7 @@ export function ProductFeatures({ options, images }: ProductFeaturesProps) {
         {images.length === 0 ? (
           <TypographyMuted>상세 이미지가 아직 등록되지 않았습니다.</TypographyMuted>
         ) : (
-          <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+          <div>
             <div className="flex flex-col gap-4">
               {visibleImages.map((src, index) => (
                 <div
@@ -87,34 +84,43 @@ export function ProductFeatures({ options, images }: ProductFeaturesProps) {
 
             {restImages.length > 0 && (
               <>
-                <CollapsibleContent className="mt-4 flex flex-col gap-4">
-                  {restImages.map((src, index) => (
-                    <div
-                      key={src}
-                      className="relative aspect-[3/4] w-full overflow-hidden rounded-2xl bg-transparent"
-                    >
-                      <CloudImage
-                        src={src}
-                        alt={`상세 이미지 ${VISIBLE_IMAGE_COUNT + index + 1}`}
-                        className="object-contain"
-                      />
-                    </div>
-                  ))}
-                </CollapsibleContent>
-                <CollapsibleTrigger asChild>
-                  <Button variant="outline" className="mt-4 w-full">
-                    {isExpanded ? "접기" : "더보기"}
-                    <ChevronDown
-                      className={clsx(
-                        "ml-1 h-4 w-4 transition-transform",
-                        isExpanded && "rotate-180",
-                      )}
-                    />
-                  </Button>
-                </CollapsibleTrigger>
+                {isExpanded && (
+                  <div
+                    id="additional-product-images"
+                    className="mt-4 flex flex-col gap-4"
+                  >
+                    {restImages.map((src, index) => (
+                      <div
+                        key={src}
+                        className="relative aspect-[3/4] w-full overflow-hidden rounded-2xl bg-transparent"
+                      >
+                        <CloudImage
+                          src={src}
+                          alt={`상세 이미지 ${VISIBLE_IMAGE_COUNT + index + 1}`}
+                          className="object-contain"
+                        />
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <Button
+                  variant="outline"
+                  className="mt-4 w-full"
+                  aria-expanded={isExpanded}
+                  aria-controls="additional-product-images"
+                  onClick={() => setIsExpanded((expanded) => !expanded)}
+                >
+                  {isExpanded ? "접기" : "더보기"}
+                  <ChevronDown
+                    className={clsx(
+                      "ml-1 h-4 w-4 transition-transform",
+                      isExpanded && "rotate-180",
+                    )}
+                  />
+                </Button>
               </>
             )}
-          </Collapsible>
+          </div>
         )}
       </div>
     </div>

--- a/src/ui/components/organisms/ProductSummary.tsx
+++ b/src/ui/components/organisms/ProductSummary.tsx
@@ -33,6 +33,7 @@ export function ProductSummary({
           <CloudImage
             src={product.thumbnail}
             alt={`${product.title} 상품 썸네일`}
+            loading="eager"
           />
           <div className="absolute top-4 right-4 flex gap-2">
             {product.isFeatured && (


### PR DESCRIPTION
## Summary

- 상품 상세 이미지 래퍼의 베이지 배경과 테두리를 제거해 투명하게 표시합니다.
- 더보기 버튼에서 남은 이미지 개수 표기를 제거합니다.
- 상세 이미지 펼침 영역을 안정적인 조건부 렌더링으로 바꿔 `fill` 부모 높이 경고를 제거합니다.
- 상품 상세 LCP 이미지에 eager 로딩을 적용하고 메인 샘플 이미지에 반응형 `sizes`를 추가합니다.

## Test plan

- 격리된 detached worktree에서 `npm ci` — 통과
- `npm run lint` — 통과
- `npm run tsc` — 통과
- CI 환경 변수로 `npm run build` — 통과
- `npx vitest run --project component src/ui/components/organisms/ProductSummary.test.tsx src/ui/components/organisms/LiveDemoSection.test.tsx` — 2개 테스트 통과
- Playwright Chromium 상품 상세 검증 — HTTP 200, 투명 배경, 테두리 0px, 더보기 후 이미지 7장 및 접기 전환 확인
- Playwright Chromium 상품 상세·메인 콘솔 검증 — warning, error, pageerror 모두 0건
- GitHub Actions `static` — GitHub Actions major outage로 queued; 사용자 승인에 따라 동일한 로컬 검증 결과로 병합 진행