### PR TITLE
feat(admin-dashboard): 관리자 대시보드를 실제 DB 데이터로 연결

### DIFF
--- a/_workspace/feat/admin-dashboard-real-data/00_requirements.json
+++ b/_workspace/feat/admin-dashboard-real-data/00_requirements.json
@@ -1,0 +1,36 @@
+{
+  "branch": "feat/admin-dashboard-real-data",
+  "summary": "admin 대시보드(/admin/dashboard)를 하드코딩 mock에서 실제 DB 기반 데이터로 연결한다",
+  "context": {
+    "current_state": "src/app/(admin)/admin/dashboard/page.tsx는 stats 4개 카드(총 상품/총 매출/주문/회원)와 '최근 활동' 카드가 전부 하드코딩된 값(24, ₩1,234,000, 89, 342, placeholder 텍스트)이다. Server Component이며 verifySession('ADMIN')만 호출하고 실제 데이터 fetch가 없다.",
+    "draft_reference": {
+      "note": "이전 세션이 그릴링 없이 즉흥으로 작성한 초안. 그대로 확정 아님 — 설계 단계에서 재검토 대상. 현재 이 브랜치 워킹트리에 uncommitted 상태로 그대로 남아있음(파일 경로 아래).",
+      "files": [
+        "src/core/domain/dashboard.ts — DashboardStats/DashboardRecentOrder 타입 초안",
+        "src/services/dashboard.ts — getDashboardStatsService 초안 (Product/User/Order 3개 모델 Promise.all 병렬 집계: 총 상품/이번달 신규 상품, 총 회원/이번달 신규 회원, 이번달·전달 매출(CONFIRMED/COMPLETED만 합산), 이번달·전달 주문수, 최근 주문 5건)",
+        "src/core/domain/order.ts — ORDER_STATUS_LABELS/ORDER_STATUS_BADGE_VARIANTS를 admin/orders mock 상수에서 여기로 승격(중복 제거 목적, 대시보드 최근 주문 배지 재사용 의도)",
+        "src/core/domain/index.ts, src/services/index.ts — 위 항목 배럴 export 추가"
+      ],
+      "open_questions_for_design": [
+        "상품/매출/주문/회원 4개 집계가 실제로 관리자가 필요로 하는 지표가 맞는지, 빠지거나 불필요한 게 있는지",
+        "매출 집계 기준을 CONFIRMED/COMPLETED로 잡은 게 맞는지(PENDING/CANCELLED 제외 근거 재확인)",
+        "'최근 활동'을 최근 주문 5건으로 채우는 게 맞는지, 다른 활동(신규 가입/신규 상품 등)도 섞어야 하는지",
+        "trend(전월 대비 증감률/증감폭) 계산이 필요한 카드가 어디까지인지"
+      ]
+    }
+  },
+  "items": [
+    {
+      "id": "REQ-1",
+      "description": "대시보드 상단 통계 카드를 실제 DB 집계값으로 렌더링한다",
+      "acceptance": "/admin/dashboard 접속 시 상품/매출/주문/회원(또는 설계 단계에서 재확정된 지표) 카드가 실제 DB 값을 표시하고, 상품/회원 등록·주문 발생 시 값이 갱신된다",
+      "passes": false
+    },
+    {
+      "id": "REQ-2",
+      "description": "'최근 활동' 카드를 실제 데이터로 렌더링한다",
+      "acceptance": "placeholder 텍스트 대신 실제 최근 활동(주문 등, 설계 단계에서 확정) 목록이 표시되고 활동이 없을 때 빈 상태 문구가 표시된다",
+      "passes": false
+    }
+  ]
+}

--- a/_workspace/feat/admin-dashboard-real-data/00_requirements.json
+++ b/_workspace/feat/admin-dashboard-real-data/00_requirements.json
@@ -24,13 +24,13 @@
       "id": "REQ-1",
       "description": "대시보드 상단 통계 카드를 실제 DB 집계값으로 렌더링한다",
       "acceptance": "/admin/dashboard 접속 시 상품/매출/주문/회원(또는 설계 단계에서 재확정된 지표) 카드가 실제 DB 값을 표시하고, 상품/회원 등록·주문 발생 시 값이 갱신된다",
-      "passes": false
+      "passes": true
     },
     {
       "id": "REQ-2",
       "description": "'최근 활동' 카드를 실제 데이터로 렌더링한다",
       "acceptance": "placeholder 텍스트 대신 실제 최근 활동(주문 등, 설계 단계에서 확정) 목록이 표시되고 활동이 없을 때 빈 상태 문구가 표시된다",
-      "passes": false
+      "passes": true
     }
   ]
 }

--- a/_workspace/feat/admin-dashboard-real-data/01_api_contract.md
+++ b/_workspace/feat/admin-dashboard-real-data/01_api_contract.md
@@ -1,0 +1,455 @@
+# 01 — API 계약 (admin 대시보드 실데이터)
+
+> 작성: api-designer / Phase 1
+> 대상 요구사항: `00_requirements.json` (REQ-1, REQ-2)
+> 협의 상대: ui-designer, db-migrator (3자 합의 완료 — §8 참고)
+
+---
+
+## 1. 채널 판정 — REST 엔드포인트를 만들지 않는다
+
+**결론: Server Component가 서비스 함수를 직접 `await` 한다. route handler·Server Action·useSWR 전부 없음.**
+
+근거는 `docs/architecture/data-access.md`의 판정표 row 1을 그대로 적용한 것이다.
+
+| 필요 | 경로 |
+|---|---|
+| 서버 렌더 시점 데이터(Server Component 렌더링용) | `src/services/*` 직접 import + 함수 호출 — route.ts 안 거침 |
+
+대시보드는 (a) 읽기 전용이라 mutation(row 2)이 아니고, (b) 브라우저 캐싱/재검증이 필요 없어 route.ts + `useSWR`(row 3)도 아니다. 이미 `export const dynamic = "force-dynamic"`인 async Server Component라 매 요청 서버에서 렌더된다.
+
+따라서 **이 문서가 정의하는 "API 계약"은 HTTP 요청/응답 shape이 아니라 서비스 함수의 시그니처와 리턴 타입이다.**
+
+### 이것이 경계면 검증에 갖는 의미 (boundary-verifier 필독)
+
+- **`{ success, data }` envelope이 이 경로에는 존재하지 않는다.** `SuccessResponse`/`ErrorResponse`/`ErrorPayload`는 채널 A(Server Action)/채널 B(route.ts) 전용이다. `src/boundary.ts`의 `routeSuccess`/`actionError`/`toErrorPayload`는 이 기능에서 **한 번도 호출되지 않는다.** 서비스는 도메인 타입을 그대로 리턴한다.
+- **JSON 직렬화 경계가 없다.** 그래서 `Date`가 `Date`로 살아서 UI까지 간다(§3 참고).
+- 새 zod 스키마를 만들지 않는다. `src/core/schemas/request/`·`response/`에 추가할 파일 **없음** — 입력 파라미터가 없고, 출력은 내부 함수 리턴이라 런타임 검증 대상이 아니다.
+
+---
+
+## 2. 지표 재확정 — `00_requirements.json`의 open question 4개에 대한 답
+
+초안(`src/services/dashboard.ts`)을 원점에서 재검토했다. 결과: **4개 카드 구성은 유지, 단 "주문" 카드의 정의가 바뀐다.**
+
+### Q1. 상품/매출/주문/회원 4개가 맞는 지표인가 → **맞다, 유지**
+
+admin 사이드바 섹션이 products / orders / users / premium-features / settings다. 4개 카드 중 3개(상품·주문·회원)가 실제 관리 섹션과 1:1로 대응해서, 대시보드가 각 섹션으로 들어가는 자연스러운 허브가 된다. 5번째 카드(예: 미처리 주문, 취소/환불)는 **추가하지 않는다** — 지금 관리자가 그 숫자를 보고 취할 수 있는 행동이 정의돼 있지 않다(PENDING 주문은 cron이 24시간 뒤 자동취소하고, 청첩장 미입력 건도 cron이 7일 뒤 자동취소+환불한다. 사람이 개입할 지점이 아직 없다).
+
+### Q2. 매출 기준이 CONFIRMED/COMPLETED가 맞는가 → **맞다. 단 기준 시각을 `createdAt` → `confirmedAt`으로 바꾼다**
+
+**상태 필터(유지):**
+- `PENDING` 제외 — 결제창만 띄우고 이탈한 주문. 24시간 뒤 cron이 자동취소한다.
+- `CANCELLED` 제외 — 취소/환불 완료. 프로젝트에 부분취소가 없어서(db-migrator 실측 확인) 환불 건은 항상 통째로 `CANCELLED`로 전이된다 → 상태 필터만으로 정확히 걸러진다.
+- `CONFIRMED` + `COMPLETED` 포함 — 둘 다 "결제가 이미 반영된" 상태다. `src/services/payment.ts:60`의 `isPaymentAppliedStatus`가 정확히 이 두 값을 같은 의미로 정의하고 있다.
+
+**두 상태가 왕복한다는 점이 중요하다:** `src/services/invitation.ts:216`이 청첩장 발행/비공개 토글에 따라 주문을 `COMPLETED` ↔ `CONFIRMED`로 되돌린다. 즉 이 둘은 결제 사실의 두 얼굴이지 진행 단계가 아니다. 한쪽만 세면 관리자가 청첩장을 비공개로 돌릴 때마다 매출이 출렁인다.
+
+**기준 시각 변경 (초안 대비 변경점):**
+
+`createdAt`(주문 행 생성 = 결제창 진입)이 아니라 `confirmedAt`(실제 결제 완료 시각, `payment.ts:364`에서 1회만 세팅)을 쓴다.
+
+1. **가상계좌**는 주문 생성월과 실제 입금월이 갈릴 수 있다. `createdAt` 기준이면 "이번 달 매출"이 실제 입금과 어긋난다.
+2. 월말/월초 경계에서 오분류된다 — 7/31 23:50에 시작해 8/1 00:05에 결제된 주문은 8월 매출이다.
+3. `confirmedAt`은 `CONFIRMED` 전이 시 한 번만 세팅되고 위의 `COMPLETED` ↔ `CONFIRMED` 토글에 영향받지 않는다 → 토글에도 안정적이다.
+4. `orderSchema.index({ orderStatus: 1, confirmedAt: 1 })`가 이미 존재한다 → 이 조합만 인덱스로 완전 커버된다.
+
+### Q3. 최근 활동을 최근 주문으로 채우는 게 맞는가 → **맞다. 통합 액티비티 피드는 만들지 않는다** (3자 합의)
+
+"신규 가입 / 신규 상품"을 섞은 통합 피드를 거부한 이유:
+
+- **"신규 상품 등록"은 관리자 본인이 방금 한 행동이다.** 자기가 한 일을 자기에게 다시 보여주는 것이라 정보량이 0에 수렴한다.
+- 이종 엔티티를 섞으려면 판별 유니온 타입 + 컬렉션 3개 조회 + JS에서 merge/정렬이 필요하고, 행 타입마다 별도 UI가 필요하다. 지표 가치 대비 비용이 안 맞는다.
+- 주문만이 (a) 고객이 발생시킨 이벤트이고, (b) 금액을 수반하며, (c) 관리자가 반응해야 할 수 있는 사건이다.
+
+**단, 카드 제목은 "최근 활동" → "최근 주문"으로 바꾸는 것을 권고한다** — 주문 목록만 그리면서 제목만 일반적인 "활동"으로 두면, 나중에 읽는 사람이 "다른 활동은 왜 안 보이지"라고 오해한다. 최종 결정은 ui-designer 소관.
+
+**미래의 통합 피드를 위한 자리를 지금 미리 만들지 않는다** — `src/models/AGENTS.md`가 명시하는 원칙("가정만으로 미리 켜지 않는다", "과설계 방지")을 따른다.
+
+**상태 필터 없음(초안 유지):** 최근 주문 5건은 `orderStatus` 필터 없이 `createdAt` desc로 뽑는다. PENDING(방금 들어옴)과 CANCELLED(방금 취소됨) 둘 다 관리자가 볼 가치가 있고, 상태는 배지가 말해준다. 필터를 걸면 오히려 "취소가 발생한 사실"이 숨는다.
+
+### Q4. trend가 필요한 카드는 어디까지인가 → **4개 전부. 단 종류가 두 가지다**
+
+카드마다 trend 종류가 다른 건 일관성 결여가 아니라 **지표의 성격이 실제로 두 종류**이기 때문이다:
+
+| 종류 | 카드 | value | trend | 이유 |
+|---|---|---|---|---|
+| **저량(stock)** | 총 상품, 총 회원 | 누적 총계 | 이번 달 증가 **절대 건수** | 누적 총계에 전월 대비 %를 씌우면 항상 작은 양수가 나와 변별력이 없다 |
+| **유량(flow)** | 매출, 결제 주문 | 이번 달 발생량 | 전월 대비 **%** | value 자체가 이미 한 달치 양이라 비율 비교가 성립한다 |
+
+그래서 리턴 타입의 필드가 카드마다 비대칭인 것이 **의도된 설계**다(ui-designer 확인 완료).
+
+기존 mock의 주문 trend `"+8 지난 주 대비"`는 혼자만 주 단위였다 — **계승하지 않는다.** 전부 월 단위로 통일한다.
+
+---
+
+## 3. 타입 계약 — `src/core/domain/dashboard.ts`
+
+```ts
+import type { OrderStatus } from "./order";
+
+/** 대시보드 "최근 주문" 한 행 — 화면이 실제로 그리는 필드만 추린다. */
+export interface DashboardRecentOrder {
+  /** 행 key 겸 관리자에게 보이는 주문 식별자. Order 컬렉션에서 unique다. */
+  merchantUid: string;
+  buyerName: string;
+  /** DB의 product.title(주문 시점 스냅샷)을 평탄화한 것. */
+  productTitle: string;
+  /** 원 단위 raw number — 통화 포맷은 UI가 한다. */
+  finalPrice: number;
+  /** raw enum — 라벨/배지는 ORDER_STATUS_LABELS / ORDER_STATUS_BADGE_VARIANTS 재사용. */
+  orderStatus: OrderStatus;
+  /** JSON 경계를 안 타므로 Date 그대로 UI까지 간다(string 아님). */
+  createdAt: Date;
+}
+
+export interface DashboardStats {
+  // ── 저량(stock) 지표 ────────────────────────────────
+  /** 소프트 삭제되지 않은 전체 상품 수(deletedAt: null). */
+  totalProducts: number;
+  /** 이번 달(KST) 등록된 상품 수. */
+  productsCreatedThisMonth: number;
+  /** 탈퇴하지 않은 전체 회원 수(isDelete: false). */
+  totalUsers: number;
+  /** 이번 달(KST) 가입한 회원 수. */
+  usersCreatedThisMonth: number;
+
+  // ── 유량(flow) 지표 ─────────────────────────────────
+  //    아래 4개는 모집단이 동일하다: orderStatus ∈ {CONFIRMED, COMPLETED}, confirmedAt 기준.
+  //    그래서 revenueThisMonth / paidOrderCountThisMonth = 평균 객단가가 성립한다.
+  /** 이번 달(KST) 결제 완료 매출 합계(원). */
+  revenueThisMonth: number;
+  /** 전월(KST) 결제 완료 매출 합계(원). 0이면 "전월 실적 없음"이다(§6 참고). */
+  revenuePreviousMonth: number;
+  /** 이번 달(KST) 결제 완료 주문 건수. */
+  paidOrderCountThisMonth: number;
+  /** 전월(KST) 결제 완료 주문 건수. */
+  paidOrderCountPreviousMonth: number;
+
+  // ── 최근 주문 ───────────────────────────────────────
+  /** createdAt desc 최대 5건. 상태 필터 없음. 주문이 없으면 빈 배열(REQ-2 빈 상태). */
+  recentOrders: DashboardRecentOrder[];
+}
+```
+
+### 계약상 보장 (UI가 의존해도 되는 것)
+
+- **모든 수치 필드는 항상 실제 `number`다. `null`/`undefined`가 절대 오지 않는다.** 집계 결과가 없으면 `0`이다.
+- **`0`은 언제나 "진짜 0"이다.** "집계 실패해서 값을 모름" 상태는 존재하지 않는다 — 집계 실패는 값이 아니라 throw로 나간다(§6). 그래서 UI는 `revenuePreviousMonth === 0` 하나만 보고 "전월 실적 없음 → trend 줄 생략"을 판정할 수 있고, 별도 sentinel 분기가 필요 없다.
+- **`recentOrders`는 항상 배열이다.** 주문이 없으면 `[]` (길이 0). `null`이 아니다.
+- **완성된 표시 문자열을 절대 내려보내지 않는다.** `"+12.5% 지난 달 대비"` 같은 문구, 통화 포맷(`"₩1,234,000"`), 상대시간(`"3시간 전"`)은 전부 UI 소관이다. 서버가 문구를 만들면 UI가 증감 부호에 따른 색상(증가=primary / 감소=destructive / 동일=muted)을 판단할 수 없다.
+
+### 상수 승격 (초안 대비 변경점)
+
+초안은 `src/services/dashboard.ts` 안에 `REVENUE_STATUSES`를 지역 선언했다. 이걸 **`src/core/domain/order.ts`로 `PAID_ORDER_STATUSES`로 승격**한다:
+
+```ts
+/** 결제가 이미 반영된 주문 상태 — 매출/결제주문 집계의 모집단이다.
+ *  services/payment.ts의 isPaymentAppliedStatus와 같은 정의를 공유한다. */
+export const PAID_ORDER_STATUSES = ["CONFIRMED", "COMPLETED"] as const;
+```
+
+이유: "결제로 인정하는 상태가 무엇인가"는 매출 정의의 핵심인데, 지금 이 정의가 `payment.ts:60`(`isPaymentAppliedStatus`)과 `invitation.ts:62`에 이미 각각 흩어져 있다. dashboard가 세 번째 사본을 만들면 나중에 상태가 하나 추가될 때 매출만 조용히 틀려진다. 값이 끝까지 문자열 리터럴이라 `src/AGENTS.md`의 SCREAMING_SNAKE_CASE 규칙에 맞다.
+
+> 기존 `isPaymentAppliedStatus`를 이 상수 기반으로 리팩터링할지는 **이번 스코프 밖**으로 둔다(결제 경로 회귀 위험 대비 이득이 작다). 새 사본을 안 만드는 것까지가 이번 범위다.
+
+### 순수 함수 배치
+
+- **전월 대비 증감률 계산은 UI가 소유한다.** ui-designer가 `src/core/utils/`에 순수함수로 작성한다. 서비스는 원시값 양쪽(`revenueThisMonth`, `revenuePreviousMonth`)만 준다.
+- **월 경계 계산은 `src/core/utils/date.ts`에 둔다** (§5 참고). 도메인 무관 날짜 연산이라 `{목적}` 기반 파일 규칙에 맞고, 서비스와 분리돼야 단위 테스트가 가능하다.
+
+---
+
+## 4. 서비스 함수 시그니처 — `src/services/dashboard.ts`
+
+```ts
+export const getDashboardStatsService = (): Promise<DashboardStats>;
+```
+
+| 항목 | 확정 |
+|---|---|
+| 파라미터 | **없음.** 필터/기간 선택 UI가 없다. 기간을 인자로 받는 형태는 소비처가 없으므로 만들지 않는다 |
+| 리턴 | `Promise<DashboardStats>` — 도메인 타입 그대로, envelope 없음 |
+| 호출자 | `src/app/(admin)/admin/dashboard/page.tsx` (Server Component) 단 하나 |
+| 인증 | **함수 내부에서 하지 않는다** (§7) |
+| 응답 방식 | **즉시 응답(동기적 await).** 비동기 잡·폴링·백그라운드 집계 없음 |
+| 캐싱 | **없음.** 페이지가 `dynamic = "force-dynamic"`이라 매 요청 재집계한다. `unstable_cache`를 붙이지 않는다 — REQ-1의 수용 기준이 "상품/회원 등록·주문 발생 시 값이 갱신된다"이다 |
+| 실패 | `AppError` throw (§6) |
+
+호출 형태:
+
+```tsx
+// page.tsx
+await verifySession("ADMIN");
+const stats = await getDashboardStatsService();
+return <AdminDashboardTemplate stats={stats} />;
+```
+
+---
+
+## 5. 필드별 계산 로직 (집계 쿼리 방향)
+
+### 5.1 월 경계는 KST로 계산한다 — 초안 대비 변경점 (중요)
+
+초안은 `new Date(now.getFullYear(), now.getMonth(), 1)`을 썼다. 이건 **서버 로컬 타임존**을 쓴다. Vercel 서버 TZ는 UTC이고, 이 프로젝트에 TZ를 고정하는 설정이 없다(`next.config`/`vercel.json` 확인함). 따라서 "이번 달"이 UTC 월 경계가 되어 KST와 9시간 어긋난다 — **9/1 오전 1시(KST)에 입금된 건이 8월 매출로 잡힌다.** 한국 대상 서비스에서 이건 "대시보드 숫자가 주문 목록과 안 맞는다"는 버그로 직결된다.
+
+`date-fns` v4 + `date-fns-tz` v3이 이미 설치돼 있고, `preview` 페이지가 `formatInTimeZone`으로 `"Asia/Seoul"`을 쓰는 선례가 있다.
+
+`src/core/utils/date.ts`에 추가할 순수함수:
+
+```ts
+/** 주어진 시각이 속한 KST 기준 전월·이번 달·다음 달 경계를 UTC instant로 돌려준다. */
+export const getKstMonthRange = (now: Date = new Date()) => {
+  const zoned = toZonedTime(now, "Asia/Seoul");
+  return {
+    startOfLastMonth: fromZonedTime(startOfMonth(subMonths(zoned, 1)), "Asia/Seoul"),
+    startOfThisMonth: fromZonedTime(startOfMonth(zoned), "Asia/Seoul"),
+    startOfNextMonth: fromZonedTime(startOfMonth(addMonths(zoned, 1)), "Asia/Seoul"),
+  };
+};
+```
+
+`date-fns-tz`는 isomorphic이라 `src/core/`의 "서버 전용 패키지 금지" 경계를 위반하지 않는다.
+
+**상한은 `now`가 아니라 `startOfNextMonth`를 쓴다** (db-migrator 제안 채택). 초안의 `$lt: now`는 매 호출 값이 달라져 쿼리가 비결정적일 뿐 아니라, 클럭 스큐로 `confirmedAt`이 `now`보다 미세하게 앞선 문서가 **조용히 집계에서 빠진다.** 월 경계로 고정하면 그 창이 닫힌다.
+
+> **UI도 같은 TZ 유틸을 쓴다 (boundary-verifier 대조 지점).** ui-designer가 최근 주문의 상대시간을 그릴 때 7일 초과 건은 절대 날짜로 폴백하는데, 기존 `src/core/utils/date.ts`의 `formatDate`가 `getFullYear()`/`getMonth()`/`getDate()` 기반이라 서버 로컬 TZ(=UTC)로 렌더된다 — KST 밤 9시 주문이 하루 밀려 보인다. UI 신규 함수 `formatRelativeTime`의 폴백 분기가 `Asia/Seoul`을 명시해 이 문제를 피한다(`01_ui_flow.md` §3.3). **즉 카드 집계 경계와 리스트 날짜 표시가 둘 다 `Asia/Seoul` 기준이다.** 기존 `formatDate` 자체는 소비처가 전역이라 이번 스코프에서 건드리지 않는다.
+
+### 5.2 매출 + 결제 주문 수 — 집계 1방으로 두 달치
+
+두 지표는 모집단이 같으므로 **하나의 파이프라인**에서 뽑는다. `$facet`이 아니라 `$cond` 그룹핑을 쓴다:
+
+```js
+OrderModel.aggregate([
+  {
+    $match: {
+      orderStatus: { $in: PAID_ORDER_STATUSES },
+      confirmedAt: { $gte: startOfLastMonth, $lt: startOfNextMonth },
+    },
+  },
+  {
+    $group: {
+      _id: { $cond: [{ $gte: ["$confirmedAt", startOfThisMonth] }, "current", "previous"] },
+      revenue: { $sum: "$finalPrice" },
+      count: { $sum: 1 },
+    },
+  },
+])
+```
+
+- `orderSchema.index({ orderStatus: 1, confirmedAt: 1 })`가 이 `$match`를 완전 커버한다.
+- 결과에서 `current`/`previous` 버킷을 꺼내되, **버킷이 없을 수 있다**(해당 월 결제 0건) → `?? 0`으로 폴백해서 §3의 "항상 number" 보장을 지킨다.
+- 초안은 이 4개 값을 위해 쿼리 4개(`sumFinalPrice` 2회 + `countDocuments` 2회)를 날렸다. 1개로 줄어든다.
+- **`$ifNull`로 `confirmedAt` 결측을 폴백하지 않는다** — `$match`에 표현식이 들어가면 위 인덱스 커버가 깨져 COLLSCAN이 된다. 결측 문제는 일회성 backfill로 푼다(§9).
+
+### 5.3 상품 / 회원 카운트
+
+```js
+ProductModel.countDocuments({ deletedAt: null })
+ProductModel.countDocuments({ deletedAt: null, createdAt: { $gte: startOfThisMonth } })
+UserModel.countDocuments({ isDelete: false })
+UserModel.countDocuments({ isDelete: false, createdAt: { $gte: startOfThisMonth } })
+```
+
+**두 모델이 서로 다른 소프트 삭제 컨벤션을 쓴다** — Product는 `deletedAt: Date | null`, User는 `isDelete: boolean`. 초안이 맞게 썼고, db-migrator가 실측으로 확인했다. 헷갈리기 쉬운 지점이라 명시해둔다.
+
+`deletedAt: null`이 정확한 필터인 근거: `services/product.ts`의 모든 읽기 경로가 `{ deletedAt: null }`로 거르고, 소프트 삭제(`:327`)는 `status: "deleted"` + `deletedAt: new Date()`를 **함께** 세팅하며 복원(`:353`)이 둘 다 되돌린다 — 두 필드가 항상 동기화된다.
+
+> `status`가 `"inactive"`/`"soldOut"`인 상품도 **포함**한다. "총 상품"은 관리자가 등록해둔 상품 자산의 총량이지 판매 중인 것만이 아니다.
+
+### 5.4 최근 주문 5건
+
+```js
+OrderModel.find()
+  .sort({ createdAt: -1 })
+  .limit(5)
+  .select("merchantUid buyerName product.title finalPrice orderStatus createdAt")
+  .lean()
+```
+
+- 상태 필터 없음(§2 Q3).
+- `.lean()` 사용 — 결과를 그대로 매핑해 리턴하고 Document 메서드가 필요 없다(`services/AGENTS.md`).
+- `product.title` → `productTitle` 평탄화는 서비스에서 한다.
+- **`_id`를 리턴 타입에 노출하지 않으므로 ObjectId → string 변환이 필요 없다.** `merchantUid`(unique string)가 행 key 역할을 한다. 만약 나중에 `/admin/orders/[orderId]` 상세 링크가 생겨서 `orderId`가 필요해지면, 그때 `_id.toString()`을 명시적으로 변환해 필드를 추가한다(`services/AGENTS.md`의 ObjectId 변환 규칙).
+
+> **인덱스 전제조건:** 이 쿼리는 필터가 없어서 기존 Order 인덱스 3개(전부 선두 필드가 `userId` 또는 `orderStatus`)를 못 쓴다 → COLLSCAN + in-memory sort다. MongoDB의 32MB 정렬 메모리 상한 때문에 주문이 쌓이면 쿼리 자체가 실패한다. **`{ createdAt: -1 }` 단일 인덱스가 필요하다** — db-migrator에 요청함(§9).
+
+### 5.5 병렬 실행
+
+쿼리들을 `Promise.all`로 병렬 실행한다. 초안은 9개 쿼리였고, §5.2의 통합만으로 6개(주문 집계 1 + 상품 2 + 회원 2 + 최근주문 1)가 된다.
+
+db-migrator가 상품/회원도 `countDocuments` 2회씩 대신 같은 문서집합을 1회 스캔하는 `$cond` 집계로 합쳐 **총 4개**까지 줄인 형태를 `01_db_schema.md`에 확정했다. **반환 shape이 동일하므로 이 계약에는 영향이 없다** — 구현은 `01_db_schema.md`의 쿼리 형태를 따르되, §3의 리턴 타입 보장(항상 number, 버킷 없으면 `?? 0`)만 지키면 된다.
+
+읽기 전용이므로 트랜잭션을 쓰지 않는다 — `services/AGENTS.md`의 트랜잭션 조건은 "여러 문서에 걸친 **쓰기**"이고, 여기 해당 없다. (트랜잭션 안에서 `Promise.all` 금지 규칙도 트랜잭션이 없으므로 무관하다.)
+
+---
+
+## 6. 에러 계약
+
+### 실패 정책: all-or-nothing (3자 합의)
+
+`Promise.all`이라 6개 중 하나라도 실패하면 전체가 reject되고, 페이지 렌더가 실패해 **`src/app/(admin)/error.tsx`가 통째로 잡는다**(해당 파일 실재 확인함).
+
+이게 의도된 설계다 — **부분 렌더된 대시보드는 관리자에게 잘못된 판단을 유도한다.** 매출 카드만 비어 있는 화면을 보고 "이번 달 매출이 0"이라고 오해하는 것보다, 페이지 전체가 에러로 막히는 편이 안전하다. per-section 폴백 UI를 설계하지 않는다.
+
+이 정책의 부수 효과로 **"집계는 됐는데 값을 모름" 상태가 타입에서 사라진다** — 그래서 §3의 "0은 언제나 진짜 0" 보장이 성립하고, UI는 `revenuePreviousMonth === 0 || paidOrderCountPreviousMonth === 0`을 안심하고 "전월 실적 없음 → trend 줄 렌더 생략"으로 해석할 수 있다.
+
+### 에러 카테고리
+
+| 상황 | 카테고리 | 비고 |
+|---|---|---|
+| DB 커넥션/타임아웃, 집계 실패, mongoose 예외 | `INTERNAL` | 유일하게 발생 가능한 분류 |
+| 미인증 / 비관리자 | — | `AppError`가 아니라 `verifySession`의 `redirect()`로 처리된다(§7) |
+| `VALIDATION` | 해당 없음 | 입력 파라미터가 없다 |
+| `NOT_FOUND` | 해당 없음 | 조회 대상이 "없을 수 있는 단일 리소스"가 아니다. 데이터가 없으면 `0`/`[]`이지 404가 아니다 |
+| `FORBIDDEN` / `UNAUTHENTICATED` / `DISABLED` / `EXTERNAL_SERVICE` | 해당 없음 | 외부 연동 없음, 기능 토글 없음 |
+
+### 구현 규칙 (초안 결함 — backend-impl 필독)
+
+**초안 `src/services/dashboard.ts`에는 try/catch가 전혀 없다.** 그래서 mongoose 예외(`CastError` 등)가 raw로 새어나가 `services/AGENTS.md`의 "services가 던지는 에러는 `AppError` 하나로 통일한다" 규칙을 위반한다. 반드시 감싸야 한다:
+
+```ts
+const [...] = await Promise.all([...]).catch((error) => {
+  throw new AppError(
+    "INTERNAL",
+    error instanceof Error ? error.message : "대시보드 통계 조회에 실패했습니다.",
+  );
+});
+```
+
+`services/AGENTS.md`: "mongoose 자체 에러는 `AppError("INTERNAL", 원본 message)`로 감싸서 다시 throw한다."
+
+> 참고: `invitation.ts:20`의 `toInternalError`는 그 파일 안의 **지역 헬퍼**라 import할 수 없다. 공용 유틸로 승격하는 건 이번 스코프 밖이다 — dashboard.ts 안에서 위 형태로 직접 처리한다.
+
+> 원문 message가 응답에 실릴 걱정은 없다 — 이 경로는 클라이언트로 나가는 envelope이 아니라 RSC 렌더 예외이고, `error.tsx`는 Next.js가 프로덕션에서 자동으로 메시지를 가린 상태로 받는다.
+
+### 빈 상태 (REQ-2)
+
+주문이 한 건도 없으면 `recentOrders: []`가 내려간다. **이건 에러가 아니다.** UI가 빈 상태 문구를 렌더한다(REQ-2 수용 기준).
+
+---
+
+## 7. 인증 — 서비스 내부에서 재검증하지 않는다
+
+**`getDashboardStatsService`는 세션/권한을 검사하지 않는다.** 접근 제어는 `page.tsx`의 `await verifySession("ADMIN")`가 전담한다(현재 코드에 이미 있음).
+
+근거:
+
+- `src/AGENTS.md`의 재검증 의무는 **Server Action** 대상이다 — Server Action은 "UI 없이 동일 오리진에서 같은 POST 요청을 직접 보낼 수 있는" 실질적 엔드포인트라서다. 이 서비스 함수는 외부에서 호출 가능한 엔드포인트가 아니라 같은 프로세스 안의 함수 호출이며, 도달하는 유일한 경로가 이미 `verifySession("ADMIN")`으로 막힌 페이지다.
+- `verifySession`은 실패 시 `AppError`를 던지지 않고 **`redirect()`** 한다(`services/auth.ts:143-152`). 리다이렉트는 UI 라우팅 관심사라 서비스 레이어 안에 들어가면 계층이 뒤집힌다.
+- `src/proxy.ts`도 `/admin` 경로를 낙관적으로 한 겹 더 막는다(전체 방어선이 아니라 보조 — `page.tsx`의 `verifySession`이 실질 경계).
+
+**backend-impl에게:** 서비스 안에 `verifySession`/`requireAdmin`을 넣지 마라. **boundary-verifier에게:** 서비스에 인증 검사가 없는 것은 결함이 아니라 위 근거에 따른 의도된 배치다.
+
+---
+
+## 8. 초안 대비 변경점 요약
+
+| # | 항목 | 초안 | 확정 | 이유 |
+|---|---|---|---|---|
+| 1 | 매출 기준 시각 | `createdAt` | **`confirmedAt`** | 가상계좌 입금월 불일치 + 월경계 오분류. 기존 인덱스가 커버 |
+| 2 | 주문 수 모집단 | 전체 주문(PENDING·CANCELLED 포함), `createdAt` | **결제 완료만(CONFIRMED+COMPLETED), `confirmedAt`** | 매출 카드와 모집단·시각 기준이 달라 `매출 ÷ 주문수 = 객단가`가 안 맞았다 |
+| 3 | 주문 필드명 | `monthlyOrderCount` / `previousMonthOrderCount` | **`paidOrderCountThisMonth` / `paidOrderCountPreviousMonth`** | #2로 의미가 바뀌었는데 이름이 그 변화를 안 담아 "전체 주문"으로 오해된다 |
+| 4 | 매출 필드명 | `monthlyRevenue` / `previousMonthRevenue` | **`revenueThisMonth` / `revenuePreviousMonth`** | 나머지 6개 필드가 전부 `…ThisMonth` 접미형인데 매출만 접두형이면 8개 필드에 두 규칙이 섞인다(db-migrator 제기) |
+| 5 | 월 경계 계산 | 서버 로컬 TZ (`new Date(y, m, 1)`) | **KST 명시 (`getKstMonthRange`)** | Vercel TZ=UTC → "이번 달"이 KST와 9시간 어긋난다 |
+| 6 | 매출/주문 쿼리 | 쿼리 4개(sum 2 + count 2) | **집계 1개(`$cond` 그룹핑)** | 모집단이 같아 한 파이프라인으로 뽑힌다. 총 9 → 6 → (db-migrator 추가 통합) 4 쿼리 |
+| 7 | 매출 상태 상수 | `dashboard.ts` 지역 `REVENUE_STATUSES` | **`core/domain/order.ts`의 `PAID_ORDER_STATUSES`로 승격** | `payment.ts`/`invitation.ts`에 이미 흩어진 정의의 세 번째 사본을 만들지 않는다 |
+| 8 | 에러 처리 | try/catch 없음 (raw mongoose 에러 누출) | **`AppError("INTERNAL", …)` 래핑** | `services/AGENTS.md` 위반 수정 |
+| 9 | 집계 상한 | `$lt: now` | **`$lt: startOfNextMonth`** | `now` 상한은 비결정적이고, 클럭 스큐 문서가 조용히 누락된다 |
+| 10 | 매출 상태 필터 | `CONFIRMED`+`COMPLETED` | **유지** | 재검토 결과 근거 확인됨(부분취소 없음, `isPaymentAppliedStatus`와 일치) |
+| 11 | 최근 주문 5건 | 유지 | **유지** | 3자 합의 |
+| 12 | 저량/유량 비대칭 필드 | 유지 | **유지 + 근거 명문화** | 카드 종류가 실제로 둘이라 의도된 비대칭이다 |
+| 13 | `confirmedAt` 결측 | (미인지) | **backfill 선행 (§9)** | #1의 전제조건. db-migrator가 git 이력으로 실재 확인 |
+| 14 | Order 인덱스 | (미인지) | **`{ createdAt: -1 }` 추가 (§9)** | 최근 주문 무필터 정렬이 32MB 상한에 걸려 쿼리가 실패한다 |
+
+### 협의 결과 — 3자 합의 완료, 미해결 쟁점 없음
+
+- **ui-designer** — 요청 1~6 전부 채택(원시 수치 / `0`은 진짜 0 / 최근주문 6필드 / 5건 / all-or-nothing / 비대칭 trend). 변경 #2·#3 및 카드 copy 수정 요청을 **전부 수용 회신**받음. `orderId`는 상세 라우트가 생길 때 요청하기로 보류.
+- **db-migrator** — 제안 4건 전부 수용, 회신으로 필드명 #4·상한 #9·backfill 소스 정정을 받아 반영함.
+- **독립 수렴:** `confirmedAt` 기준(#1)과 주문수 모집단 통일(#2)은 api-designer·db-migrator가 서로 모르는 상태에서 **같은 결론**에 도달했다. 반대로 §5.1(KST)·§5.4(인덱스)·§9(backfill)는 api-designer가 제기해 db-migrator가 검증했다.
+- **1라운드 왕복으로 종결** — 3라운드 상한에 도달한 쟁점 없음.
+
+### UI 카피 — ui-designer 확정본 (`01_ui_flow.md` §4.1.1)
+
+| # | title | description | trend |
+|---|---|---|---|
+| 1 | 등록 상품 | 삭제 제외 전체 상품 | 이번 달 증가 건수 |
+| 2 | 총 매출 | 이번 달 결제 완료 기준 | 전월 대비 % |
+| 3 | 결제 주문 | 이번 달 결제 완료 주문 | 전월 대비 % |
+| 4 | 활동 회원 | 탈퇴 제외 가입 회원 | 이번 달 증가 건수 |
+
+- 3번은 변경 #2가 반영된 필수 수정이다.
+- 1번 description은 api-designer가 제안한 "등록된 상품 수" 대신 ui-designer의 **"삭제 제외 전체 상품"**을 채택했다 — 집계 조건이 `deletedAt: null` 하나뿐이라 비공개(`inactive`)·품절(`soldOut`)까지 포함되는데, "등록된 상품 수"는 그 사실을 감춘다. description이 쿼리 조건과 1:1로 읽히는 편이 낫다. **동의함.**
+- 유량 카드 둘(2·3)의 trend를 전월 대비 %로 통일 — 나란히 놓인 두 지표가 같은 형태여야 함께 읽힌다.
+- mock의 `"+8 지난 주 대비"`(혼자만 주 단위)는 계승 금지.
+
+---
+
+## 9. 구현 전제조건 (확정 — **차단 조건**, 코드보다 먼저 처리)
+
+두 건 모두 db-migrator 검증을 거쳐 확정됐다. 타입 시그니처는 이걸 안 해도 컴파일되지만, **건너뛰면 계약대로 구현해도 숫자가 틀리거나 쿼리가 실패한다.**
+
+> **"리턴 타입에 영향 없음"으로 읽지 마라 (ui-designer 지적 반영).** 전제-1을 건너뛰면 매출·결제주문 카드가 **에러 없이 조용히 축소된 숫자를 렌더한다.** UI는 §3의 "0은 언제나 진짜 0" 보장을 근거로 `-`·"데이터 없음" 폴백을 **의도적으로 전부 제거했으므로**(`01_ui_flow.md` §7 Q14), 축소된 값은 화면에서 정상값과 구분이 불가능하다. 던져지는 에러도 빈 상태도 아닌 **그럴듯한 오답**이라 이 화면에서 가장 위험한 실패 양상이다. 순서 권고가 아니라 차단 조건으로 취급한다.
+
+### 전제-1. `confirmedAt` 결측 backfill — **가설이 아니라 실재하는 결함**
+
+db-migrator가 git 이력으로 확인한 결과, 결측이 발생할 수 있는 구간이 실제로 존재했다:
+
+| 시점 | 상태 |
+|---|---|
+| ~2026-07-29 이전 | 결제 확정 코드가 `orderStatus="CONFIRMED"` + `paymentId` 대입 후 `save()`만 실행 — **`confirmedAt` 대입 없음** |
+| 2026-07-29 PR #77 (`e2eb63e`) | `Order.confirmedAt` 필드 신설 |
+| 이후 (`payment.ts:364`) | 항상 세팅 |
+
+**즉 PR #77 배포 이전에 결제 확정된 운영 주문은 `confirmedAt`이 없다.** 변경 #1(`confirmedAt` 기준 집계)을 그대로 적용하면 그 주문들이 **에러 없이 조용히 매출에서 빠진다** — 숫자만 작아지는 최악의 실패 모드다. (7/29가 최근이라 실제 해당 건수는 0일 수도 있다. 코드로는 알 수 없어 실측이 필요하다.)
+
+**확정 절차** (`01_db_schema.md` §4-1, backend-impl이 구현 전 1회 수행):
+
+1. 실측: `db.orders.countDocuments({ orderStatus: { $in: ["CONFIRMED","COMPLETED"] }, confirmedAt: null })` — `null` 비교가 필드 누락 문서까지 함께 잡는다
+2. **0건** → 문서에 "확인 완료(0건)" 기록하고 그대로 진행
+3. **1건 이상** → backfill 1회 수행. 조건이 `confirmedAt: null`이라 멱등하다
+
+**backfill 소스 우선순위: `Payment.paidAt` > `Order.createdAt`.** `payment.model.ts:236`에 `paidAt`이 있고 `:192`의 `merchantUid`가 unique라 주문과 1:1 조인된다 — 실제 결제 완료 시각이라 정답에 가장 가깝다.
+
+> ⚠️ **`updatedAt`을 소스로 쓰면 안 된다.** api-designer가 초안으로 제시했다가 db-migrator가 반박해 철회한 안이다 — §2 Q2에서 근거로 든 `invitation.ts:216`의 `CONFIRMED` ↔ `COMPLETED` 토글이 바로 그 `updatedAt`을 갱신하기 때문에, 청첩장을 발행/비공개한 주문의 `updatedAt`은 결제 시각과 완전히 무관해진다. 매출 기준의 안정성 근거였던 사실이 backfill 소스로는 정반대로 작용한다.
+
+> 운영 DB 접근은 설계 단계에서 아무도 수행하지 않았다 — **리더 확인 사항**(`01_db_schema.md` §7).
+
+### 전제-2. Order `{ createdAt: -1 }` 인덱스 — 권고에서 **필수**로 승격
+
+§5.4의 무필터 정렬 전제조건. db-migrator가 분석에 동의하고 필수로 확정했다: 32MB blocking-sort 상한은 "느려짐"이 아니라 **"쿼리 실패"**라 대시보드가 통째로 죽는다.
+
+덤으로, `/admin/orders`가 지금 `mockOrders`를 쓰고 있고 곧 실데이터 전환 대상인데 **그 관리자 전역 주문 목록도 `userId` 스코프가 없어** 같은 인덱스를 필요로 한다. 이번 기능에 넣는 게 맞다.
+
+---
+
+## 10. backend-impl 구현 체크리스트
+
+**선행(코드보다 먼저):**
+- [ ] §9 전제-1 — `confirmedAt: null` 건수 실측, 1건 이상이면 `Payment.paidAt` 기준 backfill
+- [ ] §9 전제-2 — Order `{ createdAt: -1 }` 인덱스 추가 (`01_db_schema.md` 참조)
+
+**코드:**
+- [ ] `src/core/domain/order.ts` — `PAID_ORDER_STATUSES` 추가
+- [ ] `src/core/domain/dashboard.ts` — §3 타입으로 교체. **필드명 4개가 초안과 다르다**: `monthlyRevenue`→`revenueThisMonth`, `previousMonthRevenue`→`revenuePreviousMonth`, `monthlyOrderCount`→`paidOrderCountThisMonth`, `previousMonthOrderCount`→`paidOrderCountPreviousMonth`
+- [ ] `src/core/utils/date.ts` — `getKstMonthRange` 추가 (3개 경계 반환) + `src/core/utils/index.ts` 배럴 확인
+- [ ] `src/core/utils/date.test.ts` — `getKstMonthRange` 단위 테스트(월초/월말 KST 경계, 1월→전월이 작년 12월, UTC와 9시간 어긋나는 케이스). 현재 `date.ts`에는 테스트 파일이 없다
+- [ ] `src/services/dashboard.ts` — §5 쿼리로 재작성(`01_db_schema.md`의 4-쿼리 형태 채택) + §6 `AppError` 래핑
+- [ ] `src/core/domain/index.ts` / `src/services/index.ts` 배럴 (초안이 이미 추가해둠, 유지)
+- [ ] `src/app/(admin)/admin/dashboard/page.tsx` — 하드코딩 `stats` 배열 제거, `getDashboardStatsService()` await 후 Template에 props 전달
+- [ ] 워킹트리의 미커밋 초안(`ORDER_STATUS_LABELS` 승격 포함)을 **덮어쓰지 말고 위 변경점을 반영해 수정**할 것
+
+**boundary-verifier 대조 지점:**
+1. 초안 `dashboard.ts`가 아직 **구 필드명**을 쓰고 있다 — 서비스 리턴/도메인 타입/UI 소비처 3곳이 새 이름으로 일치하는지
+2. `recentOrders[].createdAt`이 `Date`인지 (`string`으로 변질되면 JSON 경계가 어딘가 생겼다는 뜻)
+3. 카드 집계 경계(`getKstMonthRange`)와 UI 날짜 표시(`formatRelativeTime` 폴백)가 **둘 다 `Asia/Seoul`** 기준인지 (§5.1)
+4. envelope(`{success, data}`)이 이 경로에 끼어들지 않았는지 (§1)
+
+### 하지 말 것
+
+- route handler / Server Action / zod 스키마 생성 (§1)
+- `{ success, data }` envelope 사용 (§1)
+- 서비스 안 `verifySession`/`requireAdmin` 호출 (§7)
+- `unstable_cache` 등 캐싱 부착 (§4)
+- per-section 부분 실패 폴백 (§6)
+- 서버에서 표시 문자열(통화·%·상대시간) 포맷 (§3)

--- a/_workspace/feat/admin-dashboard-real-data/01_db_schema.md
+++ b/_workspace/feat/admin-dashboard-real-data/01_db_schema.md
@@ -1,0 +1,331 @@
+# 01_db_schema.md — admin 대시보드 실데이터 집계 설계
+
+> 담당: db-migrator / Phase 1 — api-designer·ui-designer 조율 반영 완료(1라운드)
+> 결론 요약: **신규 컬렉션·신규 필드 없음.** 기존 Order/Product/User를 읽기 전용으로 집계한다.
+> 단 **레거시 `confirmedAt` 결측 backfill 1건은 조건부 필수**다(§4-1 — 배포 전 확인 필요, 매출이 조용히 누락되는 실패 모드).
+> 초안(`src/services/dashboard.ts`) 대비 변경점: 매출 기준 시각, 주문수 모집단, KST 월 경계, 쿼리 병합, 필드명. 인덱스 1건 필수 + 2건 권고.
+
+---
+
+## 1. 필드 실측 검증 (초안 가정 vs 실제 스키마)
+
+| 초안 가정 | 실제 | 판정 |
+|---|---|---|
+| `Order.orderStatus` enum `PENDING/CONFIRMED/COMPLETED/CANCELLED` | 동일 (`order.model.ts:68-73`, `core/domain/order.ts:33-38`에도 `ORDER_STATUSES`로 중복 정의) | 실재 |
+| `Order.finalPrice: number` (required) | 동일 (`order.model.ts:118`) | 실재 |
+| `Order.createdAt` | `{ timestamps: true }` (`order.model.ts:146`) | 실재 |
+| `Order.confirmedAt?: Date` | 실재 (`order.model.ts:92`) — CONFIRMED 전이 시각, `payment.ts:364`에서만 세팅 | 초안 미사용 → **사용 권고**(§2) |
+| `Product.deletedAt` 소프트 삭제 | 실재. `deletedAt: { type: Date, default: null }` — **optional이 아니라 nullable**, 모든 문서에 항상 존재 (`product.model.ts:144`) | 실재 |
+| `User.isDelete` 소프트 삭제 | 실재. `isDelete: { type: Boolean, default: false }` (`user.model.ts:29`) | 실재 |
+
+### 소프트 삭제 컨벤션이 모델마다 다른 건 실제 사실이다
+
+초안이 Product엔 `deletedAt: null`, User엔 `isDelete: false`를 쓴 건 **오류가 아니라 프로젝트 현실을 정확히 반영한 것**이다.
+
+- Product: `services/product.ts`의 조회 경로 전부가 `{ deletedAt: null }`로 거른다(단건/목록/좋아요/휴지통 12개 지점). 소프트 삭제 시 `status: "deleted"`도 같이 세팅되지만(`product.ts:327`) **판별 기준(canonical)은 `deletedAt`**이다 — 복원은 `{ status: "active", deletedAt: null }`. 대시보드도 `deletedAt`을 쓴다(`status`를 쓰면 `inactive`/`soldOut`까지 어떻게 셀지 별도 정책이 필요해지고 기존 목록 화면 카운트와 어긋난다).
+- User: `services/user.ts:60`이 `{ email, isDelete: false }`. `deletedAt` 필드 자체가 없다.
+
+> 컨벤션 통일은 이 기능의 스코프가 아니다. 통일하려면 User에 `deletedAt` 추가 + 전 문서 backfill + 기존 쿼리 전수 수정이 필요하므로, 별도 Issue 대상으로 남긴다.
+
+### 매출 인정 상태 = `CONFIRMED | COMPLETED` — 근거 확인됨
+
+초안의 필터가 맞다. 임의 선택이 아니라 프로젝트에 이미 존재하는 정의와 일치한다.
+
+- `services/payment.ts:61-62` `isPaymentAppliedStatus(orderStatus) = orderStatus === "CONFIRMED" || orderStatus === "COMPLETED"` — 결제 중복 반영 방지 판정이 쓰는 "결제가 이미 반영된 상태"의 정의.
+- `services/invitation.ts:63` 청첩장 사용 가능 조건도 같은 두 값.
+- 상태 전이 실측:
+  - `PENDING` → 결제 전(결제창 미진입 또는 가상계좌 입금 대기). 매출 아님.
+  - `CONFIRMED` — `payment.ts:362-364` 결제 PAID 확인 시 전이 + `confirmedAt` 세팅 + `Product.salesCount` 증가(트랜잭션).
+  - `COMPLETED` — `invitation.ts:230` 청첩장 발행 시 CONFIRMED→COMPLETED. **결제와 무관한 이행 완료 상태**라 매출에서 빼면 안 된다(발행하면 매출이 사라지는 버그가 된다).
+  - `CANCELLED` — 취소/환불. `payment.ts:635` 환불은 **항상 전액 취소 후 orderStatus를 CANCELLED로 전이**한다(부분 취소 경로 없음). 따라서 `$in: [CONFIRMED, COMPLETED]` 필터만으로 환불건이 자동 제외된다 — 별도 환불 차감 로직 불필요.
+
+---
+
+## 2. 확정 쿼리 설계
+
+### 2-0. 월 경계는 KST로 계산한다 (초안 수정 필수)
+
+초안의 `new Date(now.getFullYear(), now.getMonth(), 1)`은 **서버 로컬 타임존**을 쓴다. 배포 환경 서버 TZ는 UTC이고 프로젝트에 TZ 고정 설정이 없으므로, 그대로 두면 "이번 달"이 UTC 월 경계가 돼 KST와 9시간 어긋난다 — 9/1 새벽(KST) 결제건이 8월 매출로 잡히고, 관리자가 주문 목록과 대조하면 숫자가 안 맞는다.
+
+`date-fns@^4.1.0` + `date-fns-tz@^3.2.0`이 이미 설치돼 있고 프로젝트에 `"Asia/Seoul"` 사용 선례가 있다. 경계 계산은 **순수 함수**이므로 `src/core/utils/`에 두고(부수효과·서버 전용 의존 없음 → `src/core/AGENTS.md` 경계 충족) 서비스는 그 결과(UTC instant)를 그대로 쿼리에 넣는다.
+
+```ts
+// src/core/utils/ — 순수 함수. 반환값은 전부 UTC instant(Date)라 쿼리에 그대로 넣는다.
+const { startOfThisMonth, startOfLastMonth, startOfNextMonth } = getKstMonthRange(new Date());
+```
+
+DB 스키마에는 영향이 없다 — MongoDB에 저장되는 `Date`는 이미 UTC instant이고, 바뀌는 건 비교 경계값뿐이다. 아래 쿼리의 `startOf*` 변수는 전부 이 KST 기준 경계를 가리킨다.
+
+### Q1. Order — 매출 + 주문수 (이번달/전달 한 방)
+
+**초안 대비 변경 2건: `createdAt` → `confirmedAt`, 그리고 쿼리 4개 → aggregation 1개.**
+
+```ts
+OrderModel.aggregate<{ _id: "current" | "previous"; revenue: number; orderCount: number }>([
+  {
+    $match: {
+      // core/domain/order.ts로 승격한 상수를 참조한다(dashboard 로컬 사본 금지)
+      orderStatus: { $in: PAID_ORDER_STATUSES },
+      confirmedAt: { $gte: startOfLastMonth, $lt: startOfNextMonth },
+    },
+  },
+  {
+    $group: {
+      _id: { $cond: [{ $gte: ["$confirmedAt", startOfThisMonth] }, "current", "previous"] },
+      revenue: { $sum: "$finalPrice" },
+      orderCount: { $sum: 1 },
+    },
+  },
+]);
+// 결과 없는 버킷은 행 자체가 안 나온다 → 호출부에서 `?? 0` 폴백 필수.
+```
+
+**왜 `confirmedAt`인가**
+1. 정확성 — 가상계좌 주문은 생성월과 입금월이 갈릴 수 있다(`PENDING_ORDER_EXPIRE_HOURS = 24`는 결제창 미진입 주문에만 적용되고, 가상계좌는 개별 입금기한을 따른다). `createdAt` 기준이면 "이번 달 매출"이 실제 입금 시점과 어긋난다.
+2. 성능 — `{ orderStatus: 1, confirmedAt: 1 }` 인덱스가 **이미 존재**한다(`order.model.ts:162`). 이 필터 조합이 선두 두 키에 정확히 대응해 인덱스로 완전 커버된다. `createdAt` 기준이면 `{orderStatus:1, paymentId:1, createdAt:1}`의 2번째 키(`paymentId`)를 건너뛰게 돼 인덱스 바운드가 끊긴다.
+
+**왜 주문수 모집단을 매출과 같게 맞추나**
+초안은 주문수를 전체 주문(`OrderModel.countDocuments({ createdAt: ... })`)으로 셌다. 이러면 (a) 자동취소되는 방치 PENDING이 카운트를 부풀리고, (b) 옆 카드의 매출과 모집단이 달라 "매출 ÷ 주문수 = 객단가"가 성립하지 않으며, (c) `createdAt` 단독 필터를 쓸 인덱스가 없어 COLLSCAN이다. 매출과 같은 모집단으로 통일하면 셋 다 해결되고 쿼리도 위 aggregation에 흡수된다.
+
+**보강 근거(api-designer)**: `invitation.ts:216`이 청첩장 발행/비공개 토글로 `CONFIRMED ↔ COMPLETED`를 왕복시킨다. 두 상태는 "결제 반영됨"의 두 얼굴이고, `confirmedAt`은 `payment.ts:364`에서 **1회만** 세팅되므로 이 토글에 영향받지 않는다 — 발행/비공개를 반복해도 매출 귀속 월이 흔들리지 않는다.
+
+**`PAID_ORDER_STATUSES` core 승격(동의) — 단 스코프는 "새 사본을 안 만드는 것"까지다**: 초안이 `dashboard.ts`에 새로 선언한 `REVENUE_STATUSES`를 `src/core/domain/order.ts`에 `PAID_ORDER_STATUSES`로 올리고 대시보드가 그걸 참조한다. 도메인 상수이므로 core 소관이고 모델 변경이 아니다.
+
+같은 두 값이 `payment.ts:61`(`isPaymentAppliedStatus`)와 `invitation.ts:63`에도 있지만 **이번 스코프에서 그 둘은 건드리지 않는다**(api-designer와 합의). 결제 경로 리팩터링은 회귀 위험 대비 이득이 작다 — 지금 필요한 건 "사본이 3개에서 4개로 늘지 않는 것"이고, 완전 통합은 결제 로직을 손대는 별도 작업에서 묶는 게 맞다.
+
+> 주문 수 모집단은 api-designer가 동일 결론에 독립 도달해 **CONFIRMED+COMPLETED / confirmedAt 기준으로 확정**했다. 관리자가 *유입 주문 총량*을 원한다는 요구가 나중에 나오면 별도 지표로 추가한다(기존 지표를 바꾸지 않는다).
+
+### Q2. Order — 최근 활동 (최근 주문 5건)
+
+```ts
+OrderModel.find()
+  .sort({ createdAt: -1 })
+  .limit(5)
+  .select("merchantUid buyerName product.title finalPrice orderStatus createdAt")
+  .lean();
+```
+
+- 정렬 기준은 **`createdAt`**(매출 집계와 달리 `confirmedAt`이 아니다). "최근 활동"은 관리자가 방금 들어온 주문을 보는 화면이라 결제 전 `PENDING`도 보여야 하고, PENDING은 `confirmedAt`이 없어 confirmedAt 정렬에서 통째로 사라진다.
+- `.lean()` 필수 — 수정 없이 그대로 반환하므로(`services/AGENTS.md`).
+- `merchantUid`는 `unique: true` 인덱스가 있으나 여기선 표시용일 뿐이다. `_id`는 select 안 해도 기본 포함되므로 UI key로 쓸 거면 `.toString()` 변환을 services에서 명시적으로 해야 한다(모델 `toJSON` transform은 `.lean()`에 안 걸린다 — `src/models/AGENTS.md`).
+- **인덱스 없음 → 현재 blocking in-memory SORT다.** §3-A 참고.
+
+> **boundary-verifier 주의 — 통계 카드와 최근 주문 리스트가 서로 다른 시각 기준을 쓰는 것은 의도다.**
+> 카드(Q1) = `confirmedAt` 기준 + `CONFIRMED|COMPLETED`만. 리스트(Q2) = `createdAt` 기준 + 전 상태 포함.
+> 불일치가 아니라 두 지표의 질문이 다르다("이번 달에 얼마가 입금됐나" vs "방금 뭐가 들어왔나"). 리스트에 PENDING 주문이 떠도, 그 주문이 매출 카드에 안 잡혀도 정상이다. ui-designer와 합의된 사항이며 상태 배지가 그 차이를 화면에서 설명한다.
+
+### Q3. Product — 총 상품 + 이번달 신규 (한 방)
+
+```ts
+ProductModel.aggregate<{ total: number; createdThisMonth: number }>([
+  { $match: { deletedAt: null } },
+  {
+    $group: {
+      _id: null,
+      total: { $sum: 1 },
+      createdThisMonth: {
+        $sum: { $cond: [{ $gte: ["$createdAt", startOfThisMonth] }, 1, 0] },
+      },
+    },
+  },
+]);
+```
+
+초안은 `countDocuments` 2번이었다. 어차피 둘 다 같은 문서 집합을 훑으므로 1회 스캔으로 합친다. `deletedAt: null`은 스키마 default가 `null`이라 필드 누락 문서가 없어 `$eq: null`로 안전하다.
+
+> **discriminator 주의(읽기는 무해)**: `ProductModel`은 `category`를 `discriminatorKey`로 쓰고 `invitation` discriminator가 등록돼 있다. mongoose는 base 모델 `find`/`aggregate`에 discriminator 필터를 걸지 않으므로 base 모델로 세면 전 카테고리가 다 잡힌다 — 대시보드가 원하는 동작이 맞다. (반대로 `InvitationProductModel`로 세면 `category: "invitation"`만 잡힌다.)
+
+### Q4. User — 총 회원 + 이번달 신규 (한 방)
+
+```ts
+UserModel.aggregate<{ total: number; createdThisMonth: number }>([
+  { $match: { isDelete: false } },
+  {
+    $group: {
+      _id: null,
+      total: { $sum: 1 },
+      createdThisMonth: {
+        $sum: { $cond: [{ $gte: ["$createdAt", startOfThisMonth] }, 1, 0] },
+      },
+    },
+  },
+]);
+```
+
+`isDelete`는 default `false`지만 **필드가 누락된 레거시 문서가 있으면 `{ isDelete: false }`가 그 문서를 못 잡는다.** 방어하려면 `{ isDelete: { $ne: true } }`가 안전하다. 스키마에 default가 있어 mongoose 경유 생성 문서는 전부 필드를 갖지만, 이 컬렉션에 mongoose 밖 삽입 이력이 있는지는 코드로 확인 불가 → 구현 시 backend-impl이 실 DB에서 `db.users.countDocuments({ isDelete: { $exists: false } })` 한 번 확인하고, 0이면 `false` 그대로, 아니면 `$ne: true`로 바꾼다. (Product의 `deletedAt`은 `$in`/`$ne: null` 형태로 이미 전 서비스가 쓰고 있어 동일 리스크가 이미 수용된 상태다.)
+
+### 실행 형태
+
+```ts
+await dbConnect();
+const [orderBuckets, productStats, userStats, recentOrders] = await Promise.all([...]);
+```
+
+- **트랜잭션 불필요.** `services/AGENTS.md` 트랜잭션 섹션 기준은 "서로 다른 문서/컬렉션에 걸친 **쓰기**가 부분 실패 시 불변조건을 깨는 경우"다. 여기는 순수 읽기 4건이라 해당 없음.
+- 따라서 `Promise.all` 병렬이 적합하다. (AGENTS.md의 "트랜잭션 안에서 `Promise.all` 금지" 제약은 세션이 있을 때만 적용되며 여기엔 세션이 없다.)
+- 쿼리 수: 초안 9개 → **4개**.
+
+---
+
+## 3. 인덱스 점검
+
+현재 정의된 인덱스 전량:
+
+| 컬렉션 | 인덱스 | 출처 |
+|---|---|---|
+| Order | `{ merchantUid: 1 }` unique | 필드 옵션 |
+| Order | `{ userId: 1 }` | 필드 옵션 |
+| Order | `{ userId: 1, orderStatus: 1, createdAt: -1 }` | `order.model.ts:155` (my-orders 페이징) |
+| Order | `{ orderStatus: 1, paymentId: 1, createdAt: 1 }` | `:161` (만료 PENDING 배치) |
+| Order | `{ orderStatus: 1, confirmedAt: 1 }` | `:162` (만료 CONFIRMED 배치) |
+| Product | **없음** (`_id`만) | — |
+| User | `{ email: 1 }` unique | 필드 옵션 |
+
+쿼리별 판정:
+
+| 쿼리 | 인덱스 | 판정 |
+|---|---|---|
+| Q1 매출/주문수 | `{ orderStatus: 1, confirmedAt: 1 }` | **커버됨.** `$in` 2값 × range → IXSCAN 2바운드 |
+| Q2 최근 주문 5건 | 없음 | **COLLSCAN + blocking SORT** — A 권고 |
+| Q3 상품 집계 | 없음 | COLLSCAN — B 권고 |
+| Q4 회원 집계 | 없음 | COLLSCAN — C 권고 |
+
+### A (필수) — `orderSchema.index({ createdAt: -1 })`
+
+Q2는 **필터가 아예 없는 전역 정렬**이다. 기존 Order 인덱스 3개는 전부 선두 필드가 `userId` 또는 `orderStatus`라 무필터 정렬을 못 받쳐준다 → **컬렉션 전체를 읽고 메모리에서 정렬한 뒤 5건을 취한다.** 데이터가 커지면 32MB blocking-sort 한계에 걸려 대시보드가 통째로 에러를 던지는 형태로 실패한다(느려지는 게 아니라 죽는다). 인덱스가 있으면 IXSCAN 5건에서 멈춘다.
+
+**Q2 설계(PENDING 포함 / `createdAt` desc)의 전제조건이므로 권고가 아니라 필수로 확정한다** — api-designer와 합의된 사항.
+
+부수 효과로 `/admin/orders`(현재 `mockOrders.ts` 사용 중, 곧 실데이터 전환 대상)의 **관리자 전역 주문 목록**도 이 인덱스가 그대로 커버한다 — 기존 `{userId:1, ...}` 인덱스는 userId 스코프가 없는 관리자 목록엔 못 쓴다.
+
+### B (권고) — `productSchema.index({ deletedAt: 1, createdAt: -1 })`
+
+Q3뿐 아니라 `getAllProducts`의 목록 뷰(`{deletedAt: null}`)와 휴지통 뷰(`{deletedAt: {$ne: null}}`)가 동일 패턴이다(`services/product.ts:175`). Product 컬렉션에 인덱스가 하나도 없는 현 상태를 감안하면 이 기능과 무관하게도 필요하다.
+
+### C (권고, 우선순위 낮음) — `userSchema.index({ isDelete: 1, createdAt: -1 })`
+
+Q4 전용. 회원 수는 상품/주문보다 증가가 빠르지만 카디널리티가 낮은 boolean 선두라 이득이 제한적이다. A/B와 달리 **이 기능 스코프 밖으로 미뤄도 된다.**
+
+### 인덱스 추가 시 운영 영향
+
+`src/db/connect.ts`가 `autoIndex`를 끄지 않아 mongoose 기본값(`autoIndex: true`)이 유효 → 스키마에 `.index()`를 추가하면 **다음 연결 시 자동 생성된다. 별도 마이그레이션 스크립트 불필요.** 현재 데이터 규모에서 빌드 비용은 무시 가능하다.
+
+---
+
+## 4. 마이그레이션 / backfill
+
+**스키마 마이그레이션은 없다** — 필드를 추가하지 않고 기존 필드만 읽는다. 단 아래 1번은 **데이터 backfill이 조건부 필수**다.
+
+### 4-1. `Order.confirmedAt` 결측 — 리스크 실재함, 배포 전 확인 필수 ⚠️
+
+git 이력을 추적한 결과 **`confirmedAt` 없이 `CONFIRMED`가 된 주문이 존재할 수 있는 구간이 실제로 있었다.**
+
+| 시점 | 상태 |
+|---|---|
+| ~ 2026-07-29 이전 | 결제 확정 코드가 `order.orderStatus = "CONFIRMED"; order.paymentId = ...; order.save()`만 실행 — **`confirmedAt` 대입 없음** (해당 시점 `payment.service.ts:174-176`에서 확인) |
+| 2026-07-29 (PR #77, `e2eb63e`) | `Order.confirmedAt` 필드 신설 |
+| 이후 (`payment.ts:364`) | CONFIRMED 전이 시 `confirmedAt` 항상 세팅 |
+
+즉 **PR #77 배포 이전에 결제 확정된 운영 주문은 `confirmedAt`이 없다.** confirmedAt 기준 집계에서 이 문서들은 에러 없이 조용히 빠져 매출 숫자만 작아진다 — 가장 나쁜 실패 모드다. (다만 2026-07-29는 최근이고 실 결제 데이터가 그 이전에 얼마나 쌓였는지는 코드로 알 수 없다. 0건일 가능성도 충분하다.)
+
+**폴백 쿼리(`$ifNull: ["$confirmedAt", "$createdAt"]`)는 채택하지 않는다** — `$match`에 표현식을 쓰면 §3의 `{orderStatus:1, confirmedAt:1}` 인덱스 커버가 깨져 COLLSCAN이 된다. 영구 성능 비용으로 일회성 데이터 문제를 덮는 건 교환비가 나쁘다.
+
+**절차 (backend-impl이 구현 전 1회 수행)**
+
+```js
+// 1) 결측 건수 확인
+db.orders.countDocuments({
+  orderStatus: { $in: ["CONFIRMED", "COMPLETED"] },
+  confirmedAt: null,   // null과 필드 누락을 모두 잡는다
+});
+```
+
+- **0건이면** → backfill 불필요. 이 문서에 "확인 완료(0건)"로 기록하고 진행.
+- **1건 이상이면** → 아래 backfill을 1회 실행한 뒤 진행.
+
+```js
+// 2) backfill — 소스 우선순위: Payment.paidAt > Order.createdAt
+//    Payment 컬렉션에 실제 결제 완료 시각(paidAt)이 있으므로 이게 정답에 가장 가깝다.
+//    (payment.model.ts:236 paidAt, :192 merchantUid unique — merchantUid로 1:1 조인)
+db.orders.aggregate([
+  { $match: { orderStatus: { $in: ["CONFIRMED", "COMPLETED"] }, confirmedAt: null } },
+  { $lookup: { from: "payments", localField: "merchantUid", foreignField: "merchantUid", as: "p" } },
+  { $project: { fallback: { $ifNull: [{ $first: "$p.paidAt" }, "$createdAt"] } } },
+]).forEach((d) => db.orders.updateOne({ _id: d._id }, { $set: { confirmedAt: d.fallback } }));
+```
+
+- `updatedAt`을 소스로 쓰면 **안 된다** — 청첩장 발행(`invitation.ts:230`의 CONFIRMED→COMPLETED)이나 이후 어떤 쓰기로든 갱신돼 결제 시각과 무관해진다.
+- `createdAt` 폴백은 가상계좌 주문에서 실제 입금 시각보다 이르게 잡히지만, 대상이 레거시 소수 건이고 매출에서 통째로 누락되는 것보다는 낫다.
+- 멱등하다 — 조건이 `confirmedAt: null`이라 재실행해도 이미 채워진 문서를 건드리지 않는다.
+
+### 4-2. `User.isDelete` 결측 — 확인만, 리스크 낮음
+
+§Q4 참고. `isDelete`는 스키마 default가 `false`라 mongoose 경유 생성 문서엔 항상 있지만, mongoose 밖 삽입 이력 여부는 코드로 확인 불가하다.
+
+```js
+db.users.countDocuments({ isDelete: { $exists: false } });
+// 0이면 { isDelete: false } 그대로 사용
+// 0이 아니면 $set: { isDelete: false } 로 backfill (또는 쿼리를 { isDelete: { $ne: true } }로 변경)
+```
+
+Product의 `deletedAt`은 동일 리스크가 이미 전 서비스 코드에서 수용된 상태라(12개 지점이 `deletedAt` 조건으로 조회 중) 별도 확인이 불필요하다.
+
+---
+
+## 5. API 필드명 ↔ DB 필드 매핑표
+
+api-designer의 응답 shape과 정렬한 결과. **DB 원본 필드명을 그대로 노출하지 않고 평탄화하는 지점은 `productTitle` 하나뿐이다.**
+
+| 응답 필드 (`DashboardStats`) | DB 소스 | 산출 |
+|---|---|---|
+| `totalProducts` | `products` | Q3 `total` |
+| `productsCreatedThisMonth` | `products.createdAt` | Q3 `createdThisMonth` |
+| `totalUsers` | `users` | Q4 `total` |
+| `usersCreatedThisMonth` | `users.createdAt` | Q4 `createdThisMonth` |
+| `revenueThisMonth` | `orders.finalPrice` | Q1 `current.revenue ?? 0` |
+| `revenuePreviousMonth` | `orders.finalPrice` | Q1 `previous.revenue ?? 0` |
+| `paidOrderCountThisMonth` | `orders` | Q1 `current.orderCount ?? 0` |
+| `paidOrderCountPreviousMonth` | `orders` | Q1 `previous.orderCount ?? 0` |
+| `recentOrders[].merchantUid` | `orders.merchantUid` | 그대로 |
+| `recentOrders[].buyerName` | `orders.buyerName` | 그대로 |
+| `recentOrders[].productTitle` | `orders.product.title` (스냅샷) | **평탄화** |
+| `recentOrders[].finalPrice` | `orders.finalPrice` | 그대로 |
+| `recentOrders[].orderStatus` | `orders.orderStatus` | 그대로 (`OrderStatus` 타입 재사용) |
+| `recentOrders[].createdAt` | `orders.createdAt` | 그대로 (`Date` — §6 미해결) |
+
+**필드명 변경 (초안 대비, api-designer 요청 수용)**
+
+| 초안 | 확정 | 사유 |
+|---|---|---|
+| `monthlyOrderCount` | `paidOrderCountThisMonth` | 모집단이 "전체 주문"→"결제 완료 주문"으로 바뀌었는데 이름이 그 변화를 안 담아 오독을 부른다 |
+| `previousMonthOrderCount` | `paidOrderCountPreviousMonth` | 위와 동일 |
+| `monthlyRevenue` | `revenueThisMonth` | 나머지 6개 필드가 전부 `...ThisMonth` 접미사를 쓴다 — 8개 필드의 시점 표기를 한 규칙으로 통일 |
+| `previousMonthRevenue` | `revenuePreviousMonth` | 위와 동일 |
+
+- 전 필드 camelCase, snake_case 없음.
+- `productTitle`은 Product 컬렉션 join이 아니라 **주문 시점 스냅샷**(`order.product.title`)이다. 상품명이 나중에 바뀌거나 상품이 소프트 삭제돼도 최근 활동 목록은 주문 당시 이름을 그대로 보여준다 — 의도된 동작이며 `$lookup` 불필요.
+- `orderStatus` 표시는 `core/domain/order.ts`의 `ORDER_STATUS_LABELS` / `ORDER_STATUS_BADGE_VARIANTS`를 재사용한다(초안이 admin/orders mock 상수에서 도메인으로 승격시킨 것 — 그 승격은 타당하므로 유지 권고).
+
+---
+
+## 6. 동료 조율 결과 (1라운드, 전부 합의 — 미해결 쟁점 없음)
+
+| 쟁점 | 제기 | 결론 |
+|---|---|---|
+| 매출 기준 시각 `createdAt` → `confirmedAt` | db-migrator | **합의.** api-designer가 독립적으로 동일 결론 도달 |
+| 주문수 모집단을 매출과 통일 | db-migrator | **합의.** 필드명도 `paidOrderCount*`로 변경 |
+| 최근 활동 = 최근 주문 5건, `createdAt` desc, PENDING 포함 | db-migrator | **합의.** 다른 컬렉션 혼합 안 함 |
+| `recentOrders[].createdAt` 직렬화 타입 | db-migrator 질의 | **`Date` 확정.** Server Component 직결(`docs/architecture/data-access.md` row 1) — route handler 경유 없음, JSON 직렬화 경계 없음 |
+| KST 월 경계 | api-designer | **수용.** §2-0에 반영 |
+| `{ createdAt: -1 }` 인덱스 | api-designer | **수용.** 권고 → **필수**로 승격(§3-A) |
+| 레거시 `confirmedAt` 결측 | api-designer | **리스크 실재 확인.** git 이력상 PR #77(2026-07-29) 이전 결제 확정 주문엔 `confirmedAt`이 없다 → §4-1 조건부 backfill 절차 확정. 폴백 쿼리는 인덱스를 깨므로 불채택 |
+| `PAID_ORDER_STATUSES` core 승격 | api-designer | **동의.** 도메인 상수라 모델 변경 아님. 스코프는 "대시보드가 새 사본을 안 만드는 것"까지 — 기존 `isPaymentAppliedStatus`/`invitation.ts:63` 리팩터링은 결제 경로 회귀 위험 대비 이득이 작아 제외 |
+| soft delete 판별 조건 / `timestamps` 유무 | ui-designer 질의 | **회신 완료.** Product=`deletedAt: null`, User=`isDelete: false`, 세 모델 모두 `timestamps: true`. UI 문구는 "등록 상품" / "활동 회원"으로 정정 권고 |
+
+## 7. 리더 확인 필요 (설계 밖 판단)
+
+1. **배포 전 §4-1 backfill 확인** — 운영 DB에 접근해 `confirmedAt` 결측 건수를 한 번 세야 한다. 이 세션에서는 운영 DB 접근을 하지 않았다. 0건이면 아무것도 안 해도 되지만, 확인 없이 배포하면 매출 카드가 조용히 작은 값을 보여준다.
+2. **캐싱 정책** — `force-dynamic`이라 매 요청마다 4쿼리가 실행된다. 대시보드 지표는 초 단위 신선도가 불필요하므로 `unstable_cache` + `revalidate: 60` 같은 완화가 가능하지만, REQ-1의 "등록·주문 발생 시 값이 갱신된다"와의 허용 지연을 정해야 한다. **본 설계는 캐싱 없음을 기본으로 둔다**(요구사항을 문자 그대로 만족). 쿼리 4개 전부 인덱스 커버(A/B/C 반영 시)라 현 규모에선 캐싱 없이도 충분하다.
+3. **인덱스 B/C 채택 여부** — A는 필수라 이 기능에 포함한다. B(Product)는 이 기능과 무관하게도 Product에 인덱스가 하나도 없는 상태를 개선하지만, 스코프 확대로 볼 수 있어 별도 Issue로 뺄지 판단이 필요하다. C(User)는 이번엔 빼도 무방하다.
+4. **soft delete 컨벤션 통일** — Product `deletedAt` vs User `isDelete` 불일치는 이 기능 스코프 밖이다(전 문서 backfill + 기존 쿼리 전수 수정 필요). 별도 Issue 등록 권고.
+5. **`/admin/orders` 실데이터 전환(별도 Issue 후보)** — 여전히 `MOCK_ORDERS` 기반이라 ui-designer가 최근 주문 카드에 단 "전체 보기" 링크가 mock 화면으로 간다. 이번 스코프 밖이지만 **DB 관점에서 선행 조건이 이미 충족된다** — §3-A의 `{ createdAt: -1 }` 인덱스가 관리자 전역 주문 목록(userId 스코프 없음 + createdAt 커서 페이징)을 그대로 커버한다. 그쪽 작업 시 인덱스 추가가 다시 필요하지 않다.

--- a/_workspace/feat/admin-dashboard-real-data/01_ui_flow.md
+++ b/_workspace/feat/admin-dashboard-real-data/01_ui_flow.md
@@ -1,0 +1,322 @@
+# 01 — UI 설계: admin 대시보드 실데이터 연결
+
+> 대상 라우트: `src/app/(admin)/admin/dashboard/page.tsx`
+> 도달 URL: **`/admin/dashboard`** — `(admin)` 라우트 그룹은 URL에서 제거된다. 파일 경로는 `(admin)/admin/dashboard/`지만 실제 URL 세그먼트는 `/admin/dashboard` 하나뿐이다(그룹 `(admin)` 소멸, 폴더 `admin` 유지).
+> 상태: **확정.** api-designer·db-migrator와 3자 합의 완료(1라운드), 미해결 쟁점 없음 — §7 참고.
+
+---
+
+## 1. 전제: 이 화면에는 클라이언트 상태 머신이 없다
+
+`page.tsx`가 `export const dynamic = "force-dynamic"` async Server Component다. 그래서:
+
+- 로딩 스피너·`useSWR`·`useState` 기반 상태 전이가 **존재하지 않는다.** 데이터는 SSR 렌더 시점에 단 한 번 확정된다.
+- fetch 실패는 클라이언트 에러 상태가 아니라 **throw → `src/app/(admin)/error.tsx`**(`ErrorFallback`, `backPath={routes.admin.dashboard}`)가 페이지 전체를 대체한다.
+- 따라서 아래 §5의 "상태 전이표"는 클라이언트 전이가 아니라 **렌더 시점 분기표**다. boundary-verifier는 이 표를 "서버 데이터 값 → 렌더 결과" 대조 기준으로 쓴다.
+
+이 전제가 깨지는 유일한 경우는 "새로고침 버튼"·"기간 필터" 같은 인터랙션이 추가될 때다. 이번 요구사항(REQ-1/REQ-2)에 그런 항목이 없으므로 **클라이언트 컴포넌트를 하나도 만들지 않는다.**
+
+---
+
+## 2. 화면 플로우
+
+```
+[관리자 로그인 상태]
+      │
+      │ 사이드바 "대시보드" 클릭 또는 /admin/dashboard 직접 진입
+      ▼
+proxy.ts (낙관적 체크) ─── 미인증/비ADMIN ──▶ 로그인/홈으로 리다이렉트
+      │
+      ▼
+page.tsx: await verifySession("ADMIN")   ← 실질 보안 경계
+      │
+      ├── 실패 ────────────────────────▶ redirect (기존 동작 유지)
+      ▼
+page.tsx: await getDashboardStatsService()
+      │
+      ├── throw ───────────────────────▶ (admin)/error.tsx 전체 대체 [상태 E]
+      ▼
+<AdminDashboardTemplate stats={...} /> 렌더
+      │
+      ├─ 통계 카드 4개            → 값은 항상 렌더(0도 유효값) [상태 A]
+      │                             trend만 조건부 [상태 B / C]
+      └─ 최근 주문 카드           → 1건 이상 [상태 A] / 0건 [상태 D]
+      │
+      ▼
+[종료] 관리자가 값을 읽고 "전체 보기" → /admin/orders 로 이탈하거나 사이드바로 이동
+```
+
+진입점은 사이드바(`SidebarNavItem type="ADMIN"`)와 `(admin)/error.tsx`의 "관리자 대시보드로" 버튼 두 곳. 이 화면에는 폼이 없다 → **폼 유효성 규칙 없음**(`src/core/schemas/request/` 재사용 대상 없음).
+
+---
+
+## 3. 컴포넌트 트리 (확정)
+
+```
+src/app/(admin)/admin/dashboard/
+├── page.tsx                          [수정] Server Component
+│    └─ verifySession("ADMIN") → getDashboardStatsService() → Template에 props 전달만
+└── _components/                      [신규 폴더]
+     ├── index.tsx                    [신규] 배럴 — AdminDashboardTemplate만 재export
+     ├── AdminDashboardTemplate.tsx   [신규] 순수. props: { stats: DashboardStats }
+     │    ├── TypographyMuted                          (atom, 기존)  인사 문구
+     │    ├── <section className="grid ...">           배치 코드 — 기존 클래스 그대로
+     │    │    └── statCards.map()  ×4
+     │    │         └── Card / CardHeader / CardTitle / CardContent   (atoms, 기존)
+     │    │              ├── lucide icon: Package · DollarSign · ShoppingCart · Users
+     │    │              ├── value    <div className="text-2xl font-bold">
+     │    │              ├── TypographyMuted (description)
+     │    │              └── TypographySmall (trend) ← 조건부 렌더, §5 상태 C
+     │    └── <RecentOrdersCard orders={stats.recentOrders} />
+     └── RecentOrdersCard.tsx         [신규] 순수. props: { orders: DashboardRecentOrder[] }
+          └── Card / CardHeader / CardTitle / CardContent            (atoms, 기존)
+               ├── CardHeader: 제목 + <Link href={routes.admin.orders}>전체 보기</Link>
+               ├── <div className="overflow-x-auto"> <table> …        (마크업 인라인)
+               │    └── 행마다 Badge(atom, 기존) + ORDER_STATUS_* lookup
+               └── 빈 상태 블록 ← §5 상태 D
+```
+
+### 3.1 왜 Template을 새로 만드는가 (필수)
+
+`src/app/AGENTS.md`: "organism을 배치(grid/flex/spacing 등)하는 코드가 하나라도 있으면 Template 추출이 필수다." 현재 `page.tsx`에 `space-y-8`, `grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`가 있으므로 예외("organism 1개를 배치 코드 없이 렌더")에 해당하지 않는다 → 추출이 강제된다.
+
+**위치는 `src/ui/components/templates/`가 아니라 라우트 로컬 `_components/`다.** `templates/AGENTS.md`: 공용 승격은 "2곳 이상의 라우트가 의도적으로 동일한 전체 배치를 공유할 때만". 소비 라우트가 `/admin/dashboard` 하나뿐이므로 로컬에 머문다. `(admin)/admin/orders/_components/AdminOrdersTemplate.tsx`와 동일 선례.
+
+### 3.2 왜 `RecentOrdersCard`만 쪼개고 `StatCard`는 안 쪼개는가 (과잉 생성 방지)
+
+| 후보 | 판정 | 근거 |
+|---|---|---|
+| `RecentOrdersCard` | **분리** | 테이블 마크업 + 배지 lookup + 빈 상태 분기까지 묶인 독립 구획(section)이다. Template 안에 인라인하면 Template이 배치 책임을 넘어 콘텐츠 렌더 책임까지 떠안는다. |
+| `DashboardStatCard` | **분리 안 함** | 현재도 `stats.map()` 안에 인라인된 15줄짜리 JSX다. 쪼개봐야 얻는 게 "15줄 이동"뿐이고, 소비처는 이 Template 하나다. 인라인 유지 = 기존 코드와 최소 diff. |
+| `_utils/` VM 빌더 | **만들지 않음** | 4개 카드 배열은 Template 안에서 인라인 선언한다. 재사용 가능한 포맷 함수만 `src/core/utils/`로 뺀다(§3.3). Template `.test.tsx` 렌더 테스트로 충분히 커버된다(`AdminProductsTemplate.test.tsx` 선례). |
+| `_types/` | **만들지 않음** | 화면 전용 VM 타입이 없다. Template은 `@/core/domain`의 `DashboardStats`를 그대로 받는다. |
+
+> 결론: **신규 파일 3개**(`index.tsx`, `AdminDashboardTemplate.tsx`, `RecentOrdersCard.tsx`) + `src/core/utils/` 함수 2개. 그 외 신규 컴포넌트 없음.
+
+### 3.3 `src/core/utils/`에 추가가 필요한 순수 함수 2개
+
+두 함수 모두 **도메인/라우트 이름을 담지 않는다**(`src/AGENTS.md`: `{목적}` 기반 파일에 도메인명 금지).
+
+| 함수 | 위치 | 시그니처 | 왜 필요한가 |
+|---|---|---|---|
+| `formatSignedPercent` | `src/core/utils/percent.ts` (신규 파일) | `(current: number, previous: number) => { label: string; direction: "up" \| "down" \| "flat" } \| null` | 전월 대비 증감률. `previous === 0`이면 `null` 반환(0 나눗셈 → "+∞%" 방지). 부호/방향을 **문자열이 아니라 구조체로** 반환해야 UI가 색상을 판정할 수 있다. |
+| `formatRelativeTime` | `src/core/utils/date.ts` (기존 파일에 추가) | `(date: Date, now?: Date) => string` | 최근 주문의 "3시간 전". 기존 `getTimeDiff`는 `Math.max(diff, 0)`로 **미래 시각만** 다뤄서(결혼식 카운트다운 전용) 과거 시각에 재사용 불가 — 그래서 신규가 불가피하다. |
+
+`formatRelativeTime` 구간: `<1분` → "방금 전", `<60분` → "N분 전", `<24시간` → "N시간 전", `<7일` → "N일 전", 그 이상 → 기존 `formatDate(date, "dot")`("2026.8.20").
+
+> **SSR 안전성**: 상대시간을 서버에서 계산해도 hydration mismatch가 없다. 이 트리에 클라이언트 컴포넌트가 하나도 없어서(§1) 브라우저가 이 값을 다시 렌더하지 않는다. 오히려 절대시각보다 안전하다 — 절대시각은 서버 타임존으로 굳어 사용자 타임존과 어긋나지만, 상대시간은 두 시각의 **차이**만 쓰므로 타임존 무관이다.
+
+> ⚠️ **`<7일` 분기만 타임존 무관이고, 그 이상 폴백 분기는 아니다.** 폴백이 호출하는 기존 `formatDate(date, "dot")`는 `getFullYear()`/`getMonth()`/`getDate()`를 쓰므로 **서버 로컬 타임존**(Vercel = UTC)으로 렌더된다. KST 밤 9시 주문이 UTC로는 전날 낮이라 하루 밀린 날짜가 찍힌다. Q11에 따라 `date-fns-tz`가 이미 의존성으로 들어오므로, **`formatRelativeTime`의 폴백 분기는 `Asia/Seoul`로 명시 포맷한다** — 카드 숫자(KST 월 경계)와 리스트 날짜가 서로 다른 타임존을 쓰는 상황을 애초에 안 만든다. 기존 `formatDate` 자체는 건드리지 않는다(소비처 전역 영향, 스코프 밖).
+
+### 3.4 재사용하는 기존 자산 (신규 제작 금지 목록)
+
+| 자산 | 경로 | 용도 |
+|---|---|---|
+| `Card` `CardHeader` `CardTitle` `CardContent` | `@/ui/components/atoms` | 카드 5개 전부 |
+| `Badge` | `@/ui/components/atoms` | 최근 주문 상태 배지 |
+| `TypographyMuted` `TypographySmall` | `@/ui/components/atoms` | description / trend / 빈 상태 문구 |
+| `ORDER_STATUS_LABELS` `ORDER_STATUS_BADGE_VARIANTS` | `@/core/domain` (`order.ts`) | 상태 라벨·배지 variant — **재정의 금지** |
+| `formatPriceWithComma` | `@/core/utils` (`price.ts`) | 매출/금액 통화 포맷 |
+| `routes.admin.orders` | `@/core/domain` (`routes.ts`) | "전체 보기" 링크 — 경로 문자열 하드코딩 금지 |
+| 테이블 마크업 패턴 | `(admin)/admin/orders/_components/AdminOrdersTemplate.tsx` L62–99 | 컬럼 구성·`overflow-x-auto`·빈 상태 블록을 시각적으로 그대로 맞춘다(컴포넌트 import가 아니라 **패턴 참조**) |
+
+---
+
+## 4. 필드 매핑 — 화면 슬롯 ↔ 데이터 출처
+
+Template이 받는 prop은 `stats: DashboardStats`(`@/core/domain/dashboard.ts`) 하나다.
+
+### 4.1 통계 카드 4개
+
+| # | title | icon | value | description | trend |
+|---|---|---|---|---|---|
+| 1 | 등록 상품 | `Package` | `stats.totalProducts.toLocaleString()` | 삭제 제외 전체 상품 | `stats.productsCreatedThisMonth` → `+N개 이번 달` (direction: `up` if >0) |
+| 2 | 총 매출 | `DollarSign` | `₩${formatPriceWithComma(stats.revenueThisMonth)}` | 이번 달 결제 완료 기준 | `formatSignedPercent(revenueThisMonth, revenuePreviousMonth)` → `+12.5% 지난 달 대비` |
+| 3 | 결제 주문 | `ShoppingCart` | `stats.paidOrderCountThisMonth.toLocaleString()` | 이번 달 결제 완료 주문 | `formatSignedPercent(paidOrderCountThisMonth, paidOrderCountPreviousMonth)` → `-8.0% 지난 달 대비` |
+| 4 | 활동 회원 | `Users` | `stats.totalUsers.toLocaleString()` | 탈퇴 제외 가입 회원 | `stats.usersCreatedThisMonth` → `+N명 이번 달` (direction: `up` if >0) |
+
+#### 4.1.1 title/description 문구를 바꾼 근거 (db-migrator 스키마 확인 결과 반영)
+
+기존 mock 문구는 집계 조건과 어긋나 있었다. 화면 문구는 실제 쿼리 조건과 1:1로 맞춘다 — 안 맞으면 관리자가 숫자를 오독한다.
+
+| 카드 | 기존 → 변경 | 근거 |
+|---|---|---|
+| 1 | `총 상품` / `등록된 템플릿 수` → `등록 상품` / `삭제 제외 전체 상품` | 집계 조건이 `{ deletedAt: null }` 하나라 **비공개(`inactive`)·품절(`soldOut`)도 포함**된다. "총"은 전수로, "템플릿"은 청첩장 한정으로 읽혀 둘 다 실제보다 좁거나 넓다. `status`로 추가 필터링하지 않기로 한 건 admin 상품 목록 화면 숫자와 어긋나지 않게 하기 위해서다. |
+| 2 | `이번 달 매출` → `이번 달 결제 완료 기준` | 집계 기준이 `Order.createdAt`이 아니라 **`confirmedAt`(결제 확정 시각)**이다. 가상계좌 주문은 생성월과 입금월이 갈릴 수 있어, 주문만 넣고 미입금인 건은 이 숫자에 안 잡힌다. 그 사실을 description이 드러내야 한다. |
+| 3 | `주문` / `이번 달 주문 수` → `결제 주문` / `이번 달 결제 완료 주문` | 모집단을 매출 카드와 동일하게 `CONFIRMED`/`COMPLETED` + `confirmedAt` 기준으로 통일한다(db-migrator·api-designer 독립 합의, **수용**). 전체 주문을 세면 자동취소 예정인 방치 `PENDING`이 카운트를 부풀리고, 무엇보다 **옆 카드와 모집단이 달라 "매출 ÷ 주문수 = 객단가"가 성립하지 않는다** — 나란히 놓인 두 카드가 암묵적으로 약속하는 관계가 깨진다. |
+| 4 | `총 회원` / `총 회원 수` → `활동 회원` / `탈퇴 제외 가입 회원` | 집계 조건이 `{ isDelete: false }`라 탈퇴 회원이 빠진다. "총 회원"은 탈퇴 포함으로 읽힌다. |
+
+#### 4.1.2 trend 종류가 카드마다 다른 근거 — 저량/유량 구분 (api-designer 합의)
+
+비대칭은 일관성 결여가 아니라 **지표 종류가 실제로 두 가지**라서다. frontend-impl은 이 구분을 지우고 통일하려 들지 말 것.
+
+| 종류 | 카드 | value의 의미 | trend 형태 | 왜 |
+|---|---|---|---|---|
+| **저량(stock)** | 1 등록 상품, 4 활동 회원 | 시점 누적 총계 | 이번 달 증가 **절대 건수** (`+N개` / `+N명`) | 누적 총계에 전월 대비 %를 씌우면 분모가 커서 항상 작은 양수가 나온다 — 변화를 못 보여준다 |
+| **유량(flow)** | 2 총 매출, 3 결제 주문 | 이미 한 달치 양 | **전월 대비 %** | 같은 길이 구간끼리의 비교라 %가 의미를 가진다 |
+
+> mock의 주문 trend `"+8 지난 주 대비"`는 혼자만 **주 단위**였다. 계승하지 않는다 — 4개 카드 전부 월 단위로 통일한다.
+
+**trend 종류가 카드마다 다른 것은 의도다.** 1·4번은 "누적 총계 + 이번 달 절대 증가분"이라 전월 대비 %가 의미를 만들지 않는다(총 회원은 정의상 단조 증가 → 항상 +%). 2·3번은 "이번 달 값"이라 전월과 비교해야 의미가 생긴다. 그래서 응답 shape의 필드 구성이 카드마다 비대칭인 게 맞다.
+
+**trend 색상**(현재 코드는 무조건 `text-primary` — 감소를 긍정색으로 칠하는 버그가 있다):
+
+| direction | 클래스 |
+|---|---|
+| `up` | `text-primary` |
+| `down` | `text-destructive` |
+| `flat` | `text-muted-foreground` |
+
+### 4.2 최근 주문 테이블 (`RecentOrdersCard`)
+
+컬럼 순서는 `/admin/orders`와 앞 5개를 일치시키고 시간만 끝에 덧붙인다 — 두 화면을 오갈 때 눈이 다시 적응할 필요가 없게.
+
+| 컬럼 | 정렬 | 소스 필드 | 렌더 |
+|---|---|---|---|
+| 주문번호 | left | `order.merchantUid` | 그대로 (행 `key`도 이 값) |
+| 고객명 | left | `order.buyerName` | 그대로 |
+| 상품 | left | `order.productTitle` | `truncate max-w-[16rem]` — 상품명이 길면 테이블이 밀린다 |
+| 상태 | left | `order.orderStatus` | `<Badge variant={ORDER_STATUS_BADGE_VARIANTS[s]}>{ORDER_STATUS_LABELS[s]}</Badge>` |
+| 금액 | right | `order.finalPrice` | `${formatPriceWithComma(v)}원` |
+| 시간 | right | `order.createdAt` | `formatRelativeTime(v)`, `text-muted-foreground` |
+
+**카드 제목은 "최근 활동"이 아니라 "최근 주문"으로 바꾼다.** 내용이 주문만 담는데 제목이 "활동"이면, 다음 사람이 그 불일치를 "신규 가입·신규 상품도 넣어야 한다"는 신호로 읽는다. REQ-2가 "실제 최근 활동(주문 등, **설계 단계에서 확정**)"으로 위임했으므로 이 범위 안이다.
+
+**통합 액티비티 피드(주문+가입+상품 혼합)를 채택하지 않은 이유**: 이종 이벤트를 한 타임라인에 합치려면 (a) 세 컬렉션을 시간순 병합하는 집계, (b) 이벤트 종류별 서로 다른 행 렌더러, (c) 종류 필터 UI가 따라온다. 현재 관리자가 대시보드에서 실제로 확인하려는 건 "돈이 들어왔는가"이고 나머지 둘은 이미 카드 trend(신규 상품 N개 / 신규 회원 N명)로 요약돼 있다. 지금 근거로는 비용 대비 이득이 없다 — 필요해지면 그때 별도 Issue로 확장한다.
+
+---
+
+## 5. 렌더 분기표 (= 이 화면의 "상태 전이표")
+
+클라이언트 전이가 아니라 **서버 데이터 값 → 렌더 결과** 매핑이다. boundary-verifier는 이 표를 대조 기준으로 쓴다.
+
+| 상태 | 트리거 조건 | 렌더 결과 | 다음 상태 |
+|---|---|---|---|
+| **A. 정상** | `getDashboardStatsService()` 성공 + `recentOrders.length > 0` | 카드 4개 값 + trend, 테이블 5행 | (종료) 재진입/새로고침 시 A~E 재평가 |
+| **B. 값 0** | 어떤 스칼라든 `0` (예: `revenueThisMonth === 0`) | `"₩0"` / `"0"`을 **그대로 렌더**한다. `-`·`—`·빈칸·"데이터 없음"으로 대체하지 않는다 — 0은 유효한 집계 결과다 | A와 동일 |
+| **C. trend 계산 불가** | ① `revenuePreviousMonth === 0` 또는 `paidOrderCountPreviousMonth === 0` → `formatSignedPercent`가 `null` 반환 <br> ② `productsCreatedThisMonth === 0` 또는 `usersCreatedThisMonth === 0` | **`TypographySmall` 줄을 통째로 렌더하지 않는다.** 빈 문자열로 자리만 남기지 않는다. 카드 높이 차이는 CSS grid 기본 `align-items: stretch`가 흡수한다(별도 `h-full` 불필요; 시각적으로 무너지면 `Card`에 `h-full` 추가) | A와 동일 |
+| **D. 최근 주문 없음** | `recentOrders.length === 0` | `<table>` 대신 카드 본문에 중앙 정렬 빈 상태: <br>제목 `아직 주문이 없습니다` (`text-sm font-medium`) <br>보조 `첫 주문이 들어오면 여기에 표시됩니다.` (`TypographyMuted`) <br>`flex flex-col items-center gap-1 py-12 text-center` — `AdminOrdersTemplate` L94–99 패턴, Card 안이라 `py-16`→`py-12` | A와 동일. **통계 카드 4개는 정상 렌더된다** — D는 카드 섹션에 영향 없음 |
+| **E. 조회 실패** | 서비스가 throw (DB 커넥션·집계 오류 등) | `page.tsx`에서 예외 전파 → `(admin)/error.tsx`의 `ErrorFallback`이 **페이지 전체 대체**. 부분 렌더 없음 | 사용자가 `unstable_retry()` → A~E 재평가 |
+| **F. 비인가** | `verifySession("ADMIN")` 실패 | 기존 동작 그대로(리다이렉트). 이번 기능이 건드리지 않는다 | — |
+
+### 5.1 상태 B·C는 예외 처리가 아니라 **상시 경로**다 (db-migrator 확인)
+
+frontend-impl이 "0 나눗셈 방어" 정도로 읽고 대충 넘기면 안 된다. 실제로 자주 밟는다:
+
+- Q1 aggregation은 해당 월에 결제 완료 주문이 **없으면 버킷 행 자체를 안 내놓고**, 서비스가 `?? 0`으로 채운다. 즉 `revenuePreviousMonth === 0`은 오류가 아니라 **정상 산출값**이다.
+- 서비스 오픈 첫 달에는 상태 B·C·D가 **동시에** 성립한다(매출 0, 전월 0, 주문 0건). 지금 이 프로젝트 상태가 정확히 그렇다 — 즉 **이 기능을 머지한 직후 관리자가 처음 보게 될 화면이 상태 C+D 조합이다.** 상태 A가 아니라.
+- 그래서 Template 테스트는 A만 통과시키면 안 되고 **B·C·D를 각각 케이스로 넣어야 한다**(§8 체크리스트).
+
+이게 §3.3에서 `formatSignedPercent`의 반환 타입을 `string`이 아니라 `{ label, direction } | null`로 잡은 실질적 이유다 — `null`이 드문 예외가 아니라 초기 몇 달간 기본값에 가깝다.
+
+### 5.2 상태 E를 all-or-nothing으로 두는 이유
+
+"통계는 나왔는데 최근 주문만 실패" 같은 부분 실패를 **허용하지 않는다.** 대시보드는 관리자가 숫자를 보고 판단하는 화면이라, 일부 섹션만 비어 있으면 "0이라서 빈 건지, 못 불러온 건지"를 화면만 보고 구분할 수 없다 — 그 모호함이 상태 B(값 0)와 정면으로 충돌한다. 전부 나오거나 전부 에러 화면이 낫다. 초안 서비스의 `Promise.all`(하나 reject → 전체 reject)이 이 정책과 이미 일치한다.
+
+---
+
+## 6. `page.tsx` 최종 형태 (계약)
+
+```
+export const dynamic = "force-dynamic";
+
+export default async function AdminDashboard() {
+  await verifySession("ADMIN");
+  const stats = await getDashboardStatsService();
+  return <AdminDashboardTemplate stats={stats} />;
+}
+```
+
+- `page.tsx`에 배치 코드(`grid`/`space-y-*`)·상수 배열·포맷 로직이 **하나도 남지 않는다** → `src/app/AGENTS.md`의 "Pages 단계만 담당" 충족.
+- organism 1개(=Template)를 배치 코드 없이 그대로 렌더 → 예외 조항 충족.
+- `verifySession`과 `getDashboardStatsService`를 **순차 await**한다(`Promise.all` 아님) — 인가 실패 시 DB 집계를 애초에 돌리지 않기 위해서다.
+
+---
+
+## 7. 3자 협상 결과 — 전 항목 확정
+
+**미해결 쟁점 없음.** api-designer·db-migrator와 1라운드에 전부 합의됐다.
+
+| # | 항목 | 확정 내용 | 출처 |
+|---|---|---|---|
+| Q1 | 데이터 경로 | **`page.tsx`가 `getDashboardStatsService()`를 직접 import + await.** route handler·`useSWR`·`fetcher` 전부 없음. `docs/architecture/data-access.md` row 1("서버 렌더 시점 데이터 → `src/services/*` 직접 호출, 같은 프로세스 안에서 HTTP 왕복 안 만듦") 근거. UI가 소비하는 계약은 HTTP JSON이 아니라 **함수 리턴 타입 `DashboardStats`** | api-designer |
+| Q2 | `createdAt` 타입 | **`Date` 객체 확정.** JSON 경계를 안 타므로 string 될 일 없다. `OrderJSON.createdAt`과도 일관 | api-designer |
+| Q3 | trend 원시 수치 | **채택.** 완성 문구는 안 내려온다, 전부 raw number. 부호·색상·포맷은 UI 소관 | api-designer |
+| Q4 | `null` 아닌 실제 `0` | **채택. 그리고 "집계 못 함" 상태는 아예 존재하지 않는다** — Q6의 all-or-nothing 때문에 집계 실패는 값이 아니라 throw로 나간다. **0이 내려오면 언제나 진짜 0이다** | api-designer |
+| Q5 | 최근 주문 5건 | **채택.** 이견 없음 | api-designer |
+| Q6 | 부분 실패 불허 | **채택.** `Promise.all` 유지, 실패 시 `AppError` → `(admin)/error.tsx` 통째 대체. per-section 폴백 설계하지 않는다 | api-designer |
+| Q7 | 매출 집계 기준 | **`CONFIRMED`+`COMPLETED`, `createdAt`이 아니라 `confirmedAt`(결제 확정 시각) 기준.** 가상계좌는 생성월≠입금월이라 `createdAt` 기준이면 "이번 달 매출"이 실제 입금과 어긋난다. `{ orderStatus: 1, confirmedAt: 1 }` 복합 인덱스가 이미 있어 커버됨 → **UI 조치: description을 "이번 달 결제 완료 기준"으로**(§4.1.1) | db-migrator |
+| Q8 | soft delete 판별 | `Product`는 `{ deletedAt: null }`(nullable, default 존재), `User`는 `{ isDelete: false }`(`deletedAt` 필드 없음). 규칙이 서로 다른 게 현재 실상이고 통일은 이 스코프 밖 → **UI 조치: 카드 문구를 "등록 상품"/"활동 회원"으로**(§4.1.1) | db-migrator |
+| Q9 | 주문 카드 모집단 통일 + **필드명 규칙 통일** | **수용.** 8개 스칼라 전부 `{지표}{ThisMonth\|PreviousMonth}` 한 규칙으로 통일한다 — 초안은 `monthly*`/`previousMonth*`/`*ThisMonth` 3종이 섞여 있었다. 리네이밍 4건은 §7.2 표 참고 | api-designer + db-migrator |
+| Q10 | 최근 주문 정렬·필터 | **상태 필터 없이 `createdAt` desc.** `PENDING`/`CANCELLED`도 포함된다 — 여기만 `confirmedAt`을 안 쓴다(PENDING은 `confirmedAt`이 없어 통째로 사라짐). 취소·대기 건이 보이는 게 관리자에겐 정보고, 상태는 배지가 말해준다 | db-migrator + api-designer |
+| Q11 | 월 경계 타임존 | **KST(Asia/Seoul) 기준으로 집계.** 초안은 서버 로컬 TZ(Vercel=UTC)라 9시간 어긋났다. `date-fns-tz`가 의존성으로 들어온다 → §3.3의 UI 조치 참고 | api-designer |
+| Q12 | `productTitle` 출처 | Order 문서의 **주문 시점 스냅샷**(Product join 아님). 상품명이 바뀌거나 상품이 삭제돼도 주문 당시 이름이 남는다 → **삭제된 상품의 주문이 리스트에 떠도 정상이다.** UI가 "상품 없음" 폴백을 만들 필요 없음 | db-migrator |
+| Q13 | `orderId`(_id) 필드 추가 | **추가 안 함.** admin에 `[orderId]` 상세 라우트가 없어 링크 걸 곳이 없다. 행 key는 `merchantUid`(unique 인덱스) 사용 | api-designer |
+| Q14 | `confirmedAt` 결측 (**UI 영향 있음**) | 2026-07-29 PR #77 이전 결제 건에 `confirmedAt` 필드가 없는 게 **실재하는 결함으로 확정**됐다. 리턴 타입은 안 바뀌지만, backfill 없이 구현하면 매출·결제주문 카드가 **에러 없이 조용히 작은 숫자를 렌더한다** — 상태 B(값 0은 진짜 0)와 구분이 안 되는 가짜 값이라 이 화면에서 제일 위험한 실패 양상이다. backend-impl이 구현 전 backfill 선행 | api-designer + db-migrator |
+| Q15 | 집계 상한 | `getKstMonthRange`가 경계 3개(전월/이번달/다음달)를 반환하고 상한을 `now`가 아닌 `startOfNextMonth`로 고정한다. **UI 영향 없음** | api-designer + db-migrator |
+
+### 7.1 확정된 `DashboardStats` (UI가 소비하는 최종 shape)
+
+```ts
+interface DashboardStats {
+  totalProducts: number;                  // deletedAt: null
+  productsCreatedThisMonth: number;
+  totalUsers: number;                     // isDelete: false
+  usersCreatedThisMonth: number;
+  revenueThisMonth: number;               // CONFIRMED+COMPLETED, confirmedAt 기준, KST 월 경계
+  revenuePreviousMonth: number;
+  paidOrderCountThisMonth: number;        // CONFIRMED+COMPLETED, confirmedAt 기준
+  paidOrderCountPreviousMonth: number;
+  recentOrders: DashboardRecentOrder[];   // createdAt desc, 5건, 상태 무필터
+}
+
+interface DashboardRecentOrder {
+  merchantUid: string;
+  buyerName: string;
+  productTitle: string;
+  finalPrice: number;
+  orderStatus: OrderStatus;
+  createdAt: Date;
+}
+```
+
+### 7.2 초안 대비 리네이밍 4건 — backend-impl 선행 작업
+
+초안 `src/core/domain/dashboard.ts`(uncommitted)는 아직 구 이름을 들고 있다. **Template을 붙이기 전에 리네이밍이 선행돼야 한다.**
+
+| 초안 필드명 | 확정 필드명 | 소비 위치 |
+|---|---|---|
+| `monthlyRevenue` | `revenueThisMonth` | §4.1 카드 2 value |
+| `previousMonthRevenue` | `revenuePreviousMonth` | §4.1 카드 2 trend |
+| `monthlyOrderCount` | `paidOrderCountThisMonth` | §4.1 카드 3 value |
+| `previousMonthOrderCount` | `paidOrderCountPreviousMonth` | §4.1 카드 3 trend |
+
+나머지 4개(`totalProducts`, `productsCreatedThisMonth`, `totalUsers`, `usersCreatedThisMonth`)와 `recentOrders`는 초안 그대로다.
+
+> **boundary-verifier 대조 지점 3곳**
+> 1. `dashboard.ts`의 8개 스칼라 필드명 ↔ `AdminDashboardTemplate`이 실제로 읽는 필드명(§4.1)이 정확히 일치하는가. 리네이밍 누락 시 타입 에러로 잡히지만, 초안이 uncommitted라 "이미 맞다"고 착각하기 쉽다.
+> 2. **카드는 `confirmedAt` 기준, 리스트는 `createdAt` 기준으로 서로 다른 게 의도다**(§7 Q7·Q10). 불일치로 판정하지 말 것 — 두 지표가 답하는 질문이 다르다(입금 총량 vs 유입 현황). db-migrator 문서 §2 Q2 아래 주의 블록에 같은 내용이 있으니 교차 확인 가능.
+> 3. 월 경계 타임존이 카드(집계, KST)와 리스트(`formatRelativeTime` 폴백, KST)에서 동일한가(§3.3 ⚠️).
+> 4. `confirmedAt` backfill이 구현보다 **먼저** 끝났는가(§7 Q14). 이건 화면만 봐서는 절대 못 잡는다 — 숫자가 그럴듯하게 작게 나올 뿐 에러가 안 난다.
+
+---
+
+## 8. 구현자(frontend-impl)를 위한 체크리스트
+
+- [ ] `_components/` 폴더 + `index.tsx` 배럴 생성 — 파일 1개여도 배럴 형태 유지(`src/app/AGENTS.md`). 배럴은 `page.tsx`가 직접 import하는 `AdminDashboardTemplate`만 재export하면 된다(`RecentOrdersCard`는 Template 내부 전용이라 배럴에 안 올려도 됨).
+- [ ] `page.tsx`/`layout.tsx` 외에는 `export default` 금지 — Template·Card 둘 다 named export(`export { AdminDashboardTemplate }`).
+- [ ] `"use client"` 붙이지 않는다 — 이 트리 전체가 Server Component다(§1).
+- [ ] `ORDER_STATUS_LABELS`/`ORDER_STATUS_BADGE_VARIANTS`를 로컬에 다시 선언하지 않는다 — `@/core/domain` 배럴에서 import.
+- [ ] "전체 보기"는 `useRouter().push()`가 아니라 `next/link`의 `<Link href={routes.admin.orders}>` — 이래야 Template이 순수한 채로 남는다(`components/AGENTS.md` 예외 2).
+- [ ] 상태 B: 값이 0일 때 falsy 단축(`value || "-"`)을 쓰지 않는다. 이 한 줄이 §5 상태 B를 정면으로 깬다.
+- [ ] 상태 C: `trend && <TypographySmall>` 형태로 **줄 자체를 생략**한다. `trend ?? ""`로 빈 문자열 렌더 금지.
+- [ ] `formatSignedPercent` / `formatRelativeTime`은 `src/core/utils/`에 두고 배럴(`index.ts`)에 `export *` 추가. 각각 `.test.ts` 동반(경계값: `previous === 0`, 음수 증감, 정확히 60분/24시간/7일).
+- [ ] `formatRelativeTime`의 `>7일` 폴백은 `Asia/Seoul` 고정 포맷 — 기존 `formatDate`를 그대로 호출하면 UTC로 새 날짜가 찍힌다(§3.3 ⚠️).
+- [ ] 초안 `src/core/domain/dashboard.ts`의 **리네이밍 4건(§7.2)이 끝난 뒤에** Template을 붙인다. 8개 스칼라가 `{지표}{ThisMonth|PreviousMonth}` 한 규칙으로 통일돼야 한다.
+- [ ] 카드 4개의 title/description은 §4.1.1의 변경 문구를 쓴다 — mock 문구(`총 상품`/`등록된 템플릿 수`/`총 회원`/`이번 달 주문 수`)를 그대로 옮기면 실제 집계 조건과 어긋난다.
+- [ ] Template `.test.tsx`로 §5의 A~D를 렌더 검증(`AdminProductsTemplate.test.tsx` 패턴). **A만 테스트하고 끝내지 말 것** — 머지 직후 관리자가 실제로 보게 될 화면은 A가 아니라 **C+D 조합(전 지표 0, 주문 0건)**이다(§5.1). 최소 케이스: ① 정상 A ② 전월 0 → trend 줄 부재 확인 ③ `recentOrders: []` → 빈 상태 문구 + 카드 4개는 정상 렌더 ④ 오픈 첫 달(전부 0) 통합 케이스.
+
+### 8.1 이번 스코프 밖(별도 Issue 후보)
+
+- `formatPriceWithComma`가 사실상 범용 콤마 포맷터인데 이름이 `price` 도메인에 묶여 있다 — 그래서 이번 설계에서 개수(상품/주문/회원)는 `.toLocaleString()`을, 통화(매출/금액)는 `formatPriceWithComma`를 쓰는 이원화가 남는다. 리네이밍은 소비처 전체를 건드리므로 이 브랜치에서 하지 않는다.
+- `(admin)/admin/orders`는 여전히 `MOCK_ORDERS` 기반이다. 대시보드 "전체 보기" 링크가 mock 화면으로 간다는 불일치가 남지만, 주문 전체조회 API는 이번 요구사항 밖이다.

--- a/_workspace/feat/admin-dashboard-real-data/03_boundary/00_preconditions.json
+++ b/_workspace/feat/admin-dashboard-real-data/03_boundary/00_preconditions.json
@@ -1,0 +1,41 @@
+{
+  "note": "설계 문서가 '차단 조건'으로 지정한 선행 항목의 해소 기록. boundary-verifier가 컨텍스트 유실 후 재에스컬레이션하지 않도록 영속 기록한다.",
+  "preconditions": [
+    {
+      "id": "전제-1",
+      "source": "01_api_contract.md §9 / 01_db_schema.md §4-1",
+      "item": "Order.confirmedAt 결측 backfill",
+      "status": "RESOLVED_NO_ACTION",
+      "resolvedBy": "leader",
+      "measurement": "db.orders.countDocuments({orderStatus:{$in:['CONFIRMED','COMPLETED']}, confirmedAt:null}) === 0",
+      "context": "결제 완료 주문 총 1건, 그 중 confirmedAt 결측 0건",
+      "verdict": "backfill 불필요. 차단 조건 해제. backend-impl에 리더 킥오프 메시지로 전달 완료.",
+      "at": "2026-08-27"
+    },
+    {
+      "id": "전제-2",
+      "source": "01_api_contract.md §9 / 01_db_schema.md §3-A",
+      "item": "Order { createdAt: -1 } 인덱스 추가 (필수)",
+      "status": "PENDING_VERIFICATION",
+      "note": "backend-impl 구현 대상. src/models/order.model.ts에 orderSchema.index({createdAt:-1}) 존재 여부로 판정한다. autoIndex:true라 별도 마이그레이션 스크립트 불필요."
+    },
+    {
+      "id": "전제-3",
+      "source": "01_db_schema.md §4-2",
+      "item": "User.isDelete 결측 확인 (리스크 낮음)",
+      "status": "RESOLVED_NO_ACTION",
+      "resolvedBy": "leader",
+      "measurement": "db.users.countDocuments({isDelete:{$exists:false}}) === 0",
+      "verdict": "결측 0건. services/dashboard.ts의 {isDelete:false} 그대로 확정, 코드 수정 불필요. backend-impl은 운영 DB 접근 불가라 리더가 직접 실측함.",
+      "at": "2026-08-27"
+    }
+  ],
+  "dataStateImplication": {
+    "note": "실측된 DB 상태가 UI 렌더 분기 판정에 직접 영향한다 (01_ui_flow.md §5.1).",
+    "detail": "결제 완료 주문이 총 1건뿐 → revenuePreviousMonth / paidOrderCountPreviousMonth가 0일 가능성이 매우 높다 → formatSignedPercent가 null 반환 → 상태 C(trend 줄 생략)가 머지 직후 실제 화면이다. Template 테스트에 C 케이스가 없으면 REDO 대상."
+  },
+  "draftStash": {
+    "note": "src/core/domain/dashboard.ts / src/services/dashboard.ts 초안은 리더가 stash@{0} ('superseded draft')로 치웠다. 두 워크트리 어디에도 없다.",
+    "implication": "01_api_contract.md §10의 '미커밋 초안을 덮어쓰지 말고 수정할 것' 항목은 무효. 확정 필드명으로 신규 작성이 정답이며 stash 복원은 구 필드명을 되살리므로 금지."
+  }
+}

--- a/_workspace/feat/admin-dashboard-real-data/03_boundary/core-utils-date-kst-month-range.json
+++ b/_workspace/feat/admin-dashboard-real-data/03_boundary/core-utils-date-kst-month-range.json
@@ -1,0 +1,61 @@
+{
+  "unit": "src/core/utils/date.ts — getKstMonthRange",
+  "boundary": "집계 월 경계(backend) ↔ 리스트 날짜 표시(frontend formatRelativeTime 폴백)",
+  "commit": "f450679",
+  "owner": "backend-impl",
+  "rounds": [
+    {
+      "round": 1,
+      "verdict": "PASS",
+      "at": "2026-08-27T14:38:00Z",
+      "checks": [
+        {
+          "criterion": "#2 필드명 일치",
+          "result": "PASS",
+          "detail": "반환 키 startOfLastMonth/startOfThisMonth/startOfNextMonth가 01_api_contract.md §5.1 및 01_db_schema.md §2-0의 구조분해 `const { startOfThisMonth, startOfLastMonth, startOfNextMonth }`와 정확히 일치."
+        },
+        {
+          "criterion": "#7 옵셔널 처리",
+          "result": "PASS",
+          "detail": "now: Date = new Date() 기본 파라미터. date.test.ts:48 케이스가 인자 생략 시 세 경계 단조증가를 검증."
+        },
+        {
+          "criterion": "타임존 (브리핑 항목 3, backend 절반)",
+          "result": "PASS",
+          "detail": "toZonedTime/fromZonedTime 3곳 전부 \"Asia/Seoul\" 명시. 서버 로컬 TZ에 의존하지 않음."
+        },
+        {
+          "criterion": "상한 경계 (§9 변경점 9)",
+          "result": "PASS",
+          "detail": "startOfNextMonth를 반환해 $lt 상한을 월 경계로 고정 가능. `now` 상한 아님."
+        },
+        {
+          "criterion": "배럴 도달성",
+          "result": "PASS",
+          "detail": "src/core/utils/index.ts에 `export * from \"./date\"`가 이미 존재 → @/core/utils에서 도달 가능. 배럴 수정 불필요."
+        },
+        {
+          "criterion": "core 경계 (서버 전용 패키지 금지)",
+          "result": "PASS",
+          "detail": "date-fns / date-fns-tz는 isomorphic. src/core/AGENTS.md 경계 위반 없음."
+        },
+        {
+          "criterion": "하지 말 것 (§1 §4 §7)",
+          "result": "PASS",
+          "detail": "route handler/Server Action/zod/envelope/unstable_cache/verifySession 없음. 기존 formatDate 미변경(계약 지시대로 스코프 밖 유지)."
+        }
+      ],
+      "independentVerification": {
+        "testArithmetic": "4개 명시 케이스의 UTC↔KST 환산을 손으로 전수 재계산 — 전부 정확",
+        "tzAgnosticism": "vitest를 기본 TZ / TZ=UTC(Vercel 재현) / TZ=America/New_York(음수 오프셋)로 3회 실행, 5 tests 전부 통과 → 구현이 시스템 TZ에 의존하지 않음을 실증",
+        "eslint": "clean"
+      },
+      "falsePositivesRejected": [
+        "prettier --check가 date.ts를 warn 처리하나 결함으로 보고하지 않음: 레포 baseline이 src/core에서만 14개 파일 위반, prettier 설정 파일 부재, lint 스크립트(eslint .)와 CI(static.yml) 어디에도 prettier 미연동. 즉 레포 관행과 일치하며 CI를 깨지 않는다."
+      ],
+      "reason": "7기준 전부 정합. 계약 §5.1과 1:1 일치하며 TZ 독립성을 실행으로 검증함."
+    }
+  ],
+  "redoCount": 0,
+  "forcedPass": false
+}

--- a/_workspace/feat/admin-dashboard-real-data/03_boundary/dashboard-frontend-template.json
+++ b/_workspace/feat/admin-dashboard-real-data/03_boundary/dashboard-frontend-template.json
@@ -1,0 +1,157 @@
+{
+  "unit": "AdminDashboardTemplate + RecentOrdersCard + formatSignedPercent + formatRelativeTime",
+  "boundary": "DashboardStats(생산자=backend 서비스) ↔ AdminDashboardTemplate이 실제로 읽는 필드(소비자)",
+  "commit": "553c221",
+  "owner": "frontend-impl",
+  "rounds": [
+    {
+      "round": 1,
+      "verdict": "FIX",
+      "at": "2026-08-27T14:48:00Z",
+      "summary": "경계면 정합성 자체는 전 항목 PASS. 그러나 계약 파일/도메인 상수의 중복 정의 2건이 있어 FIX. 설계 오류가 아니라 부분 수정으로 해결되므로 REDO 아님.",
+      "passedChecks": [
+        {
+          "criterion": "#2 필드명 일치 (브리핑 항목 1 — 최중점)",
+          "result": "PASS",
+          "detail": "Template이 읽는 8개 스칼라가 backend 확정본과 정확히 일치: totalProducts(54) / productsCreatedThisMonth(57,58) / totalUsers(82) / usersCreatedThisMonth(85,86) / revenueThisMonth(42,64) / revenuePreviousMonth(43) / paidOrderCountThisMonth(46,73) / paidOrderCountPreviousMonth(47). 구 이름 0건. RecentOrdersCard의 6필드도 일치."
+        },
+        {
+          "criterion": "#1 envelope",
+          "result": "PASS",
+          "detail": "Template이 stats prop을 직접 받음. fetch/useSWR/{success,data} 없음."
+        },
+        {
+          "criterion": "브리핑 항목 6 — falsy 단축 금지 (REDO 트리거 대상)",
+          "result": "PASS",
+          "detail": "diff 전체 grep 결과 `|| \"-\"`, `?? \"\"` 패턴 0건. 값은 toLocaleString()/formatPriceWithComma()로 무조건 렌더(0 포함). trend는 `{stat.trend && <TypographySmall>}`(113행)로 줄 자체를 생략 — 빈 문자열 렌더 아님. 저량 카드는 `> 0 ? {...} : null`로 §5 상태 C② 충족."
+        },
+        {
+          "criterion": "브리핑 항목 6 — C+D 테스트 존재 (REDO 트리거 대상)",
+          "result": "PASS",
+          "detail": "AdminDashboardTemplate.test.tsx 4케이스: ①A ②C(전월0→trend 부재) ③D(빈배열→빈상태+카드4개) ④C+D 통합(전 지표 0). ④가 '0'/'₩0'이 렌더됨을 단언(상태 B)하고 동시에 queryByText(/지난 달 대비/).not.toBeInTheDocument()로 trend 부재를 단언한다 — 머지 직후 실제 화면을 정확히 커버."
+        },
+        {
+          "criterion": "브리핑 항목 3 — 타임존 (frontend 절반)",
+          "result": "PASS",
+          "detail": "formatRelativeTime의 >7일 폴백이 formatDate(toZonedTime(date, KST_TIMEZONE), \"dot\")로 Asia/Seoul 명시(date.ts:114,129). 기존 formatDate 자체는 미변경(스코프 준수). 카드 집계(getKstMonthRange)와 리스트 표시가 둘 다 KST로 일치."
+        },
+        {
+          "criterion": "브리핑 항목 5 — createdAt Date 유지",
+          "result": "PASS",
+          "detail": "RecentOrdersCard가 order.createdAt을 Date 그대로 formatRelativeTime에 전달(87행). string 파싱/변환 없음."
+        },
+        {
+          "criterion": "#3 파일경로 ↔ 링크경로",
+          "result": "PASS",
+          "detail": "'전체 보기'가 <Link href={routes.admin.orders}>(28행) — 하드코딩 없음. routes.admin.orders='/admin/orders'이고 실제 파일은 src/app/(admin)/admin/orders/page.tsx((admin) 그룹은 URL에서 소멸) → 일치."
+        },
+        {
+          "criterion": "#4 상태 전이 ↔ 렌더 분기표",
+          "result": "PASS",
+          "detail": "§5 상태 A/B/C/D 전부 코드에 반영. D는 orders.length===0 분기(35행)로 테이블 대신 빈 상태 블록, 문구·클래스가 §5 D행과 일치(py-12, flex flex-col items-center gap-1 text-center)."
+        },
+        {
+          "criterion": "trend 색상 버그 수정",
+          "result": "PASS",
+          "detail": "TREND_DIRECTION_CLASS로 up=text-primary/down=text-destructive/flat=text-muted-foreground(30~34행). 기존 '무조건 text-primary'(감소를 긍정색으로 칠하던 버그) 해소 — §4.1.1 표와 일치."
+        },
+        {
+          "criterion": "UI 카피",
+          "result": "PASS",
+          "detail": "4개 카드 title/description이 §4.1.1 확정본과 일치(등록 상품/삭제 제외 전체 상품, 총 매출/이번 달 결제 완료 기준, 결제 주문/이번 달 결제 완료 주문, 활동 회원/탈퇴 제외 가입 회원). mock 문구 계승 없음. 카드 제목 '최근 활동'→'최근 주문' 반영."
+        },
+        {
+          "criterion": "컴포넌트 규약",
+          "result": "PASS",
+          "detail": "\"use client\" 0건(전 트리 Server Component), named export만, _components/index.tsx 배럴이 AdminDashboardTemplate만 재export(§8 체크리스트대로 RecentOrdersCard는 미노출). page.tsx 미변경 — 브리핑 항목 7의 순서 규칙 준수."
+        },
+        {
+          "criterion": "formatSignedPercent 계약",
+          "result": "PASS",
+          "detail": "previous===0 → null 반환(15행)으로 0 나눗셈 회피. {label, direction} 구조체 반환이라 UI가 색상 판정 가능 — §3.3 시그니처와 일치."
+        }
+      ],
+      "findings": [
+        {
+          "id": "F1",
+          "severity": "FIX",
+          "criterion": "#2 케이스/정의 중복 — 도메인 상수 2중 정의",
+          "problem": "553c221이 ORDER_STATUS_LABELS / ORDER_STATUS_BADGE_VARIANTS를 src/core/domain/order.ts:46,53에 추가했는데, 기존 정의가 src/app/(admin)/admin/orders/_constants/mockOrders.ts:43,50에 그대로 남아 있다. 같은 상수가 두 곳에 존재하고, /admin/orders(AdminOrdersTemplate.tsx:15-19가 '../_constants'에서 import)와 /admin/dashboard(RecentOrdersCard가 @/core/domain에서 import)가 서로 다른 사본을 소비한다.",
+          "why": "현재 값은 두 사본이 동일해서 화면상 차이가 없다. 그러나 01_ui_flow.md §3.4가 이 두 상수를 '재정의 금지'로 명시했고, 01_db_schema.md §5는 초안이 mock 상수에서 도메인으로 '승격'시킨 것을 유지하라고 했다 — 승격은 이동이지 복제가 아니다. 나란히 놓인 두 admin 화면이 같은 주문 상태 어휘를 다른 출처에서 읽으면, 한쪽만 수정될 때 조용히 갈라진다. 01_api_contract.md §3이 PAID_ORDER_STATUSES에 대해 경계한 '사본이 늘어나면 나중에 상태가 추가될 때 한쪽만 조용히 틀려진다'와 같은 실패 양상이다.",
+          "fix": "mockOrders.ts:43-58의 두 상수를 삭제하고, AdminOrdersTemplate.tsx:15-19의 import에서 ORDER_STATUS_LABELS/ORDER_STATUS_BADGE_VARIANTS를 빼서 @/core/domain에서 가져오도록 바꾼다(MOCK_ORDERS는 '../_constants' 유지). 스코프 밖 아님 — 스태시된 초안이 정확히 이 두 파일을 수정했고 db_schema §5가 그 승격을 '유지 권고'했다. 01_ui_flow.md §8.1이 스코프 밖으로 둔 건 MOCK_ORDERS→실데이터 전환이지 상수 위치가 아니다.",
+          "owner": "frontend-impl"
+        },
+        {
+          "id": "F2",
+          "severity": "FIX",
+          "criterion": "계약 파일 2중 소유 — add/add 머지 충돌",
+          "problem": "src/core/domain/dashboard.ts가 두 브랜치에 각각 신규 생성됐다(backend 1accaba, frontend 553c221). 내용은 주석 1줄만 다르다: 42행 recentOrders 주석에서 frontend본이 '(REQ-2 빈 상태)'를 뺐다. src/core/domain/index.ts의 `export type * from \"./dashboard\";` 한 줄도 양쪽이 각각 추가했다.",
+          "why": "타입 필드명은 완전히 일치하므로 경계면 결함은 아니다. 다만 두 브랜치가 같은 신규 파일을 만들었으므로 리더 병합 시 dashboard.ts와 index.ts 둘 다 add/add 충돌이 난다. 이 기능에서 가장 중요한 계약 파일을 손으로 고르게 두면 잘못된 쪽이 채택될 여지가 생긴다. 소유권은 01_api_contract.md §10이 backend-impl에 배정했다.",
+          "fix": "frontend-impl이 backend의 1accaba 위로 rebase하고 자신의 src/core/domain/dashboard.ts와 core/domain/index.ts의 dashboard export 줄을 버린다(backend본 채택). frontend의 core/utils/index.ts `export * from \"./percent\";`는 frontend 단독이라 유지. backend는 조치 불필요.",
+          "owner": "frontend-impl (backend는 인지만)"
+        }
+      ],
+      "independentVerification": {
+        "note": "frontend 보고를 신뢰하지 않고 직접 실행 검증",
+        "tsc": "npm run tsc 통과",
+        "eslint": "exit 0",
+        "tests": "percent.test.ts + date.test.ts + AdminDashboardTemplate.test.tsx — 22/22 통과",
+        "kstFallbackEmpirical": "임시 테스트를 작성해 TZ=UTC / America/New_York / Asia/Seoul 3회 실행. KST 21:00(2026-08-20T12:00Z)과 KST 23:30(2026-08-20T14:30Z) 주문이 세 TZ 모두에서 '2026.8.20'으로 렌더됨을 확인 — 설계자가 경고한 '하루 밀림'이 실제로 발생하지 않음을 실증. 검증 후 임시 파일 삭제함.",
+        "falsyScan": "git diff 71e0d4e..553c221 전체에서 `|| \"`, `?? \"\"` 패턴 0건",
+        "duplicateScan": "order.ts 최종본에서 export const ORDER_STATUS_LABELS 정의 1건(중복 선언 아님) — 컴파일은 통과하나 mockOrders.ts에 별도 사본 잔존을 확인"
+      },
+      "selfCorrection": "이전 라운드 보고에서 'ORDER_STATUS_LABELS/BADGE_VARIANTS가 커밋된 base(1bbce1e)에 이미 존재한다'고 기록했으나 오류였다. git show 1bbce1e:src/core/domain/order.ts 확인 결과 base에는 없고, base의 정의 위치는 mockOrders.ts:43이다. 당시 grep이 frontend 워크트리의 미커밋 작업본을 읽은 것을 커밋 상태로 오독했다. F1은 이 정정에서 드러난 사안이다."
+    },
+    {
+      "round": 2,
+      "verdict": "PASS",
+      "at": "2026-08-27T14:54:00Z",
+      "commits": ["7313451 (rebase 후 재적용)", "8b1e729 (F1 fix)"],
+      "summary": "F1·F2 둘 다 해소 확인. 라운드 1에서 PASS였던 항목들이 rebase 후에도 유지되는지 전수 재확인함.",
+      "findingResolution": [
+        {
+          "id": "F1",
+          "result": "RESOLVED",
+          "detail": "8b1e729이 mockOrders.ts에서 두 상수를 삭제(-17줄)하고 AdminOrdersTemplate.tsx:15를 `@/core/domain` import로 교체. 레포 전역 grep 결과 ORDER_STATUS_LABELS/ORDER_STATUS_BADGE_VARIANTS의 정의는 이제 src/core/domain/order.ts 한 곳뿐이고, 소비처 2곳(AdminOrdersTemplate, RecentOrdersCard)이 모두 @/core/domain에서 읽는다 — 단일 출처 성립.",
+          "collateralChecks": [
+            "_constants/index.ts가 `export * from \"./mockOrders\"`(named 재export 아님)라 상수 삭제로 배럴이 깨지지 않음",
+            "mockOrders.ts의 `import type { OrderStatus }`는 MockOrder 인터페이스가 계속 사용하므로 미사용 import 아님",
+            "core/domain/index.ts는 `export * from \"./order\"`(값 export)라 상수 import 가능 — type-only였다면 깨졌을 지점",
+            "my-orders/_constants/labels.ts의 DEFAULT_ORDER_STATUS_LABELS/CATEGORY_ORDER_STATUS_LABELS는 이름도 목적도 다른 고객용 라벨이라 F1 대상 아님(스코프 밖, 미변경 정상)"
+          ]
+        },
+        {
+          "id": "F2",
+          "result": "RESOLVED",
+          "detail": "backend-1accaba 위로 rebase 완료. src/core/domain/dashboard.ts가 표준 브랜치본과 diff 무출력(바이트 동일) — backend본 채택 확인. core/domain/index.ts의 dashboard export 줄 1개(중복 없음). core/utils/index.ts의 percent export는 frontend 단독분으로 유지. add/add 충돌 소멸."
+        }
+      ],
+      "regressionChecks": [
+        "8개 스칼라 필드 읽기 전부 잔존(각 1~2회), 구 필드명 레포 전역 0건",
+        "falsy 단축 스캔(1accaba..HEAD diff) 0건",
+        "formatRelativeTime KST 폴백 유지(date.ts:114 KST_TIMEZONE, :129 toZonedTime)",
+        "trend 조건부 렌더 유지(AdminDashboardTemplate.tsx:113 `{stat.trend && (`)",
+        "page.tsx 미변경 — 브리핑 항목 7 순서 규칙 준수"
+      ],
+      "independentVerification": {
+        "tsc": "통과",
+        "eslint": "npx eslint . (전체) exit 0",
+        "tests": "src/app/(admin)/ + src/core/utils — 17 파일 / 109 테스트 통과, 대시보드 관련 전건 통과"
+      },
+      "preExistingFailureExcluded": {
+        "file": "src/core/utils/category.test.ts",
+        "tests": "getSubCategoryOptions favor(5개) / ceremony(4개) 2건 실패",
+        "verdict": "이번 기능과 무관한 선행 결함. 표준 브랜치(frontend 변경 0)에서 동일하게 실패하고, 양 브랜치 모두 category.ts/category.test.ts를 건드린 이력이 없다. 원인은 dea757c(서브카테고리 5개 추가) 때 테스트 미갱신으로 보인다. CI(static.yml)는 lint/tsc/build만 돌려 vitest를 실행하지 않으므로 PR을 막지는 않는다. 프로젝트 AGENTS.md의 '목적 밖 과제는 별도 Issue' 규칙에 따라 이 브랜치에서 고치지 않고 Issue 후보로 리더에게 보고함."
+      },
+      "reason": "F1·F2 해소 확인, 라운드 1 PASS 항목 전부 회귀 없음. 경계면 전 기준 정합."
+    }
+  ],
+  "redoCount": 0,
+  "forcedPass": false,
+  "remainingWork": {
+    "item": "src/app/(admin)/admin/dashboard/page.tsx 배선",
+    "status": "NOT_STARTED",
+    "detail": "7313451이 'mock-first template'이라 Template/Card는 완성됐지만 page.tsx는 여전히 하드코딩 stats 배열을 인라인 렌더한다. 01_ui_flow.md §6의 최종 형태(verifySession → getDashboardStatsService() → <AdminDashboardTemplate stats={stats} />)로 교체돼야 기능이 실제로 연결된다. 브리핑 항목 7의 선행조건(backend 유닛 병합)은 1accaba 표준 브랜치 병합으로 이미 충족됨 — 착수 가능 상태.",
+    "verifyOnSubmit": "page.tsx가 서비스를 직접 await하는지(route handler/fetch 미개입), verifySession과 서비스 호출이 순차 await인지(Promise.all 아님 — 인가 실패 시 집계 미실행), 배치 코드/상수 배열/포맷 로직이 page.tsx에 남지 않는지"
+  }
+}

--- a/_workspace/feat/admin-dashboard-real-data/03_boundary/dashboard-page-wiring.json
+++ b/_workspace/feat/admin-dashboard-real-data/03_boundary/dashboard-page-wiring.json
@@ -1,0 +1,66 @@
+{
+  "unit": "src/app/(admin)/admin/dashboard/page.tsx — 서비스↔화면 배선",
+  "boundary": "getDashboardStatsService(생산자) ↔ page.tsx ↔ AdminDashboardTemplate(소비자) — 이 기능의 최종 경계면",
+  "commit": "9472de2",
+  "owner": "frontend-impl",
+  "rounds": [
+    {
+      "round": 1,
+      "verdict": "PASS",
+      "at": "2026-08-27T14:59:00Z",
+      "checks": [
+        {
+          "criterion": "#1 응답 래핑 / JSON 경계 부재",
+          "result": "PASS",
+          "detail": "page.tsx가 getDashboardStatsService()를 직접 await(8행). route handler·fetch·useSWR 미개입 → JSON 직렬화 경계가 없다. 따라서 recentOrders[].createdAt이 Date로 UI까지 도달한다(브리핑 항목 5의 실제 성립 지점). 01_api_contract.md §1 / data-access.md row 1 준수."
+        },
+        {
+          "criterion": "#5 API ↔ 소비처 매핑",
+          "result": "PASS",
+          "detail": "getDashboardStatsService의 유일한 호출자가 page.tsx(계약 §4의 '호출자 단 하나')이고, 서비스가 만들어졌는데 아무도 안 쓰는 상태가 아니다. 반대로 Template이 요구하는 stats prop의 유일한 공급원도 이 호출이다. 1:1 매핑 성립."
+        },
+        {
+          "criterion": "#6 즉시응답 ↔ 비동기",
+          "result": "PASS",
+          "detail": "동기적 await 1회. 폴링·백그라운드 잡·비동기 결과 필드 접근 없음."
+        },
+        {
+          "criterion": "인가 순서 (§6)",
+          "result": "PASS",
+          "detail": "verifySession(\"ADMIN\")(7행)과 getDashboardStatsService()(8행)가 순차 await다. Promise.all이 아니라서 인가 실패 시 DB 집계가 애초에 실행되지 않는다 — 01_ui_flow.md §6이 명시한 의도와 일치."
+        },
+        {
+          "criterion": "Pages 단계 책임 (src/app/AGENTS.md)",
+          "result": "PASS",
+          "detail": "배치 코드(grid/space-y-*)·상수 배열·포맷 로직이 전부 제거됐다(-76/+4). organism 1개(Template)를 배치 코드 없이 렌더 → Template 추출 예외 조항 충족. 01_ui_flow.md §6 최종 형태와 일치."
+        },
+        {
+          "criterion": "#3 파일경로 ↔ 링크경로",
+          "result": "PASS",
+          "detail": "빌드 매니페스트로 확증: app-path-routes-manifest.json이 '/(admin)/admin/dashboard/page' => '/admin/dashboard'로 매핑한다. (admin) 라우트 그룹이 URL에서 소멸한다는 01_ui_flow.md §1 전제가 실제 빌드 산출물에서 확인됨. RecentOrdersCard의 routes.admin.orders='/admin/orders'도 동일 규칙으로 유효."
+        },
+        {
+          "criterion": "force-dynamic 유지 (§4 캐싱 없음)",
+          "result": "PASS",
+          "detail": "export const dynamic = \"force-dynamic\" 유지(1행). 빌드 산출물의 prerender-manifest.json에 /admin/dashboard가 없음을 확인 — 정적 프리렌더되지 않고 매 요청 서버 렌더된다. unstable_cache 부착 없음. REQ-1의 '등록·주문 발생 시 값이 갱신된다' 충족."
+        },
+        {
+          "criterion": "배럴 경유 import",
+          "result": "PASS",
+          "detail": "@/services 배럴이 ./auth(verifySession)와 ./dashboard(getDashboardStatsService) 둘 다 값 export. ./_components 배럴이 AdminDashboardTemplate 재export. 배럴 우회 직접 경로 import 없음."
+        }
+      ],
+      "independentVerification": {
+        "note": "붙여넣은 스니펫이 아니라 실제 커밋된 파일을 읽어 대조함",
+        "build": "npm run build (CI static.yml과 동일한 env로 실행) — 성공. 이 기능의 조립이 실제 프로덕션 빌드에서 성립함을 확인. server-only 경계 위반도 없음(위반 시 빌드가 깨진다).",
+        "tsc": "통과",
+        "eslint": "npx eslint . exit 0",
+        "tests": "percent + date + AdminDashboardTemplate 22/22 통과",
+        "workingTree": "clean — 미커밋 잔여물 없음"
+      },
+      "reason": "최종 경계면 전 기준 정합. 서비스→page→Template 배선이 JSON 경계 없이 직결되고, 프로덕션 빌드로 조립 성립을 확증함."
+    }
+  ],
+  "redoCount": 0,
+  "forcedPass": false
+}

--- a/_workspace/feat/admin-dashboard-real-data/03_boundary/dashboard-service-and-types.json
+++ b/_workspace/feat/admin-dashboard-real-data/03_boundary/dashboard-service-and-types.json
@@ -1,0 +1,99 @@
+{
+  "unit": "src/core/domain/dashboard.ts + src/services/dashboard.ts (+배럴 2개, integration test)",
+  "boundary": "서비스 리턴 타입(생산자) ↔ DashboardStats 도메인 계약 ↔ AdminDashboardTemplate 소비 필드(소비자 미구현)",
+  "commit": "1accaba",
+  "owner": "backend-impl",
+  "rounds": [
+    {
+      "round": 1,
+      "verdict": "PASS",
+      "at": "2026-08-27T14:43:00Z",
+      "checks": [
+        {
+          "criterion": "#1 API 응답 래핑 불일치 (envelope)",
+          "result": "PASS",
+          "detail": "서비스가 DashboardStats를 그대로 리턴. routeSuccess/actionError/toErrorPayload 미호출, {success,data} 없음. 브랜치 전체 diff에 해당 패턴 0건. 01_api_contract.md §1 충족."
+        },
+        {
+          "criterion": "#2 필드명 일치 (브리핑 항목 1 — 최중점)",
+          "result": "PASS",
+          "detail": "8개 스칼라 전부 확정본과 일치: totalProducts / productsCreatedThisMonth / totalUsers / usersCreatedThisMonth / revenueThisMonth / revenuePreviousMonth / paidOrderCountThisMonth / paidOrderCountPreviousMonth. 구 이름(monthlyRevenue, previousMonthRevenue, monthlyOrderCount, previousMonthOrderCount) 브랜치 전체에 0건. DashboardRecentOrder 6필드도 §3과 일치."
+        },
+        {
+          "criterion": "#6 즉시응답 ↔ 비동기 (createdAt 타입, 브리핑 항목 5)",
+          "result": "PASS",
+          "detail": "recentOrders[].createdAt이 .lean<RecentOrderLean[]>()의 raw Date를 그대로 매핑, toISOString/String 변환 없음. JSON 직렬화 경계 없음(route handler/fetch 미개입). integration test가 toBeInstanceOf(Date)로 단언."
+        },
+        {
+          "criterion": "#7 옵셔널 필드 처리 (?? 0 보장)",
+          "result": "PASS",
+          "detail": "$group 버킷 부재 시 currentBucket?.revenue ?? 0 등 8개 스칼라 전부 ?? 0 폴백. productAgg/userAgg도 [0] 부재 대비 옵셔널 체이닝. '항상 number, null/undefined 절대 없음' 계약 성립."
+        },
+        {
+          "criterion": "이중 시각 기준 (브리핑 항목 2 — 오판 금지 대상)",
+          "result": "PASS (의도된 설계로 확인)",
+          "detail": "Q1 카드 집계는 confirmedAt 기준 + PAID_ORDER_STATUSES 필터, Q2 최근주문은 createdAt 기준 + 상태 무필터. 01_db_schema.md §2 Q2 주의블록 및 01_ui_flow.md §7 Q7/Q10과 일치 — 불일치로 판정하지 않음."
+        },
+        {
+          "criterion": "타임존 (브리핑 항목 3, backend 절반)",
+          "result": "PASS",
+          "detail": "getKstMonthRange() 사용, 상한을 startOfNextMonth로 고정(§9 변경점 9). 서버 로컬 TZ 산술 없음. frontend formatRelativeTime 폴백과의 대조는 프론트 유닛에서 수행 예정."
+        },
+        {
+          "criterion": "에러 계약 (§6)",
+          "result": "PASS",
+          "detail": "Promise.all(...).catch()에서 AppError(\"INTERNAL\", 원본 message) 래핑. all-or-nothing 유지, per-section 폴백 없음. integration test가 OrderModel.aggregate를 mockRejectedValueOnce로 강제 실패시켜 category/message 검증."
+        },
+        {
+          "criterion": "인증 배치 (§7)",
+          "result": "PASS",
+          "detail": "서비스 내부 verifySession/requireAdmin 호출 없음. 유일한 문자열 매치는 '여기서 검사하지 않는다'는 주석. 계약이 의도한 배치와 일치."
+        },
+        {
+          "criterion": "하지 말 것 (브리핑 항목 8)",
+          "result": "PASS",
+          "detail": "브랜치 전체 9개 파일 — route handler/Server Action/zod 스키마 신규 생성 0건, unstable_cache 0건, src/models 중 order.model.ts만(인덱스 1줄). src/app/api·src/actions 미변경."
+        },
+        {
+          "criterion": "소프트 삭제 두 컨벤션",
+          "result": "PASS",
+          "detail": "Product는 {deletedAt: null}, User는 {isDelete: false} — 01_db_schema.md §1의 실측 결과와 일치(모델마다 컨벤션이 다른 게 프로젝트 현실). ProductModel base 사용으로 discriminator 전 카테고리 포함."
+        },
+        {
+          "criterion": "배럴 노출",
+          "result": "PASS",
+          "detail": "core/domain/index.ts는 `export type * from \"./dashboard\"` (타입 전용 모듈이라 정확), services/index.ts는 `export * from \"./dashboard\"`. 프론트가 @/core/domain에서 DashboardStats 도달 가능."
+        },
+        {
+          "criterion": "런타임 크래시 리스크 (product.title 평탄화)",
+          "result": "PASS",
+          "detail": "order.product.title 접근이 안전한지 스키마로 확인 — order.model.ts에서 product: {type: ProductSnapShotSchema, required: true}, title: {type: String, required: true}. buyerName/finalPrice도 required. 타입 단언이 가리는 undefined 접근 위험 없음."
+        }
+      ],
+      "independentVerification": {
+        "note": "backend 보고를 신뢰하지 않고 직접 실행 검증함",
+        "integrationTest": "npx vitest run --project integration — 11/11 통과",
+        "testDbSafety": "backend가 gitignored .env를 워크트리에 복사했다고 보고 → 운영 DB 오염 가능성을 직접 확인함. 결과: 안전. .env에 MONGO_TEST_URI가 아예 없고, integration 프로젝트의 globalSetup(testing/support/setup/mongo-server.ts)이 MongoMemoryReplSet을 띄워 MONGO_TEST_URI를 주입한다. beforeEach의 clearCollections()는 그 임시 인메모리 replSet만 비운다. dbConnect의 resolveUri도 VITEST일 때 MONGO_TEST_URI 없으면 throw하는 이중 안전장치가 있다. .env는 gitignore되어 커밋에도 없음.",
+        "tsc": "npm run tsc 통과",
+        "eslint": "exit 0",
+        "forbiddenPatternScan": "git diff 1bbce1e..HEAD 전체에서 unstable_cache/routeSuccess/actionError/success:true/z.object 매치 0건"
+      },
+      "falsePositivesRejected": [
+        "dbConnect() 미래핑: line 45의 `await dbConnect()`가 AppError 래핑 .catch() 바깥에 있어 연결 실패 시 raw Error가 샌다(계약 §6 에러표는 'DB 커넥션/타임아웃 → INTERNAL'로 분류). 그러나 결함으로 보고하지 않음 — src/services/*.ts 전 서비스(auth/order/product/user/payment/invitation)가 예외 없이 dbConnect()를 미래핑 호출하는 레포 전역 관행이다. 이 브랜치가 도입한 편차가 아니며, 프로젝트 AGENTS.md의 '목적 밖 과제는 별도 Issue' 규칙에 따라 별도 Issue 후보로만 남긴다."
+      ],
+      "reason": "7기준 + 계약 고유 조항 전부 정합. 필드명 8개·Date 유지·?? 0·AppError·envelope 부재를 전수 대조했고, 통합테스트 11건을 직접 실행해 통과 확인. 타입 단언이 가릴 수 있는 런타임 크래시 지점(product.title)도 스키마로 역추적해 안전 확인."
+    }
+  ],
+  "redoCount": 0,
+  "forcedPass": false,
+  "openPreconditions": [
+    {
+      "id": "전제-3",
+      "item": "User.isDelete 결측 실측 (01_db_schema.md §4-2)",
+      "status": "NOT_PERFORMED",
+      "detail": "db_schema §4-2가 backend-impl에게 `db.users.countDocuments({isDelete:{$exists:false}})` 실측을 지시했고, 0이면 {isDelete:false} 유지, 아니면 {$ne:true}로 변경하라고 했다. backend 완료 보고에 이 항목이 없다. 코드는 문서가 지정한 기본값({isDelete:false})을 쓰고 있어 '틀린 코드'는 아니지만, 실측이 안 끝나 전제가 열려 있다.",
+      "risk": "mongoose 밖에서 삽입된 레거시 user 문서가 있으면 totalUsers/usersCreatedThisMonth가 에러 없이 조용히 축소된다 — 전제-1(confirmedAt)과 동일한 '그럴듯한 오답' 실패 양상.",
+      "escalatedTo": "leader (운영 DB 접근 주체)"
+    }
+  ]
+}

--- a/_workspace/feat/admin-dashboard-real-data/03_boundary/order-paid-statuses-and-createdat-index.json
+++ b/_workspace/feat/admin-dashboard-real-data/03_boundary/order-paid-statuses-and-createdat-index.json
@@ -1,0 +1,52 @@
+{
+  "unit": "src/core/domain/order.ts (PAID_ORDER_STATUSES) + src/models/order.model.ts ({createdAt:-1} 인덱스)",
+  "boundary": "매출 집계 모집단 정의(도메인 상수) ↔ 서비스 집계 쿼리 / 최근주문 정렬 성능 전제조건",
+  "commit": "71e0d4e",
+  "owner": "backend-impl",
+  "rounds": [
+    {
+      "round": 1,
+      "verdict": "PASS",
+      "at": "2026-08-27T14:39:00Z",
+      "checks": [
+        {
+          "criterion": "#2 필드명/값 일치",
+          "result": "PASS",
+          "detail": "PAID_ORDER_STATUSES = [\"CONFIRMED\",\"COMPLETED\"] as const — 01_api_contract.md §3 상수 승격 블록과 문자 단위 일치. 01_db_schema.md §1의 isPaymentAppliedStatus(payment.ts:61) 정의와도 동일."
+        },
+        {
+          "criterion": "배치 위치 (§3 상수 승격)",
+          "result": "PASS",
+          "detail": "src/core/domain/order.ts에 승격. dashboard 지역 사본(REVENUE_STATUSES) 생성하지 않음 — '네 번째 사본 금지' 요구 충족."
+        },
+        {
+          "criterion": "스코프 준수",
+          "result": "PASS",
+          "detail": "payment.ts의 isPaymentAppliedStatus와 invitation.ts:63을 건드리지 않음. 계약 §3 각주가 '기존 리팩터링은 스코프 밖'으로 못박은 대로."
+        },
+        {
+          "criterion": "§9 전제-2 (필수 인덱스)",
+          "result": "PASS",
+          "detail": "orderSchema.index({ createdAt: -1 }) 추가. 01_db_schema.md §3-A 요구와 일치. autoIndex:true라 별도 마이그레이션 스크립트 불필요."
+        },
+        {
+          "criterion": "브리핑 항목 8 (스키마 변경 제한)",
+          "result": "PASS",
+          "detail": "src/models 하위에서 order.model.ts만 수정, 변경 내용은 인덱스 1줄 추가뿐. 필드 추가/타입 변경 없음 — 허용 범위와 정확히 일치."
+        },
+        {
+          "criterion": "기존 인덱스 간섭",
+          "result": "PASS",
+          "detail": "기존 3개 복합 인덱스(선두 userId 또는 orderStatus) 미변경. 신규 단일 인덱스는 무필터 createdAt desc 정렬 전용이라 중복/잠식 없음."
+        }
+      ],
+      "independentVerification": {
+        "eslint": "clean (order.ts, order.model.ts)",
+        "diffSize": "order.ts +4, order.model.ts +5 — 외과적 변경, 부수 수정 없음"
+      },
+      "reason": "계약 §3 상수 정의와 db_schema §3-A 인덱스 요구를 정확히 충족. 스코프 밖 파일 무변경."
+    }
+  ],
+  "redoCount": 0,
+  "forcedPass": false
+}

--- a/_workspace/feat/admin-dashboard-real-data/04_integration_report.md
+++ b/_workspace/feat/admin-dashboard-real-data/04_integration_report.md
@@ -60,6 +60,12 @@
 | 2 | `src/db/connect.ts`의 `dbConnect()`가 에러를 `AppError`로 안 감쌈 | `services/AGENTS.md` 규약과 어긋나지만 이 브랜치가 도입한 편차 아님 — 전 서비스 공통 기존 패턴 |
 | 3 | `/admin/orders`가 여전히 `MOCK_ORDERS` 기반 | 설계 단계에서 스코프 밖 합의. 단 이번에 추가한 `{createdAt:-1}` 인덱스가 그쪽 실데이터 전환의 DB 선행조건을 이미 충족시켜둠 |
 | 4 | Product/User 소프트 삭제 컨벤션 불일치(`deletedAt` vs `isDelete`) | 통일하려면 전 문서 backfill + 쿼리 전수 수정 필요, 별도 작업 |
+| 5 | `src/adapters/browser/cloudinary/widget.test.ts` 실패 1건 | test-suite가 Phase4 전체 스위트 재실행 중 발견. `dev`에서도 동일 재현, 이 기능과 무관 |
+| 6 | `invitationMessage.mapper.test.ts` 실패 1건 | 위와 동일 — `dev`에서도 동일 재현, 이 기능과 무관 |
+
+## 8. Phase 4 결과
+
+`page.integration.test.ts` 4케이스(골든패스/빈DB=상태C+D/역할불일치 회귀/미인증 회귀) 추가, mongodb-memory-server 기반. 신규 파일 4/4 통과, 전체 스위트 832 passed / 4 failed(전부 §6의 무관 기존 결함, 이 브랜치 미접촉 확인됨). lint/tsc 0 errors. 상세: `04_test_report.md`.
 
 ## 7. Phase 4 위임 사항
 

--- a/_workspace/feat/admin-dashboard-real-data/04_integration_report.md
+++ b/_workspace/feat/admin-dashboard-real-data/04_integration_report.md
@@ -1,0 +1,66 @@
+# 04 — 통합 리포트: admin 대시보드 실데이터 연결
+
+> 작성: 리더 (feature-team-orchestrator)
+> Phase 0~3 완료, Phase 4(test-suite) 착수 전 요약
+
+---
+
+## 1. 요구사항 충족 판정
+
+| REQ | 설명 | 수용 기준 | 판정 |
+|---|---|---|---|
+| REQ-1 | 대시보드 상단 통계 카드를 실제 DB 집계값으로 렌더링 | `/admin/dashboard` 접속 시 상품/매출/주문/회원 카드가 실제 DB 값 표시, 등록·주문 발생 시 갱신 | **충족** — `getDashboardStatsService`가 `force-dynamic` 페이지에서 매 요청 재집계(캐싱 없음), `page.tsx`가 직접 연결(9472de2) |
+| REQ-2 | '최근 활동' 카드를 실제 데이터로 렌더링 | placeholder 대신 실제 목록, 빈 상태 문구 존재 | **충족** — "최근 주문"으로 개칭, `RecentOrdersCard`가 최근 5건 테이블 렌더, 빈 배열 시 빈 상태 블록(§5 상태 D) |
+
+두 항목 모두 boundary-verifier PASS(강제 PASS 아님, REDO 0)로 뒷받침됨.
+
+## 2. Phase별 산출물
+
+- Phase 0: `00_requirements.json`
+- Phase 1: `01_api_contract.md`(api-designer) / `01_ui_flow.md`(ui-designer) / `01_db_schema.md`(db-migrator) — 3자 합의, 미해결 쟁점 0
+- Phase 2+3: `03_boundary/`에 유닛별 판정 5건 + 전제조건 3건 기록
+
+## 3. 구현 요약
+
+**변경/신규 파일 (7커밋, `dev` 대비):**
+- `src/core/domain/order.ts` — `PAID_ORDER_STATUSES`, `ORDER_STATUS_LABELS`/`ORDER_STATUS_BADGE_VARIANTS` 승격
+- `src/core/domain/dashboard.ts` (신규) — `DashboardStats`/`DashboardRecentOrder`
+- `src/core/utils/date.ts` — `getKstMonthRange`(backend), `formatRelativeTime`(frontend) 추가, 각각 테스트 동반
+- `src/core/utils/percent.ts` (신규) — `formatSignedPercent` + 테스트
+- `src/models/order.model.ts` — `{ createdAt: -1 }` 인덱스 추가
+- `src/services/dashboard.ts` (신규) — `getDashboardStatsService`, 4-쿼리 병렬 집계, `AppError` 래핑, 통합테스트 11건
+- `src/app/(admin)/admin/dashboard/_components/` (신규) — `AdminDashboardTemplate`/`RecentOrdersCard`/배럴, 렌더 테스트 4케이스(A/C/D/오픈첫달)
+- `src/app/(admin)/admin/dashboard/page.tsx` — mock 배열 제거, 서비스 직접 연결
+- `src/app/(admin)/admin/orders/_components/AdminOrdersTemplate.tsx`, `.../mockOrders.ts` — 상태 라벨 상수 중복 제거(F1)
+
+## 4. 초안(그릴링 없이 즉흥 작성됐던 이전 세션 코드) 대비 실질 변경 — 설계 재검토로 잡힌 것
+
+전부 `01_api_contract.md` §8에 근거 명시. 핵심만:
+
+1. 매출/결제주문 기준 시각 `createdAt` → `confirmedAt` (가상계좌 입금월 불일치 방지)
+2. "주문" 카드 모집단을 매출과 통일(결제 완료만) — 안 그러면 옆 카드와 나눠 낸 객단가가 틀린 값
+3. 월 경계를 서버 로컬 TZ(UTC)에서 KST 명시로 수정 — 9시간 어긋남 버그
+4. 필드명 8개 규칙 통일(`{지표}ThisMonth/PreviousMonth`)
+5. 서비스 에러 처리 누락(raw mongoose 에러 누출) 수정 — `AppError` 래핑
+6. 쿼리 9개 → 4개로 병합
+7. trend 색상 버그 수정(기존 mock 코드가 무조건 `text-primary`라 매출 감소도 긍정색)
+
+## 5. 운영 데이터 전제조건 — 리더가 직접 실측, 전부 해소
+
+- `confirmedAt` 결측: 0건 (결제 완료 주문 총 1건 중)
+- `User.isDelete` 결측: 0건
+
+둘 다 읽기 전용 확인이었고 backfill 쓰기는 발생하지 않았다.
+
+## 6. 스코프 밖 — 별도 Issue 등록 대상
+
+| # | 항목 | 근거 |
+|---|---|---|
+| 1 | `src/core/utils/category.test.ts`의 `getSubCategoryOptions` 2건(favor/ceremony) 선행 실패 | 이 기능과 무관 — 변경 0인 `dev`에서도 동일 실패. `dea757c`(서브카테고리 5종 추가) 때 테스트 미갱신으로 추정. CI(`static.yml`)는 vitest를 안 돌려 PR을 막지 않음 |
+| 2 | `src/db/connect.ts`의 `dbConnect()`가 에러를 `AppError`로 안 감쌈 | `services/AGENTS.md` 규약과 어긋나지만 이 브랜치가 도입한 편차 아님 — 전 서비스 공통 기존 패턴 |
+| 3 | `/admin/orders`가 여전히 `MOCK_ORDERS` 기반 | 설계 단계에서 스코프 밖 합의. 단 이번에 추가한 `{createdAt:-1}` 인덱스가 그쪽 실데이터 전환의 DB 선행조건을 이미 충족시켜둠 |
+| 4 | Product/User 소프트 삭제 컨벤션 불일치(`deletedAt` vs `isDelete`) | 통일하려면 전 문서 backfill + 쿼리 전수 수정 필요, 별도 작업 |
+
+## 7. Phase 4 위임 사항
+
+test-suite에게 골든패스 통합 테스트 작성 요청 예정. 이미 unit/integration 레벨 커버리지(서비스 11건, Template 4케이스, 유틸 다수)가 두터운 편이라, Phase 4는 **E2E 관점(admin 로그인 → 대시보드 진입 → 실제 렌더 확인)** 에 집중해도 될 것으로 판단.

--- a/_workspace/feat/admin-dashboard-real-data/04_test_report.md
+++ b/_workspace/feat/admin-dashboard-real-data/04_test_report.md
@@ -1,0 +1,103 @@
+# 04 — 테스트 리포트: admin 대시보드 실데이터 연결
+
+> 작성: test-suite (Phase 4)
+> 대상 브랜치: `feat/admin-dashboard-real-data` (워크트리 아님, 표준 브랜치에 직접 작업)
+
+---
+
+## 1. 착수 전 커버리지 파악 — 무엇이 이미 덮여 있었는가
+
+`04_integration_report.md`와 기존 테스트 파일을 먼저 읽고 확인한 결과:
+
+| 계층 | 파일 | 케이스 수 | 커버 범위 |
+|---|---|---|---|
+| Service | `src/services/dashboard.integration.test.ts` | 11 | `getDashboardStatsService`의 DB 집계 로직(저량/유량 지표, KST 월 경계, soft delete 필터, `confirmedAt` 기준 매출, `recentOrders` 정렬/개수, 에러 래핑) |
+| Template | `src/app/(admin)/admin/dashboard/_components/AdminDashboardTemplate.test.tsx` | 4 | 순수 렌더 계약(상태 A 정상, C trend 생략, D 빈 최근주문, C+D 오픈 첫 달 통합) |
+| Auth | `src/services/auth.integration.test.ts` | — | `verifySession`의 redirect 계약(세션 없음/role 불일치/성공) 이미 촘촘히 커버 |
+
+**빈 곳**: `page.tsx`가 이 세 계층을 실제로 올바르게 연결하는지 — DB → 실제 `getDashboardStatsService()` → `page.tsx` → `AdminDashboardTemplate`의 `stats` prop으로 데이터가 정확히 배선되는지, 그리고 `verifySession("ADMIN")`이 page.tsx에서 실제로 그 인자로 호출되고 실패 시 뒤 단계(DB 집계)를 건너뛰는지를 확인하는 테스트가 없었다. 이 경계가 이번 Phase 4의 대상이다.
+
+---
+
+## 2. 추가한 테스트
+
+**신규 파일**: `src/app/(admin)/admin/dashboard/page.integration.test.ts` (4케이스)
+
+기존 선례 `src/app/(main)/page.integration.test.ts`(홈 페이지 통합 테스트)와 `src/app/api/order/route.integration.test.ts`(route의 auth partial mock)의 패턴을 그대로 따랐다. `page.tsx`의 JSX는 함수 호출이 아니라 엘리먼트 서술자라 `await page()`가 반환한 엘리먼트의 `props`만 검사하면 하위 Template 바디는 실행되지 않는다 — 그래서 jsdom도 렌더링도 필요 없다(`@vitest-environment node`).
+
+인증 경계는 `verifySession` 함수 자체를 다시 검증하지 않고 partial mock(`vi.mock("@/services", ...)`)으로 role만 제어 가능하게 대체했다 — 세션/쿠키/JWT 발급 메커니즘은 이 페이지의 검증 대상이 아니라는 `route.integration.test.ts`의 기존 원칙을 그대로 적용했다.
+
+| # | 시나리오 | 검증 내용 |
+|---|---|---|
+| 1 | 골든패스 | 상품 1건(`createProductService`) + 결제 완료 주문 1건(`createOrderService` → `CONFIRMED`/`confirmedAt` 설정) + 회원 1건을 실제 DB에 시딩 → `page()` 호출 → `verifySession`이 정확히 `"ADMIN"` 인자로 호출됐는지, `getDashboardStatsService`가 1회 호출됐는지, 반환된 엘리먼트의 `props.stats`가 시딩한 실제 값(totalProducts, totalUsers, paidOrderCountThisMonth, revenueThisMonth, recentOrders 1건의 merchantUid)과 일치하는지 확인 |
+| 2 | 빈 DB 상태(상태 C+D 조합) | `01_ui_flow.md` §5.1이 "머지 직후 관리자가 실제로 보게 될 화면"이라고 명시한 케이스 — DB에 아무것도 시딩하지 않고 `page()` 호출 → 8개 스칼라 전부 0, `recentOrders: []`가 예외 없이 `props.stats`로 전달되는지 `toEqual`로 전체 shape 검증 |
+| 3 | 회귀: 비인가(role 불일치) | `role: "USER"`로 `page()` 호출 → `verifySession("ADMIN")`이 호출되고 reject되는지, 그 이후 단계인 `getDashboardStatsService`가 **호출되지 않는지**(`01_ui_flow.md` §6 "순차 await, `Promise.all` 아님" 계약의 실행 확인 — 인가 실패 시 DB 집계 자체가 안 돌아야 한다) |
+| 4 | 회귀: 미인증 | `role: null`로 `page()` 호출 → `/login`으로의 redirect 계약이 유지되는지, `getDashboardStatsService` 미호출 확인 |
+
+시나리오 3·4는 사용자 요청의 "가벼운 회귀 확인"에 해당한다 — `verifySession` 자체의 분기 로직은 `auth.integration.test.ts`가 이미 담당하므로, 여기서는 "page.tsx가 그 계약을 실제로 올바르게 소비하는가"만 확인했다.
+
+### 발견한 버그
+없음. 시나리오 3·4를 작성하며 `Promise.all`이 아닌 순차 `await` 계약이 실제로 지켜지고 있음을 확인했고(만약 `Promise.all`이었다면 `getDashboardStatsService` mock이 호출됐을 것), boundary-verifier가 이미 잡아낸 배선과 일치했다.
+
+---
+
+## 3. 테스트 인프라 변경
+
+`vitest.config.ts`의 `integration` project `include` 목록에 신규 파일 경로를 1줄 추가했다(기존 `src/app/(main)/page.integration.test.ts`와 동일한 방식 — 이 프로젝트는 app 라우터 page 레벨 통합 테스트를 명시적 파일 단위 allowlist로 관리한다).
+
+```diff
+  "src/app/(main)/page.integration.test.ts",
+  "src/app/(main)/_components/PopularProductsSection.integration.test.tsx",
++ "src/app/(admin)/admin/dashboard/page.integration.test.ts",
+```
+
+---
+
+## 4. 실행 결과
+
+### 4.1 신규 테스트 단독 실행
+```
+npx vitest run --project integration "src/app/(admin)/admin/dashboard/page.integration.test.ts"
+Test Files  1 passed (1)
+     Tests  4 passed (4)
+```
+
+### 4.2 전체 스위트 (2회 재현, 동일 결과)
+```
+npx vitest run
+Test Files  3 failed | 138 passed (141)
+     Tests  4 failed | 832 passed (836)
+```
+
+**실패 4건 — 전부 이 기능과 무관, `dev` 브랜치에서도 동일하게 실패(신규 회귀 아님)**:
+
+| 파일 | 케이스 | 비고 |
+|---|---|---|
+| `src/core/utils/category.test.ts` | favor/ceremony 서브카테고리 2건 | `04_integration_report.md` §6에 리더가 이미 기록한 기존 결함(`dea757c` 서브카테고리 5종 추가 시 테스트 미갱신 추정) |
+| `src/adapters/browser/cloudinary/widget.test.ts` | 크롭 가능한 단일 이미지 위젯 초기화 1건 | **이번 스위트 실행에서 새로 확인**. 미보고 상태였음 — 아래 §5 참고 |
+| `src/app/(preview)/preview/[publicKey]/_utils/invitationMessage.mapper.test.ts` | 부모 연락처 관계 표시 1건 | **이번 스위트 실행에서 새로 확인**. 미보고 상태였음 — 아래 §5 참고 |
+
+이 브랜치(`feat/admin-dashboard-real-data`)는 `dev` 최신 커밋(`d1da0af`)에서 분기했고, `git diff dev...HEAD --stat` 확인 결과 이 3개 파일 중 어느 것도 이 브랜치가 건드리지 않았다. `cloudinary/widget.test.ts`와 `invitationMessage.mapper.test.ts`를 격리 실행해도 동일하게 실패해 테스트 오염이 아님을 확인했다. 즉 4건 전부 `dev` 상태 그대로의 기존 실패이며, 이 기능이 만든 회귀가 아니다.
+
+### 4.3 Lint / 타입체크
+- `npx eslint "src/app/(admin)/admin/dashboard/page.integration.test.ts" "vitest.config.ts"` → 0 errors, 0 warnings
+- `npx tsc --noEmit` → 0 errors
+- (참고: `npm run lint`를 리포지토리 루트에서 그대로 돌리면 다른 세션의 워크트리(`.claude/worktrees/fix-admin-route-navigation/`)에 있는 vendored 파일까지 스캔해 무관한 대량 오류가 섞여 나온다 — 이번 변경분만 범위를 좁혀 별도 확인함)
+
+---
+
+## 5. 스코프 밖 — 별도 확인 권고
+
+`cloudinary/widget.test.ts`·`invitationMessage.mapper.test.ts` 실패 2건은 `04_integration_report.md` §6에 아직 기록돼 있지 않다. admin 대시보드 기능과 무관하고 설계 변경 없이 고칠 수 있는 성격의 버그도 아니라 이번 스코프에서 고치지 않았다(에이전트 지침상 사소한 수정만 직접 고치고 그 외는 플래그만 남기게 되어 있음) — 리더가 `04_integration_report.md` §6 표에 3·4번 항목으로 추가하거나 별도 Issue 등록을 검토해야 한다.
+
+---
+
+## 6. 완료 기준 체크
+
+- [x] 골든패스 통합 테스트(DB 시딩 → 실제 렌더 데이터) 작성
+- [x] 빈 상태(상태 C+D) 회귀 테스트 작성 — `01_ui_flow.md` §5.1 명시 케이스
+- [x] 비인가/미인증 회귀 확인(가벼운 수준)
+- [x] `npm run test` 전체 스위트 실행·통과 확인(신규 실패 0건, 기존 무관 실패 4건은 `dev`에서도 동일)
+- [x] lint(신규/변경 파일 범위) 통과
+- [x] tsc 통과
+- [x] 표준 브랜치에 직접 작업(워크트리 미사용)

--- a/src/app/(admin)/admin/dashboard/_components/AdminDashboardTemplate.test.tsx
+++ b/src/app/(admin)/admin/dashboard/_components/AdminDashboardTemplate.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import type { DashboardRecentOrder, DashboardStats } from "@/core/domain";
+import { AdminDashboardTemplate } from "./AdminDashboardTemplate";
+
+const buildRecentOrder = (
+  overrides?: Partial<DashboardRecentOrder>,
+): DashboardRecentOrder => ({
+  merchantUid: "TK-20260821-0142",
+  buyerName: "김민준",
+  productTitle: "봄빛 청첩장 세트",
+  finalPrice: 31000,
+  orderStatus: "CONFIRMED",
+  createdAt: new Date("2026-08-27T10:00:00.000Z"),
+  ...overrides,
+});
+
+const buildStats = (overrides?: Partial<DashboardStats>): DashboardStats => ({
+  totalProducts: 24,
+  productsCreatedThisMonth: 2,
+  totalUsers: 342,
+  usersCreatedThisMonth: 23,
+  revenueThisMonth: 1234000,
+  revenuePreviousMonth: 1000000,
+  paidOrderCountThisMonth: 89,
+  paidOrderCountPreviousMonth: 80,
+  recentOrders: [buildRecentOrder()],
+  ...overrides,
+});
+
+const getCard = (titleText: string) => {
+  const title = screen.getByText(titleText);
+  const card = title.closest('[data-slot="card"]');
+  if (!card) throw new Error(`카드(${titleText})를 찾지 못했습니다`);
+  return within(card as HTMLElement);
+};
+
+describe("AdminDashboardTemplate", () => {
+  it("① 정상 상태: 카드 4개 값/trend와 최근 주문 테이블을 렌더링한다", () => {
+    render(<AdminDashboardTemplate stats={buildStats()} />);
+
+    expect(getCard("등록 상품").getByText("24")).toBeInTheDocument();
+    expect(getCard("등록 상품").getByText("+2개 이번 달")).toBeInTheDocument();
+
+    expect(getCard("총 매출").getByText("₩1,234,000")).toBeInTheDocument();
+    expect(getCard("총 매출").getByText("+23.4% 지난 달 대비")).toBeInTheDocument();
+
+    expect(getCard("결제 주문").getByText("89")).toBeInTheDocument();
+    expect(getCard("결제 주문").getByText("+11.3% 지난 달 대비")).toBeInTheDocument();
+
+    expect(getCard("활동 회원").getByText("342")).toBeInTheDocument();
+    expect(getCard("활동 회원").getByText("+23명 이번 달")).toBeInTheDocument();
+
+    expect(screen.getByText("TK-20260821-0142")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "전체 보기" })).toHaveAttribute(
+      "href",
+      "/admin/orders",
+    );
+  });
+
+  it("② 전월 실적이 0이면 매출/결제주문 trend 줄이 렌더되지 않는다 (상태 C)", () => {
+    render(
+      <AdminDashboardTemplate
+        stats={buildStats({
+          revenuePreviousMonth: 0,
+          paidOrderCountPreviousMonth: 0,
+        })}
+      />,
+    );
+
+    expect(screen.queryByText(/지난 달 대비/)).not.toBeInTheDocument();
+    // 저량 지표(상품/회원) trend는 이번 달 증가분 기준이라 영향받지 않는다.
+    expect(getCard("등록 상품").getByText("+2개 이번 달")).toBeInTheDocument();
+  });
+
+  it("③ recentOrders가 빈 배열이면 빈 상태 문구를 렌더링하고 카드 4개는 정상 렌더된다 (상태 D)", () => {
+    render(<AdminDashboardTemplate stats={buildStats({ recentOrders: [] })} />);
+
+    expect(screen.getByText("아직 주문이 없습니다")).toBeInTheDocument();
+    expect(
+      screen.getByText("첫 주문이 들어오면 여기에 표시됩니다."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+
+    expect(getCard("등록 상품").getByText("24")).toBeInTheDocument();
+    expect(getCard("총 매출").getByText("₩1,234,000")).toBeInTheDocument();
+  });
+
+  it("④ 오픈 첫 달 통합(전 지표 0 + 주문 0건): 값 0은 그대로 렌더되고 trend 줄은 전부 생략된다 (상태 C+D)", () => {
+    render(
+      <AdminDashboardTemplate
+        stats={{
+          totalProducts: 0,
+          productsCreatedThisMonth: 0,
+          totalUsers: 0,
+          usersCreatedThisMonth: 0,
+          revenueThisMonth: 0,
+          revenuePreviousMonth: 0,
+          paidOrderCountThisMonth: 0,
+          paidOrderCountPreviousMonth: 0,
+          recentOrders: [],
+        }}
+      />,
+    );
+
+    expect(getCard("등록 상품").getByText("0")).toBeInTheDocument();
+    expect(getCard("총 매출").getByText("₩0")).toBeInTheDocument();
+    expect(getCard("결제 주문").getByText("0")).toBeInTheDocument();
+    expect(getCard("활동 회원").getByText("0")).toBeInTheDocument();
+
+    expect(screen.queryByText(/이번 달$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/지난 달 대비/)).not.toBeInTheDocument();
+
+    expect(screen.getByText("아직 주문이 없습니다")).toBeInTheDocument();
+  });
+});

--- a/src/app/(admin)/admin/dashboard/_components/AdminDashboardTemplate.tsx
+++ b/src/app/(admin)/admin/dashboard/_components/AdminDashboardTemplate.tsx
@@ -1,0 +1,130 @@
+import { DollarSign, Package, ShoppingCart, Users } from "lucide-react";
+import type { ComponentType } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  TypographyMuted,
+  TypographySmall,
+} from "@/ui/components/atoms";
+import type { DashboardStats } from "@/core/domain";
+import { cn, formatPriceWithComma, formatSignedPercent } from "@/core/utils";
+import { RecentOrdersCard } from "./RecentOrdersCard";
+
+type TrendDirection = "up" | "down" | "flat";
+
+type StatTrend = {
+  label: string;
+  direction: TrendDirection;
+};
+
+type StatCard = {
+  title: string;
+  icon: ComponentType<{ className?: string }>;
+  value: string;
+  description: string;
+  trend: StatTrend | null;
+};
+
+const TREND_DIRECTION_CLASS: Record<TrendDirection, string> = {
+  up: "text-primary",
+  down: "text-destructive",
+  flat: "text-muted-foreground",
+};
+
+interface AdminDashboardTemplateProps {
+  stats: DashboardStats;
+}
+
+const AdminDashboardTemplate = ({ stats }: AdminDashboardTemplateProps) => {
+  const revenueTrend = formatSignedPercent(
+    stats.revenueThisMonth,
+    stats.revenuePreviousMonth,
+  );
+  const paidOrderTrend = formatSignedPercent(
+    stats.paidOrderCountThisMonth,
+    stats.paidOrderCountPreviousMonth,
+  );
+
+  const statCards: StatCard[] = [
+    {
+      title: "등록 상품",
+      icon: Package,
+      value: stats.totalProducts.toLocaleString(),
+      description: "삭제 제외 전체 상품",
+      trend:
+        stats.productsCreatedThisMonth > 0
+          ? { label: `+${stats.productsCreatedThisMonth}개 이번 달`, direction: "up" }
+          : null,
+    },
+    {
+      title: "총 매출",
+      icon: DollarSign,
+      value: `₩${formatPriceWithComma(stats.revenueThisMonth)}`,
+      description: "이번 달 결제 완료 기준",
+      trend: revenueTrend
+        ? { label: `${revenueTrend.label} 지난 달 대비`, direction: revenueTrend.direction }
+        : null,
+    },
+    {
+      title: "결제 주문",
+      icon: ShoppingCart,
+      value: stats.paidOrderCountThisMonth.toLocaleString(),
+      description: "이번 달 결제 완료 주문",
+      trend: paidOrderTrend
+        ? { label: `${paidOrderTrend.label} 지난 달 대비`, direction: paidOrderTrend.direction }
+        : null,
+    },
+    {
+      title: "활동 회원",
+      icon: Users,
+      value: stats.totalUsers.toLocaleString(),
+      description: "탈퇴 제외 가입 회원",
+      trend:
+        stats.usersCreatedThisMonth > 0
+          ? { label: `+${stats.usersCreatedThisMonth}명 이번 달`, direction: "up" }
+          : null,
+    },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <TypographyMuted>
+        모바일 청첩장 관리자 대시보드에 오신 것을 환영합니다.
+      </TypographyMuted>
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {statCards.map((stat) => (
+          <Card key={stat.title}>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-muted-foreground text-sm font-medium">
+                {stat.title}
+              </CardTitle>
+              <stat.icon className="text-muted-foreground h-4 w-4" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-foreground mb-1 text-2xl font-bold">
+                {stat.value}
+              </div>
+              <TypographyMuted className="mb-1">
+                {stat.description}
+              </TypographyMuted>
+              {stat.trend && (
+                <TypographySmall
+                  className={cn(TREND_DIRECTION_CLASS[stat.trend.direction], "font-medium")}
+                >
+                  {stat.trend.label}
+                </TypographySmall>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <RecentOrdersCard orders={stats.recentOrders} />
+    </div>
+  );
+};
+
+export { AdminDashboardTemplate };

--- a/src/app/(admin)/admin/dashboard/_components/RecentOrdersCard.tsx
+++ b/src/app/(admin)/admin/dashboard/_components/RecentOrdersCard.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  TypographyMuted,
+} from "@/ui/components/atoms";
+import type { DashboardRecentOrder } from "@/core/domain";
+import {
+  ORDER_STATUS_BADGE_VARIANTS,
+  ORDER_STATUS_LABELS,
+  routes,
+} from "@/core/domain";
+import { formatPriceWithComma, formatRelativeTime } from "@/core/utils";
+
+interface RecentOrdersCardProps {
+  orders: DashboardRecentOrder[];
+}
+
+const RecentOrdersCard = ({ orders }: RecentOrdersCardProps) => {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>최근 주문</CardTitle>
+        <Link
+          href={routes.admin.orders}
+          className="text-muted-foreground text-sm hover:underline"
+        >
+          전체 보기
+        </Link>
+      </CardHeader>
+      <CardContent>
+        {orders.length === 0 ? (
+          <div className="flex flex-col items-center gap-1 py-12 text-center">
+            <p className="text-sm font-medium">아직 주문이 없습니다</p>
+            <TypographyMuted>
+              첫 주문이 들어오면 여기에 표시됩니다.
+            </TypographyMuted>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-muted border-b">
+                <tr>
+                  <th className="px-4 py-3 text-left text-sm font-semibold">
+                    주문번호
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold">
+                    고객명
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold">
+                    상품
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold">
+                    상태
+                  </th>
+                  <th className="px-4 py-3 text-right text-sm font-semibold">
+                    금액
+                  </th>
+                  <th className="px-4 py-3 text-right text-sm font-semibold">
+                    시간
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {orders.map((order) => (
+                  <tr
+                    key={order.merchantUid}
+                    className="hover:bg-muted/50 transition-colors"
+                  >
+                    <td className="px-4 py-3 text-sm">{order.merchantUid}</td>
+                    <td className="px-4 py-3 text-sm">{order.buyerName}</td>
+                    <td className="max-w-[16rem] truncate px-4 py-3 text-sm">
+                      {order.productTitle}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge variant={ORDER_STATUS_BADGE_VARIANTS[order.orderStatus]}>
+                        {ORDER_STATUS_LABELS[order.orderStatus]}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 text-right text-sm font-semibold">
+                      {formatPriceWithComma(order.finalPrice)}원
+                    </td>
+                    <td className="text-muted-foreground px-4 py-3 text-right text-sm">
+                      {formatRelativeTime(order.createdAt)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export { RecentOrdersCard };

--- a/src/app/(admin)/admin/dashboard/_components/index.tsx
+++ b/src/app/(admin)/admin/dashboard/_components/index.tsx
@@ -1,0 +1,1 @@
+export { AdminDashboardTemplate } from "./AdminDashboardTemplate";

--- a/src/app/(admin)/admin/dashboard/page.integration.test.ts
+++ b/src/app/(admin)/admin/dashboard/page.integration.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+//
+// page.tsx가 verifySession → getDashboardStatsService → AdminDashboardTemplate로
+// 이어지는 배선을 실제로 올바르게 연결하는지 검증한다. 서비스 내부 집계 로직
+// 자체는 src/services/dashboard.integration.test.ts(11건)가, Template 렌더
+// 계약(상태 A~D)은 AdminDashboardTemplate.test.tsx(4케이스)가 이미 담당하므로
+// 여기서 다시 검증하지 않는다. (main)/page.integration.test.ts와 같은 이유로
+// JSX는 함수 호출이 아니라 엘리먼트 서술자라, `await page()`가 반환한 엘리먼트의
+// props만 검사하고 렌더링은 하지 않는다(jsdom 불필요, 하위 Template 바디도
+// 실행되지 않는다).
+//
+// 인증 경계는 auth.integration.test.ts가 verifySession() 자체의 redirect 계약을
+// (세션 없음/role 불일치/성공 3가지) 이미 촘촘히 덮고 있다. 여기서는 그 함수
+// 자체를 다시 검증하지 않고, "page.tsx가 verifySession('ADMIN')을 실제로 그
+// 인자로 호출하는지"와 "실패 시 뒤 단계(getDashboardStatsService)로 진행하지
+// 않는지"(01_ui_flow.md §6 "순차 await, Promise.all 아님" 계약)만 회귀 확인한다
+// — route.integration.test.ts가 requireAuth를 partial mock으로 대체하는 것과
+// 같은 원리(세션/쿠키/JWT 발급 자체는 이 페이지의 검증 대상이 아니다).
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import mongoose from "mongoose";
+import type * as ServicesModule from "@/services";
+import { dbConnect } from "@/db";
+import {
+  buildOrderInput,
+  buildProductInput,
+  buildUserInput,
+  clearCollections,
+} from "@testing/support";
+import { OrderModel, ProductModel } from "@/models";
+
+const { authState } = vi.hoisted(() => ({
+  authState: { role: "ADMIN" as "ADMIN" | "USER" | null },
+}));
+
+vi.mock("@/services", async (importOriginal) => {
+  const actual = await importOriginal<typeof ServicesModule>();
+  return {
+    ...actual,
+    verifySession: vi.fn(async (requiredRole?: string) => {
+      if (!authState.role) {
+        throw new Error("REDIRECT:/login");
+      }
+      if (requiredRole && authState.role !== requiredRole) {
+        throw new Error("REDIRECT:/");
+      }
+      return {
+        userId: "admin-id",
+        email: "admin@example.com",
+        role: authState.role,
+      };
+    }),
+    getDashboardStatsService: vi.fn(actual.getDashboardStatsService),
+  };
+});
+
+import {
+  createOrderService,
+  createProductService,
+  getDashboardStatsService,
+  verifySession,
+} from "@/services";
+import { UserModel } from "@/models";
+import page from "./page";
+
+describe("(admin)/admin/dashboard/page — 통합(DB~page.tsx 데이터 배선)", () => {
+  beforeEach(async () => {
+    await dbConnect();
+    await clearCollections();
+    authState.role = "ADMIN";
+    vi.mocked(verifySession).mockClear();
+    vi.mocked(getDashboardStatsService).mockClear();
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  it("골든패스: DB에 시딩한 실제 데이터가 getDashboardStatsService를 거쳐 AdminDashboardTemplate의 stats prop으로 그대로 전달된다", async () => {
+    const productInput = buildProductInput({ title: "실데이터 검증용 상품" });
+    await createProductService(productInput);
+    const product = await ProductModel.findOne({
+      title: productInput.title,
+    }).lean();
+
+    const orderInput = buildOrderInput();
+    const order = await createOrderService({
+      ...orderInput,
+      product: { ...orderInput.product, productId: product!._id.toString() },
+    });
+    // createdAt/confirmedAt은 timestamps 옵션으로 채워지고 immutable로 잠기므로
+    // 두 보호를 모두 풀어야 한다(dashboard.integration.test.ts와 동일 패턴).
+    await OrderModel.updateOne(
+      { _id: order._id },
+      { $set: { orderStatus: "CONFIRMED", confirmedAt: new Date() } },
+      { timestamps: false, overwriteImmutable: true },
+    );
+
+    await UserModel.create(buildUserInput());
+
+    const element = (await page()) as any;
+
+    expect(verifySession).toHaveBeenCalledWith("ADMIN");
+    expect(getDashboardStatsService).toHaveBeenCalledTimes(1);
+
+    const stats = element.props.stats;
+    expect(stats.totalProducts).toBe(1);
+    expect(stats.totalUsers).toBe(1);
+    expect(stats.paidOrderCountThisMonth).toBe(1);
+    expect(stats.revenueThisMonth).toBe(order.finalPrice);
+    expect(stats.recentOrders).toHaveLength(1);
+    expect(stats.recentOrders[0].merchantUid).toBe(order.merchantUid);
+  });
+
+  it("빈 DB 상태(상태 C+D — 머지 직후 실제로 보게 될 화면, 01_ui_flow.md §5.1): 주문/상품/회원이 0건이어도 에러 없이 렌더되고 전 지표가 0·recentOrders는 빈 배열로 전달된다", async () => {
+    const element = (await page()) as any;
+
+    expect(element.props.stats).toEqual({
+      totalProducts: 0,
+      productsCreatedThisMonth: 0,
+      totalUsers: 0,
+      usersCreatedThisMonth: 0,
+      revenueThisMonth: 0,
+      revenuePreviousMonth: 0,
+      paidOrderCountThisMonth: 0,
+      paidOrderCountPreviousMonth: 0,
+      recentOrders: [],
+    });
+  });
+
+  it("회귀: ADMIN이 아닌 세션이면 verifySession이 거부하고 getDashboardStatsService는 호출되지 않는다", async () => {
+    authState.role = "USER";
+
+    await expect(page()).rejects.toThrow("REDIRECT:/");
+
+    expect(verifySession).toHaveBeenCalledWith("ADMIN");
+    expect(getDashboardStatsService).not.toHaveBeenCalled();
+  });
+
+  it("회귀: 미인증 세션이면 로그인 페이지로 redirect되고 getDashboardStatsService는 호출되지 않는다", async () => {
+    authState.role = null;
+
+    await expect(page()).rejects.toThrow("REDIRECT:/login");
+
+    expect(getDashboardStatsService).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -1,83 +1,11 @@
 export const dynamic = "force-dynamic";
 
-import { Card, CardContent, CardHeader, CardTitle, TypographyMuted, TypographySmall } from "@/ui/components/atoms";
-import { Package, DollarSign, ShoppingCart, Users } from "lucide-react";
-import { verifySession } from "@/services";
+import { verifySession, getDashboardStatsService } from "@/services";
+import { AdminDashboardTemplate } from "./_components";
 
 export default async function AdminDashboard() {
   await verifySession("ADMIN");
+  const stats = await getDashboardStatsService();
 
-  const stats = [
-    {
-      title: "총 상품",
-      value: "24",
-      icon: Package,
-      description: "등록된 템플릿 수",
-      trend: "+2 이번 달",
-    },
-    {
-      title: "총 매출",
-      value: "₩1,234,000",
-      icon: DollarSign,
-      description: "이번 달 매출",
-      trend: "+12.5% 지난 달 대비",
-    },
-    {
-      title: "주문",
-      value: "89",
-      icon: ShoppingCart,
-      description: "이번 달 주문 수",
-      trend: "+8 지난 주 대비",
-    },
-    {
-      title: "회원",
-      value: "342",
-      icon: Users,
-      description: "총 회원 수",
-      trend: "+23 이번 달",
-    },
-  ];
-
-  return (
-    <div className="space-y-8">
-      <div>
-        <TypographyMuted>
-          모바일 청첩장 관리자 대시보드에 오신 것을 환영합니다.
-        </TypographyMuted>
-      </div>
-
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {stats.map((stat) => (
-          <Card key={stat.title}>
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-muted-foreground text-sm font-medium">
-                {stat.title}
-              </CardTitle>
-              <stat.icon className="text-muted-foreground h-4 w-4" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-foreground mb-1 text-2xl font-bold">
-                {stat.value}
-              </div>
-              <TypographyMuted className="mb-1">
-                {stat.description}
-              </TypographyMuted>
-              <TypographySmall className="text-primary font-medium">{stat.trend}</TypographySmall>
-            </CardContent>
-          </Card>
-        ))}
-      </section>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>최근 활동</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <TypographyMuted>
-            최근 활동 내역이 여기에 표시됩니다.
-          </TypographyMuted>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <AdminDashboardTemplate stats={stats} />;
 }

--- a/src/app/(admin)/admin/orders/_components/AdminOrdersTemplate.tsx
+++ b/src/app/(admin)/admin/orders/_components/AdminOrdersTemplate.tsx
@@ -12,11 +12,8 @@ import {
   TypographyMuted,
 } from "@/ui/components/atoms";
 import type { OrderStatus } from "@/core/domain";
-import {
-  MOCK_ORDERS,
-  ORDER_STATUS_BADGE_VARIANTS,
-  ORDER_STATUS_LABELS,
-} from "../_constants";
+import { ORDER_STATUS_BADGE_VARIANTS, ORDER_STATUS_LABELS } from "@/core/domain";
+import { MOCK_ORDERS } from "../_constants";
 
 const STATUS_FILTER_OPTIONS: Array<{ value: OrderStatus | "ALL"; label: string }> = [
   { value: "ALL", label: "전체 상태" },

--- a/src/app/(admin)/admin/orders/_constants/mockOrders.ts
+++ b/src/app/(admin)/admin/orders/_constants/mockOrders.ts
@@ -39,20 +39,3 @@ export const MOCK_ORDERS: MockOrder[] = [
     finalPrice: 28000,
   },
 ];
-
-export const ORDER_STATUS_LABELS: Record<OrderStatus, string> = {
-  PENDING: "주문대기",
-  CONFIRMED: "결제완료",
-  COMPLETED: "완료",
-  CANCELLED: "취소",
-};
-
-export const ORDER_STATUS_BADGE_VARIANTS: Record<
-  OrderStatus,
-  "default" | "secondary" | "destructive" | "outline"
-> = {
-  PENDING: "secondary",
-  CONFIRMED: "default",
-  COMPLETED: "default",
-  CANCELLED: "destructive",
-};

--- a/src/core/domain/dashboard.ts
+++ b/src/core/domain/dashboard.ts
@@ -1,0 +1,44 @@
+import type { OrderStatus } from "./order";
+
+/** 대시보드 "최근 주문" 한 행 — 화면이 실제로 그리는 필드만 추린다. */
+export interface DashboardRecentOrder {
+  /** 행 key 겸 관리자에게 보이는 주문 식별자. Order 컬렉션에서 unique다. */
+  merchantUid: string;
+  buyerName: string;
+  /** DB의 product.title(주문 시점 스냅샷)을 평탄화한 것. */
+  productTitle: string;
+  /** 원 단위 raw number — 통화 포맷은 UI가 한다. */
+  finalPrice: number;
+  /** raw enum — 라벨/배지는 ORDER_STATUS_LABELS / ORDER_STATUS_BADGE_VARIANTS 재사용. */
+  orderStatus: OrderStatus;
+  /** JSON 경계를 안 타므로 Date 그대로 UI까지 간다(string 아님). */
+  createdAt: Date;
+}
+
+export interface DashboardStats {
+  // ── 저량(stock) 지표 ────────────────────────────────
+  /** 소프트 삭제되지 않은 전체 상품 수(deletedAt: null). */
+  totalProducts: number;
+  /** 이번 달(KST) 등록된 상품 수. */
+  productsCreatedThisMonth: number;
+  /** 탈퇴하지 않은 전체 회원 수(isDelete: false). */
+  totalUsers: number;
+  /** 이번 달(KST) 가입한 회원 수. */
+  usersCreatedThisMonth: number;
+
+  // ── 유량(flow) 지표 ─────────────────────────────────
+  //    아래 4개는 모집단이 동일하다: orderStatus ∈ {CONFIRMED, COMPLETED}, confirmedAt 기준.
+  //    그래서 revenueThisMonth / paidOrderCountThisMonth = 평균 객단가가 성립한다.
+  /** 이번 달(KST) 결제 완료 매출 합계(원). */
+  revenueThisMonth: number;
+  /** 전월(KST) 결제 완료 매출 합계(원). 0이면 "전월 실적 없음"이다. */
+  revenuePreviousMonth: number;
+  /** 이번 달(KST) 결제 완료 주문 건수. */
+  paidOrderCountThisMonth: number;
+  /** 전월(KST) 결제 완료 주문 건수. */
+  paidOrderCountPreviousMonth: number;
+
+  // ── 최근 주문 ───────────────────────────────────────
+  /** createdAt desc 최대 5건. 상태 필터 없음. 주문이 없으면 빈 배열(REQ-2 빈 상태). */
+  recentOrders: DashboardRecentOrder[];
+}

--- a/src/core/domain/index.ts
+++ b/src/core/domain/index.ts
@@ -2,6 +2,7 @@ export type * from "./alert";
 export type * from "./announcement";
 export type * from "./checkout";
 export type * from "./couple-info";
+export type * from "./dashboard";
 export * from "./error";
 export * from "./error-messages";
 export type * from "./field";

--- a/src/core/domain/order.ts
+++ b/src/core/domain/order.ts
@@ -43,6 +43,23 @@ export type OrderStatus = (typeof ORDER_STATUSES)[number];
  *  services/payment.ts의 isPaymentAppliedStatus와 같은 정의를 공유한다. */
 export const PAID_ORDER_STATUSES = ["CONFIRMED", "COMPLETED"] as const;
 
+export const ORDER_STATUS_LABELS: Record<OrderStatus, string> = {
+  PENDING: "주문대기",
+  CONFIRMED: "결제완료",
+  COMPLETED: "완료",
+  CANCELLED: "취소",
+};
+
+export const ORDER_STATUS_BADGE_VARIANTS: Record<
+  OrderStatus,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  PENDING: "secondary",
+  CONFIRMED: "default",
+  COMPLETED: "default",
+  CANCELLED: "destructive",
+};
+
 export type OrderJSON = {
   _id: string;
   merchantUid: string;

--- a/src/core/domain/order.ts
+++ b/src/core/domain/order.ts
@@ -39,6 +39,10 @@ export const ORDER_STATUSES = [
 
 export type OrderStatus = (typeof ORDER_STATUSES)[number];
 
+/** 결제가 이미 반영된 주문 상태 — 매출/결제주문 집계의 모집단이다.
+ *  services/payment.ts의 isPaymentAppliedStatus와 같은 정의를 공유한다. */
+export const PAID_ORDER_STATUSES = ["CONFIRMED", "COMPLETED"] as const;
+
 export type OrderJSON = {
   _id: string;
   merchantUid: string;

--- a/src/core/utils/date.test.ts
+++ b/src/core/utils/date.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { getKstMonthRange } from "./date";
+
+describe("getKstMonthRange", () => {
+  it("월초 KST 경계 — 8/1 00:00(KST) 입력이면 이번 달은 8월, 지난 달은 7월, 다음 달은 9월이다", () => {
+    // 2026-08-01T00:00:00+09:00 === 2026-07-31T15:00:00Z
+    const now = new Date("2026-07-31T15:00:00.000Z");
+    const { startOfLastMonth, startOfThisMonth, startOfNextMonth } =
+      getKstMonthRange(now);
+
+    expect(startOfLastMonth.toISOString()).toBe("2026-06-30T15:00:00.000Z"); // 7/1 00:00 KST
+    expect(startOfThisMonth.toISOString()).toBe("2026-07-31T15:00:00.000Z"); // 8/1 00:00 KST
+    expect(startOfNextMonth.toISOString()).toBe("2026-08-31T15:00:00.000Z"); // 9/1 00:00 KST
+  });
+
+  it("월말 KST 경계 — 8/31 23:59:59(KST) 입력도 여전히 8월로 취급한다", () => {
+    // 2026-08-31T23:59:59+09:00 === 2026-08-31T14:59:59Z
+    const now = new Date("2026-08-31T14:59:59.000Z");
+    const { startOfThisMonth, startOfNextMonth } = getKstMonthRange(now);
+
+    expect(startOfThisMonth.toISOString()).toBe("2026-07-31T15:00:00.000Z"); // 8/1 00:00 KST
+    expect(startOfNextMonth.toISOString()).toBe("2026-08-31T15:00:00.000Z"); // 9/1 00:00 KST
+  });
+
+  it("UTC 기준 날짜와 9시간 어긋나는 경계 — UTC로는 8/31이지만 KST로는 이미 9/1이다", () => {
+    // 2026-08-31T15:00:00Z === 2026-09-01T00:00:00+09:00
+    // UTC 날짜만 보고 월 경계를 잡으면 "8월"로 오분류되지만, KST 기준으로는 9월이 시작된 시점이다.
+    const now = new Date("2026-08-31T15:00:00.000Z");
+    const { startOfLastMonth, startOfThisMonth, startOfNextMonth } =
+      getKstMonthRange(now);
+
+    expect(startOfThisMonth.toISOString()).toBe("2026-08-31T15:00:00.000Z"); // 9/1 00:00 KST — now 그 자체
+    expect(startOfLastMonth.toISOString()).toBe("2026-07-31T15:00:00.000Z"); // 8/1 00:00 KST
+    expect(startOfNextMonth.toISOString()).toBe("2026-09-30T15:00:00.000Z"); // 10/1 00:00 KST
+  });
+
+  it("1월 입력이면 전월 경계가 작년 12월이다(연도 롤오버)", () => {
+    // 2026-01-15T12:00:00+09:00 === 2026-01-15T03:00:00Z
+    const now = new Date("2026-01-15T03:00:00.000Z");
+    const { startOfLastMonth, startOfThisMonth, startOfNextMonth } =
+      getKstMonthRange(now);
+
+    expect(startOfLastMonth.toISOString()).toBe("2025-11-30T15:00:00.000Z"); // 2025-12-01 00:00 KST
+    expect(startOfThisMonth.toISOString()).toBe("2025-12-31T15:00:00.000Z"); // 2026-01-01 00:00 KST
+    expect(startOfNextMonth.toISOString()).toBe("2026-01-31T15:00:00.000Z"); // 2026-02-01 00:00 KST
+  });
+
+  it("파라미터를 생략하면 현재 시각 기준으로 세 경계를 반환한다(throw하지 않음)", () => {
+    const result = getKstMonthRange();
+
+    expect(result.startOfLastMonth.getTime()).toBeLessThan(
+      result.startOfThisMonth.getTime(),
+    );
+    expect(result.startOfThisMonth.getTime()).toBeLessThan(
+      result.startOfNextMonth.getTime(),
+    );
+  });
+});

--- a/src/core/utils/date.test.ts
+++ b/src/core/utils/date.test.ts
@@ -1,5 +1,55 @@
 import { describe, it, expect } from "vitest";
-import { getKstMonthRange } from "./date";
+import { formatRelativeTime, getKstMonthRange } from "./date";
+
+const SECOND = 1000;
+const MINUTE = SECOND * 60;
+const HOUR = MINUTE * 60;
+const DAY = HOUR * 24;
+
+describe("formatRelativeTime", () => {
+  const now = new Date("2026-08-27T12:00:00.000Z");
+
+  it("1분 미만이면 방금 전을 반환한다", () => {
+    const date = new Date(now.getTime() - 30 * SECOND);
+    expect(formatRelativeTime(date, now)).toBe("방금 전");
+  });
+
+  it("60분 미만이면 N분 전을 반환한다", () => {
+    const date = new Date(now.getTime() - 45 * MINUTE);
+    expect(formatRelativeTime(date, now)).toBe("45분 전");
+  });
+
+  it("정확히 60분이면 1시간 전으로 넘어간다", () => {
+    const date = new Date(now.getTime() - 60 * MINUTE);
+    expect(formatRelativeTime(date, now)).toBe("1시간 전");
+  });
+
+  it("24시간 미만이면 N시간 전을 반환한다", () => {
+    const date = new Date(now.getTime() - 5 * HOUR);
+    expect(formatRelativeTime(date, now)).toBe("5시간 전");
+  });
+
+  it("정확히 24시간이면 1일 전으로 넘어간다", () => {
+    const date = new Date(now.getTime() - 24 * HOUR);
+    expect(formatRelativeTime(date, now)).toBe("1일 전");
+  });
+
+  it("7일 미만이면 N일 전을 반환한다", () => {
+    const date = new Date(now.getTime() - 6 * DAY);
+    expect(formatRelativeTime(date, now)).toBe("6일 전");
+  });
+
+  it("정확히 7일 이상이면 KST 기준 절대 날짜(dot 포맷)로 폴백한다", () => {
+    const date = new Date(now.getTime() - 7 * DAY);
+    expect(formatRelativeTime(date, now)).toBe("2026.8.20");
+  });
+
+  it("폴백은 서버 로컬(UTC)이 아니라 Asia/Seoul 기준으로 날짜가 밀리지 않는다", () => {
+    // UTC 기준 2026-08-19T15:30:00Z = KST 2026-08-20 00:30 — UTC로 포맷하면 8/19로 하루 밀린다.
+    const date = new Date("2026-08-19T15:30:00.000Z");
+    expect(formatRelativeTime(date, now)).toBe("2026.8.20");
+  });
+});
 
 describe("getKstMonthRange", () => {
   it("월초 KST 경계 — 8/1 00:00(KST) 입력이면 이번 달은 8월, 지난 달은 7월, 다음 달은 9월이다", () => {

--- a/src/core/utils/date.ts
+++ b/src/core/utils/date.ts
@@ -110,3 +110,21 @@ export const formatDate = (date: string | Date, type: DateFormatType) => {
       return `${year}-${month}-${dayDate}`;
   }
 };
+
+const KST_TIMEZONE = "Asia/Seoul";
+
+/**
+ * 과거 시각과 기준 시각(now)의 차이를 상대 시간 문구로 변환한다.
+ * <1분 "방금 전", <60분 "N분 전", <24시간 "N시간 전", <7일 "N일 전",
+ * 그 이상은 KST(Asia/Seoul) 기준 `formatDate(date, "dot")` 폴백.
+ */
+export const formatRelativeTime = (date: Date, now: Date = new Date()): string => {
+  const diff = now.getTime() - date.getTime();
+
+  if (diff < MINUTE) return "방금 전";
+  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}분 전`;
+  if (diff < DAY) return `${Math.floor(diff / HOUR)}시간 전`;
+  if (diff < DAY * 7) return `${Math.floor(diff / DAY)}일 전`;
+
+  return formatDate(toZonedTime(date, KST_TIMEZONE), "dot");
+};

--- a/src/core/utils/date.ts
+++ b/src/core/utils/date.ts
@@ -1,3 +1,6 @@
+import { toZonedTime, fromZonedTime } from "date-fns-tz";
+import { startOfMonth, subMonths, addMonths } from "date-fns";
+
 const SECOND = 1000;
 const MINUTE = SECOND * 60;
 const HOUR = MINUTE * 60;
@@ -42,6 +45,16 @@ export const updateCountdownMessage = (
   if (minutes > 0) return `결혼식까지 ${minutes}분 남았습니다`;
 
   return "결혼식이 끝났습니다";
+};
+
+/** 주어진 시각이 속한 KST 기준 전월·이번 달·다음 달 경계를 UTC instant로 돌려준다. */
+export const getKstMonthRange = (now: Date = new Date()) => {
+  const zoned = toZonedTime(now, "Asia/Seoul");
+  return {
+    startOfLastMonth: fromZonedTime(startOfMonth(subMonths(zoned, 1)), "Asia/Seoul"),
+    startOfThisMonth: fromZonedTime(startOfMonth(zoned), "Asia/Seoul"),
+    startOfNextMonth: fromZonedTime(startOfMonth(addMonths(zoned, 1)), "Asia/Seoul"),
+  };
 };
 
 export type DateFormatType =

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -7,6 +7,7 @@ export * from "./escape-regexp";
 export * from "./hangul";
 export * from "./id";
 export * from "./page";
+export * from "./percent";
 export * from "./price";
 export * from "./seoul-open-api-parser";
 export * from "./sidebar";

--- a/src/core/utils/percent.test.ts
+++ b/src/core/utils/percent.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { formatSignedPercent } from "./percent";
+
+describe("formatSignedPercent", () => {
+  it("previous가 0이면 null을 반환한다(0 나눗셈 방지, 전월 실적 없음)", () => {
+    expect(formatSignedPercent(1000, 0)).toBeNull();
+  });
+
+  it("현재값이 더 크면 양수 label과 up 방향을 반환한다", () => {
+    expect(formatSignedPercent(1125, 1000)).toEqual({
+      label: "+12.5%",
+      direction: "up",
+    });
+  });
+
+  it("현재값이 더 작으면 음수 label과 down 방향을 반환한다", () => {
+    expect(formatSignedPercent(920, 1000)).toEqual({
+      label: "-8.0%",
+      direction: "down",
+    });
+  });
+
+  it("변화가 없으면 flat 방향을 반환한다", () => {
+    expect(formatSignedPercent(1000, 1000)).toEqual({
+      label: "0.0%",
+      direction: "flat",
+    });
+  });
+
+  it("previous가 음수라도 부호/방향을 정확히 계산한다", () => {
+    // (10 - (-10)) / -10 * 100 = -200%
+    expect(formatSignedPercent(10, -10)).toEqual({
+      label: "-200.0%",
+      direction: "down",
+    });
+  });
+});

--- a/src/core/utils/percent.ts
+++ b/src/core/utils/percent.ts
@@ -1,0 +1,26 @@
+export type SignedPercentTrend = {
+  label: string;
+  direction: "up" | "down" | "flat";
+};
+
+/**
+ * 전월 대비 증감률을 계산한다. `previous`가 0이면 0 나눗셈(→ "+∞%")을 피하기 위해
+ * `null`을 반환한다 — 서비스 오픈 첫 달처럼 전월 실적이 없는 경우가 상시 경로다.
+ * 부호/방향을 완성 문자열이 아니라 구조체로 반환해야 UI가 색상을 판정할 수 있다.
+ */
+export const formatSignedPercent = (
+  current: number,
+  previous: number,
+): SignedPercentTrend | null => {
+  if (previous === 0) return null;
+
+  const percent = ((current - previous) / previous) * 100;
+  const direction: SignedPercentTrend["direction"] =
+    percent > 0 ? "up" : percent < 0 ? "down" : "flat";
+  const sign = percent > 0 ? "+" : percent < 0 ? "-" : "";
+
+  return {
+    label: `${sign}${Math.abs(percent).toFixed(1)}%`,
+    direction,
+  };
+};

--- a/src/models/order.model.ts
+++ b/src/models/order.model.ts
@@ -161,6 +161,11 @@ orderSchema.index({ userId: 1, orderStatus: 1, createdAt: -1 });
 orderSchema.index({ orderStatus: 1, paymentId: 1, createdAt: 1 }); // findExpiredPendingOrdersForAllUsers
 orderSchema.index({ orderStatus: 1, confirmedAt: 1 }); // findExpiredAwaitingInvitationOrdersForAllUsers
 
+// 관리자 대시보드 "최근 주문" + 관리자 전역 주문 목록 전용 — 둘 다 상태 필터 없이
+// createdAt desc 전역 정렬이라 위 복합 인덱스(선두 필드가 userId/orderStatus)를 못 쓴다.
+// 없으면 COLLSCAN + blocking in-memory SORT(32MB 상한에 걸리면 쿼리 자체가 실패한다).
+orderSchema.index({ createdAt: -1 });
+
 export const OrderModel =
   (mongoose.models.Order as Model<IOrder>) ||
   mongoose.model<IOrder>("Order", orderSchema);

--- a/src/services/dashboard.integration.test.ts
+++ b/src/services/dashboard.integration.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import mongoose from "mongoose";
+import { dbConnect } from "@/db";
+import {
+  buildOrderInput,
+  buildProductInput,
+  buildUserInput,
+  clearCollections,
+} from "@testing/support";
+import { getKstMonthRange } from "@/core/utils";
+import { OrderModel, ProductModel, UserModel } from "@/models";
+import { createOrderService } from "./order";
+import { createProductService } from "./product";
+import { getDashboardStatsService } from "./dashboard";
+
+describe("getDashboardStatsService", () => {
+  let defaultProductId: string;
+  // 이번 달/전월(KST) 경계 안쪽 임의 시각 — 실제 서비스도 같은 getKstMonthRange()를
+  // 호출하므로 테스트 시각과 몇 ms 차이가 나도 같은 버킷으로 떨어진다.
+  let thisMonth: Date;
+  let previousMonth: Date;
+  let outsideRange: Date;
+
+  beforeEach(async () => {
+    await dbConnect();
+    await clearCollections();
+
+    const { startOfThisMonth, startOfLastMonth } = getKstMonthRange();
+    thisMonth = new Date(startOfThisMonth.getTime() + 60 * 60 * 1000);
+    previousMonth = new Date(startOfLastMonth.getTime() + 60 * 60 * 1000);
+    outsideRange = new Date(startOfLastMonth.getTime() - 24 * 60 * 60 * 1000);
+
+    // REQ-5(수량 범위 검증)를 만족시키기 위한 기본 주문 대상 상품 — 이 상품 자체가
+    // "이번 달 등록"이라 총 상품/이번달 신규 상품 어서션의 베이스라인이 된다.
+    const productInput = buildProductInput({
+      title: "대시보드 테스트 기본 상품",
+      minQuantity: 1,
+      maxQuantity: 0,
+    });
+    await createProductService(productInput);
+    const savedProduct = await ProductModel.findOne({
+      title: productInput.title,
+    }).lean();
+    defaultProductId = savedProduct!._id.toString();
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  const buildOrderInputForTest = (
+    overrides?: Parameters<typeof buildOrderInput>[0],
+  ): ReturnType<typeof buildOrderInput> => {
+    const input = buildOrderInput(overrides);
+    return {
+      ...input,
+      product: {
+        ...input.product,
+        productId: overrides?.product?.productId ?? defaultProductId,
+      },
+    };
+  };
+
+  // createdAt은 timestamps 옵션으로 자동 채워지고 immutable로 잠기므로, 월 버킷을
+  // 임의로 옮기려면 두 보호를 모두 풀어야 한다(order.integration.test.ts와 동일 패턴).
+  const setOrderTiming = async (
+    orderId: mongoose.Types.ObjectId,
+    fields: Partial<{
+      orderStatus: string;
+      confirmedAt: Date;
+      createdAt: Date;
+    }>,
+  ) => {
+    await OrderModel.updateOne(
+      { _id: orderId },
+      { $set: fields },
+      { timestamps: false, overwriteImmutable: true },
+    );
+  };
+
+  describe("빈 상태(REQ-2)", () => {
+    it("주문/추가 상품/회원이 없으면 유량 지표는 전부 0이고 recentOrders는 빈 배열이다", async () => {
+      const result = await getDashboardStatsService();
+
+      // beforeEach가 만든 기본 상품 1개만 존재하는 상태
+      expect(result.totalProducts).toBe(1);
+      expect(result.totalUsers).toBe(0);
+      expect(result.usersCreatedThisMonth).toBe(0);
+      expect(result.revenueThisMonth).toBe(0);
+      expect(result.revenuePreviousMonth).toBe(0);
+      expect(result.paidOrderCountThisMonth).toBe(0);
+      expect(result.paidOrderCountPreviousMonth).toBe(0);
+      expect(result.recentOrders).toEqual([]);
+    });
+  });
+
+  describe("상품/회원 저량 지표", () => {
+    it("소프트 삭제된 상품은 totalProducts에서 제외된다", async () => {
+      const deletedInput = buildProductInput({ title: "삭제된 상품" });
+      await createProductService(deletedInput);
+      await ProductModel.updateOne(
+        { title: deletedInput.title },
+        { $set: { deletedAt: new Date(), status: "deleted" } },
+      );
+
+      const result = await getDashboardStatsService();
+
+      expect(result.totalProducts).toBe(1); // beforeEach의 기본 상품만
+    });
+
+    it("이번 달(KST) 등록 상품만 productsCreatedThisMonth에 잡힌다", async () => {
+      const oldInput = buildProductInput({ title: "지난 달 등록 상품" });
+      await createProductService(oldInput);
+      await ProductModel.updateOne(
+        { title: oldInput.title },
+        { $set: { createdAt: previousMonth } },
+        { timestamps: false, overwriteImmutable: true },
+      );
+
+      const result = await getDashboardStatsService();
+
+      expect(result.totalProducts).toBe(2); // 기본 상품 + 지난달 상품
+      expect(result.productsCreatedThisMonth).toBe(1); // 기본 상품(방금 생성=이번달)만
+    });
+
+    it("탈퇴 회원은 totalUsers에서 제외되고, 이번 달 가입만 usersCreatedThisMonth에 잡힌다", async () => {
+      await UserModel.create(
+        buildUserInput({ email: "active-this-month@example.com" }),
+      );
+      await UserModel.create(
+        buildUserInput({ email: "deleted@example.com", isDelete: true }),
+      );
+      const oldUser = await UserModel.create(
+        buildUserInput({ email: "old@example.com" }),
+      );
+      await UserModel.updateOne(
+        { _id: oldUser._id },
+        { $set: { createdAt: previousMonth } },
+        { timestamps: false, overwriteImmutable: true },
+      );
+
+      const result = await getDashboardStatsService();
+
+      expect(result.totalUsers).toBe(2); // active-this-month + old (탈퇴 제외)
+      expect(result.usersCreatedThisMonth).toBe(1); // active-this-month만
+    });
+  });
+
+  describe("매출/결제 주문", () => {
+    it("CONFIRMED/COMPLETED만 집계되고 PENDING/CANCELLED는 제외된다", async () => {
+      const confirmed = await createOrderService(buildOrderInputForTest());
+      await setOrderTiming(confirmed._id, {
+        orderStatus: "CONFIRMED",
+        confirmedAt: thisMonth,
+      });
+
+      const completed = await createOrderService(buildOrderInputForTest());
+      await setOrderTiming(completed._id, {
+        orderStatus: "COMPLETED",
+        confirmedAt: thisMonth,
+      });
+
+      // PENDING — confirmedAt이 아예 없으므로 $match에서 자연히 제외된다.
+      await createOrderService(buildOrderInputForTest());
+
+      const cancelled = await createOrderService(buildOrderInputForTest());
+      await setOrderTiming(cancelled._id, {
+        orderStatus: "CANCELLED",
+        confirmedAt: thisMonth,
+      });
+
+      const result = await getDashboardStatsService();
+
+      expect(result.paidOrderCountThisMonth).toBe(2);
+      expect(result.revenueThisMonth).toBe(
+        confirmed.finalPrice + completed.finalPrice,
+      );
+    });
+
+    it("confirmedAt이 이번 달이면 thisMonth, 전월이면 previousMonth 버킷에 집계된다", async () => {
+      const current = await createOrderService(buildOrderInputForTest());
+      await setOrderTiming(current._id, {
+        orderStatus: "CONFIRMED",
+        confirmedAt: thisMonth,
+      });
+
+      const prev = await createOrderService(buildOrderInputForTest());
+      await setOrderTiming(prev._id, {
+        orderStatus: "CONFIRMED",
+        confirmedAt: previousMonth,
+      });
+
+      const result = await getDashboardStatsService();
+
+      expect(result.paidOrderCountThisMonth).toBe(1);
+      expect(result.revenueThisMonth).toBe(current.finalPrice);
+      expect(result.paidOrderCountPreviousMonth).toBe(1);
+      expect(result.revenuePreviousMonth).toBe(prev.finalPrice);
+    });
+
+    it("전전월처럼 범위 밖 confirmedAt은 집계에서 완전히 빠진다", async () => {
+      const outside = await createOrderService(buildOrderInputForTest());
+      await setOrderTiming(outside._id, {
+        orderStatus: "CONFIRMED",
+        confirmedAt: outsideRange,
+      });
+
+      const result = await getDashboardStatsService();
+
+      expect(result.paidOrderCountThisMonth).toBe(0);
+      expect(result.paidOrderCountPreviousMonth).toBe(0);
+      expect(result.revenueThisMonth).toBe(0);
+      expect(result.revenuePreviousMonth).toBe(0);
+    });
+
+    it("전월 실적이 없으면 0을 반환한다(undefined 아님)", async () => {
+      const current = await createOrderService(buildOrderInputForTest());
+      await setOrderTiming(current._id, {
+        orderStatus: "CONFIRMED",
+        confirmedAt: thisMonth,
+      });
+
+      const result = await getDashboardStatsService();
+
+      expect(result.revenuePreviousMonth).toBe(0);
+      expect(result.paidOrderCountPreviousMonth).toBe(0);
+    });
+  });
+
+  describe("recentOrders", () => {
+    it("createdAt desc로 최대 5건만 반환하고 상태 필터가 없다(PENDING 포함)", async () => {
+      const created: { merchantUid: string; createdAt: Date }[] = [];
+      for (let i = 0; i < 6; i += 1) {
+        const order = await createOrderService(buildOrderInputForTest());
+        const createdAt = new Date(Date.now() - (6 - i) * 60 * 1000);
+        await setOrderTiming(order._id, { createdAt });
+        created.push({ merchantUid: order.merchantUid, createdAt });
+      }
+      // 마지막(가장 최근) 주문은 orderStatus를 안 건드려 기본값 PENDING 그대로다.
+
+      const result = await getDashboardStatsService();
+
+      expect(result.recentOrders).toHaveLength(5);
+      const expectedMerchantUids = created
+        .slice()
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+        .slice(0, 5)
+        .map((o) => o.merchantUid);
+      expect(result.recentOrders.map((o) => o.merchantUid)).toEqual(
+        expectedMerchantUids,
+      );
+      expect(
+        result.recentOrders.some((o) => o.orderStatus === "PENDING"),
+      ).toBe(true);
+    });
+
+    it("productTitle이 product.title 스냅샷으로 평탄화되고 createdAt이 Date 인스턴스로 온다", async () => {
+      const order = await createOrderService(
+        buildOrderInputForTest({
+          product: {
+            productId: defaultProductId,
+            title: "스냅샷 확인용 상품명",
+            thumbnail: "https://example.com/thumbnail.jpg",
+            pricing: { originalPrice: 9900, discountedPrice: 9900 },
+            quantity: 1,
+            selectedFeatures: [],
+          },
+        }),
+      );
+
+      const result = await getDashboardStatsService();
+
+      const row = result.recentOrders.find(
+        (o) => o.merchantUid === order.merchantUid,
+      );
+      expect(row?.productTitle).toBe("스냅샷 확인용 상품명");
+      expect(row?.createdAt).toBeInstanceOf(Date);
+      expect(row?.finalPrice).toBe(order.finalPrice);
+      expect(row?.buyerName).toBe(order.buyerName);
+    });
+  });
+
+  describe("에러 계약", () => {
+    it("mongoose 예외가 나면 raw 에러가 아니라 AppError(INTERNAL)로 감싸 던진다", async () => {
+      const aggregateSpy = vi
+        .spyOn(OrderModel, "aggregate")
+        .mockRejectedValueOnce(new Error("DB 커넥션 끊김"));
+
+      await expect(getDashboardStatsService()).rejects.toMatchObject({
+        category: "INTERNAL",
+        message: "DB 커넥션 끊김",
+      });
+
+      aggregateSpy.mockRestore();
+    });
+  });
+});

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -1,0 +1,147 @@
+import "server-only";
+import { OrderModel, ProductModel, UserModel } from "@/models";
+import type {
+  DashboardStats,
+  DashboardRecentOrder,
+  OrderStatus,
+} from "@/core/domain";
+import { AppError, PAID_ORDER_STATUSES } from "@/core/domain";
+import { getKstMonthRange } from "@/core/utils";
+import { dbConnect } from "@/db";
+
+type OrderMonthlyBucket = {
+  _id: "current" | "previous";
+  revenue: number;
+  orderCount: number;
+};
+
+type ProductMonthlyStats = {
+  _id: null;
+  total: number;
+  createdThisMonth: number;
+};
+
+type UserMonthlyStats = {
+  _id: null;
+  total: number;
+  createdThisMonth: number;
+};
+
+type RecentOrderLean = {
+  merchantUid: string;
+  buyerName: string;
+  product: { title: string };
+  finalPrice: number;
+  orderStatus: OrderStatus;
+  createdAt: Date;
+};
+
+/**
+ * admin 대시보드 4개 카드(등록 상품/총 매출/결제 주문/활동 회원) + 최근 주문 5건.
+ * 파라미터 없음, envelope 없음 — Server Component(`page.tsx`)가 직접 await한다.
+ * 인증은 여기서 검사하지 않는다(`page.tsx`의 verifySession("ADMIN")가 전담).
+ */
+export const getDashboardStatsService = async (): Promise<DashboardStats> => {
+  await dbConnect();
+
+  const { startOfLastMonth, startOfThisMonth, startOfNextMonth } =
+    getKstMonthRange();
+
+  const [orderBuckets, productStats, userStats, recentOrdersRaw] =
+    await Promise.all([
+      // Q1 — 매출 + 결제 주문수(이번달/전달 한 방). 결제 반영 상태(CONFIRMED|COMPLETED)만,
+      // 기준 시각은 confirmedAt. { orderStatus: 1, confirmedAt: 1 } 인덱스가 완전 커버한다.
+      OrderModel.aggregate<OrderMonthlyBucket>([
+        {
+          $match: {
+            orderStatus: { $in: PAID_ORDER_STATUSES },
+            confirmedAt: { $gte: startOfLastMonth, $lt: startOfNextMonth },
+          },
+        },
+        {
+          $group: {
+            _id: {
+              $cond: [
+                { $gte: ["$confirmedAt", startOfThisMonth] },
+                "current",
+                "previous",
+              ],
+            },
+            revenue: { $sum: "$finalPrice" },
+            orderCount: { $sum: 1 },
+          },
+        },
+      ]),
+      // Q3 — 상품 총계 + 이번달 신규(한 스캔). 소프트 삭제는 deletedAt: null 기준.
+      ProductModel.aggregate<ProductMonthlyStats>([
+        { $match: { deletedAt: null } },
+        {
+          $group: {
+            _id: null,
+            total: { $sum: 1 },
+            createdThisMonth: {
+              $sum: { $cond: [{ $gte: ["$createdAt", startOfThisMonth] }, 1, 0] },
+            },
+          },
+        },
+      ]),
+      // Q4 — 회원 총계 + 이번달 신규(한 스캔). 소프트 삭제는 isDelete: false 기준.
+      UserModel.aggregate<UserMonthlyStats>([
+        { $match: { isDelete: false } },
+        {
+          $group: {
+            _id: null,
+            total: { $sum: 1 },
+            createdThisMonth: {
+              $sum: { $cond: [{ $gte: ["$createdAt", startOfThisMonth] }, 1, 0] },
+            },
+          },
+        },
+      ]),
+      // Q2 — 최근 주문 5건. 상태 필터 없이 createdAt desc. { createdAt: -1 } 인덱스 필요.
+      OrderModel.find()
+        .sort({ createdAt: -1 })
+        .limit(5)
+        .select(
+          "merchantUid buyerName product.title finalPrice orderStatus createdAt",
+        )
+        .lean<RecentOrderLean[]>(),
+    ]).catch((error) => {
+      throw new AppError(
+        "INTERNAL",
+        error instanceof Error
+          ? error.message
+          : "대시보드 통계 조회에 실패했습니다.",
+      );
+    });
+
+  // $group 결과는 해당 월에 결제 완료 주문이 0건이면 버킷 행 자체가 안 나온다 — ?? 0 폴백 필수.
+  const currentBucket = orderBuckets.find((bucket) => bucket._id === "current");
+  const previousBucket = orderBuckets.find(
+    (bucket) => bucket._id === "previous",
+  );
+
+  const productAgg = productStats[0];
+  const userAgg = userStats[0];
+
+  const recentOrders: DashboardRecentOrder[] = recentOrdersRaw.map((order) => ({
+    merchantUid: order.merchantUid,
+    buyerName: order.buyerName,
+    productTitle: order.product.title,
+    finalPrice: order.finalPrice,
+    orderStatus: order.orderStatus,
+    createdAt: order.createdAt,
+  }));
+
+  return {
+    totalProducts: productAgg?.total ?? 0,
+    productsCreatedThisMonth: productAgg?.createdThisMonth ?? 0,
+    totalUsers: userAgg?.total ?? 0,
+    usersCreatedThisMonth: userAgg?.createdThisMonth ?? 0,
+    revenueThisMonth: currentBucket?.revenue ?? 0,
+    revenuePreviousMonth: previousBucket?.revenue ?? 0,
+    paidOrderCountThisMonth: currentBucket?.orderCount ?? 0,
+    paidOrderCountPreviousMonth: previousBucket?.orderCount ?? 0,
+    recentOrders,
+  };
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,6 @@
 import "server-only";
 export * from "./auth";
+export * from "./dashboard";
 export * from "./invitation";
 export * from "./guestbook";
 export * from "./order";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
             "src/app/api/**/*.integration.test.{ts,tsx}",
             "src/app/(main)/page.integration.test.ts",
             "src/app/(main)/_components/PopularProductsSection.integration.test.tsx",
+            "src/app/(admin)/admin/dashboard/page.integration.test.ts",
           ],
           globalSetup: ["./testing/support/setup/mongo-server.ts"],
           fileParallelism: false,


### PR DESCRIPTION
## Summary

- `/admin/dashboard`가 100% 하드코딩 mock이던 것을 실제 DB 집계로 교체했다 — 상품/매출/결제주문/회원 통계 카드 4개와 "최근 주문" 테이블.
- feature-team-orchestrator 5-Phase(설계 팬아웃 → 구현+경계면 검증 → 통합 테스트) 전체를 태웠다. 설계 산출물/판정 기록은 `_workspace/feat/admin-dashboard-real-data/`에 남아있다.
- 매출/결제주문 집계 기준을 `createdAt`에서 `confirmedAt`으로, 월 경계를 서버 로컬(UTC) 대신 KST 명시로 바꿨다 — 가상계좌 입금월 불일치와 9시간 타임존 어긋남을 방지한다.
- 기존 mock 문구 4개가 실제 집계 조건(비공개/품절 상품 포함, 탈퇴회원 제외 등)과 어긋나 있던 걸 바로잡았고, trend 색상이 무조건 `text-primary`라 매출 감소도 긍정색으로 표시되던 버그를 고쳤다.

## Test plan

- `src/services/dashboard.integration.test.ts` 11건 (mongodb-memory-server)
- `AdminDashboardTemplate.test.tsx` 4케이스 (정상/전월0/빈주문/오픈첫달 통합 — C+D 상태 포함)
- `page.integration.test.ts` 4케이스 (골든패스/빈DB/역할불일치 회귀/미인증 회귀)
- `date.test.ts`/`percent.test.ts` — KST 경계, 3개 TZ 환경 재현 검증
- 전체 vitest 스위트 832 passed / 4 failed — 실패 4건 전부 이 브랜치 미접촉, `dev`에서도 동일 재현 확인(#145, #146 관련)
- `lint`/`tsc` 0 errors
- 운영 DB 전제조건 2건(confirmedAt/isDelete 결측) 읽기 전용으로 직접 실측 — 둘 다 0건, backfill 불필요

## 스코프 밖 발견사항 (별도 Issue 등록)

Related to #145, #146, #147, #148, #149