### PR TITLE
fix(admin-products): 상품 목록에 커서 페이지네이션을 추가한다

### DIFF
--- a/src/app/(admin)/admin/products/_components/AdminProductsTemplate.test.tsx
+++ b/src/app/(admin)/admin/products/_components/AdminProductsTemplate.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { ProductJSON } from "@/core/domain";
+import type { AdminProductListPage, ProductJSON } from "@/core/domain";
 
 vi.mock("./ProductTableRow", () => ({
   ProductTableRow: ({ product }: { product: { title: string } }) => (
@@ -19,32 +19,49 @@ const buildProduct = (overrides?: Partial<ProductJSON>): ProductJSON =>
     ...overrides,
   }) as ProductJSON;
 
-describe("AdminProductsTemplate", () => {
-  it("상품 개수와 테이블 헤더를 렌더링한다", () => {
-    render(<AdminProductsTemplate products={[buildProduct()]} />);
+const buildPage = (
+  overrides?: Partial<AdminProductListPage>,
+): AdminProductListPage => ({
+  items: [buildProduct()],
+  nextCursor: null,
+  ...overrides,
+});
 
-    expect(screen.getByText("등록된 템플릿 상품을 관리합니다. (총 1개)")).toBeInTheDocument();
+describe("AdminProductsTemplate", () => {
+  it("상품 목록과 테이블 헤더를 렌더링한다", () => {
+    render(<AdminProductsTemplate page={buildPage()} />);
+
+    expect(screen.getByText("등록된 템플릿 상품을 관리합니다.")).toBeInTheDocument();
     expect(screen.getByText("썸네일")).toBeInTheDocument();
+    expect(screen.getByText("봄맞이 청첩장")).toBeInTheDocument();
   });
 
   it("상품이 없으면 빈 상태 메시지를 렌더링한다", () => {
-    render(<AdminProductsTemplate products={[]} />);
+    render(<AdminProductsTemplate page={buildPage({ items: [] })} />);
 
     expect(screen.getByText("등록된 상품이 없습니다.")).toBeInTheDocument();
   });
 
   it("상품 목록/휴지통 탭 링크를 렌더링한다", () => {
-    render(<AdminProductsTemplate products={[buildProduct()]} />);
+    render(<AdminProductsTemplate page={buildPage()} />);
 
     const trashLink = screen.getByRole("link", { name: "휴지통" });
     expect(trashLink).toHaveAttribute("href", "/admin/products?view=trash");
   });
 
   it("view가 trash면 휴지통 제목과 빈 상태 문구를 렌더링하고 상품 등록 버튼을 숨긴다", () => {
-    render(<AdminProductsTemplate products={[]} view="trash" />);
+    render(
+      <AdminProductsTemplate page={buildPage({ items: [] })} view="trash" />,
+    );
 
     expect(screen.getByRole("heading", { name: "휴지통" })).toBeInTheDocument();
     expect(screen.getByText("삭제된 상품이 없습니다.")).toBeInTheDocument();
     expect(screen.queryByText("상품 등록")).not.toBeInTheDocument();
+  });
+
+  it("nextCursor가 있으면 다음 페이지 버튼이 활성화된다", () => {
+    render(<AdminProductsTemplate page={buildPage({ nextCursor: "abc" })} />);
+
+    expect(screen.getByRole("link", { name: "다음 페이지" })).toBeInTheDocument();
   });
 });

--- a/src/app/(admin)/admin/products/_components/AdminProductsTemplate.tsx
+++ b/src/app/(admin)/admin/products/_components/AdminProductsTemplate.tsx
@@ -1,21 +1,25 @@
 import Link from "next/link";
 import { Plus } from "lucide-react";
 import { Button, TypographyH1, TypographyMuted } from "@/ui/components/atoms";
-import type { ProductJSON } from "@/core/domain";
+import { CursorPagination } from "@/ui/components/molecules";
+import type { AdminProductListPage } from "@/core/domain";
 import { routes } from "@/core/domain";
 import { TABLE_COLUMNS } from "../_constants";
 import { ProductTableRow } from "./ProductTableRow";
 
 interface AdminProductsTemplateProps {
-  products: ProductJSON[];
+  page: AdminProductListPage;
   view?: "active" | "trash";
+  cursor?: string;
 }
 
 const AdminProductsTemplate = ({
-  products,
+  page,
   view = "active",
+  cursor,
 }: AdminProductsTemplateProps) => {
   const isTrash = view === "trash";
+  const products = page.items;
 
   return (
     <div className="space-y-6">
@@ -26,8 +30,8 @@ const AdminProductsTemplate = ({
           </TypographyH1>
           <TypographyMuted>
             {isTrash
-              ? `삭제된 상품을 조회하고 복구합니다. (총 ${products.length}개)`
-              : `등록된 템플릿 상품을 관리합니다. (총 ${products.length}개)`}
+              ? "삭제된 상품을 조회하고 복구합니다."
+              : "등록된 템플릿 상품을 관리합니다."}
           </TypographyMuted>
         </div>
         {!isTrash && (
@@ -85,12 +89,12 @@ const AdminProductsTemplate = ({
         )}
       </div>
 
-      <div className="flex items-center justify-between">
-        <TypographyMuted>
-          총 {products.length}개 상품
-        </TypographyMuted>
-        <div className="flex gap-2">페이지네이션 버튼</div>
-      </div>
+      <CursorPagination
+        basePath={routes.admin.products.root}
+        query={isTrash ? { view: "trash" } : {}}
+        hasCursor={!!cursor}
+        nextCursor={page.nextCursor}
+      />
     </div>
   );
 };

--- a/src/app/(admin)/admin/products/page.tsx
+++ b/src/app/(admin)/admin/products/page.tsx
@@ -1,10 +1,29 @@
 export const dynamic = "force-dynamic";
 
-import { getAllProductsService, verifySession } from "@/services";
+import { verifySession, getAdminProductsPageService } from "@/services";
+import { adminProductListRequestSchema } from "@/core/schemas";
+import { decodeCursor, validateAndFlatten } from "@/core/utils";
 import { AdminProductsTemplate } from "./_components";
 
-const resolveView = (raw: string | string[] | undefined): "active" | "trash" =>
-  raw === "trash" ? "trash" : "active";
+// 필터/커서는 URL이 소유하므로 어떤 입력이 와도 throw하지 않는다 — 유효하지 않은
+// view는 스키마가, 형식이 깨진 cursor는 decodeCursor가 걸러 "필터/커서 없음"으로
+// 떨어뜨린다. 그 뒤에도 남는 방어(예: 직접 조작된 요청)는 service의 AppError가 맡는다.
+const resolveFilters = (
+  searchParams: Record<string, string | string[] | undefined>,
+) => {
+  const parsed = validateAndFlatten(adminProductListRequestSchema, {
+    view: typeof searchParams.view === "string" ? searchParams.view : null,
+    cursor: typeof searchParams.cursor === "string" ? searchParams.cursor : null,
+  });
+
+  if (!parsed.success) return {};
+
+  const { view, cursor } = parsed.data;
+  if (cursor && !decodeCursor(cursor)) {
+    return { view };
+  }
+  return { view, cursor };
+};
 
 export default async function ProductsPage({
   searchParams,
@@ -13,8 +32,8 @@ export default async function ProductsPage({
 }) {
   await verifySession("ADMIN");
 
-  const view = resolveView((await searchParams).view);
-  const products = await getAllProductsService(undefined, undefined, view);
+  const { view = "active", cursor } = resolveFilters(await searchParams);
+  const page = await getAdminProductsPageService({ view, cursor });
 
-  return <AdminProductsTemplate products={products} view={view} />;
+  return <AdminProductsTemplate page={page} view={view} cursor={cursor} />;
 }

--- a/src/core/domain/product.ts
+++ b/src/core/domain/product.ts
@@ -1,5 +1,6 @@
 import type { InvitationTheme } from "./theme";
 import type { ProductCategory, SubCategory } from "./product-category";
+import type { CursorPage } from "./cursor";
 
 // 0. Home 인기 상품 섹션(좋아요순 Top N) 관련 상수 — service 기본값과 UI 노출 게이트가 같은 값을 본다.
 export const POPULAR_PRODUCTS_LIMIT = 8;
@@ -38,6 +39,8 @@ export interface ProductJSON {
 }
 
 export type Product = ProductJSON;
+
+export type AdminProductListPage = CursorPage<ProductJSON>;
 
 // 1. 필터 키 배열 정의 (UI 노출 순서 보장 및 타입 추출용)
 export const PRODUCT_SORT_KEYS = [

--- a/src/core/schemas/index.ts
+++ b/src/core/schemas/index.ts
@@ -1,6 +1,7 @@
 import "./config";
 
 export * from "./request/adminOrderList.schema";
+export * from "./request/adminProductList.schema";
 export * from "./request/adminUserList.schema";
 export * from "./request/coupleInfo.schema";
 export * from "./request/email.schema";

--- a/src/core/schemas/request/adminProductList.schema.ts
+++ b/src/core/schemas/request/adminProductList.schema.ts
@@ -1,0 +1,13 @@
+import * as z from "zod";
+
+// URL searchParams는 "값 없음"을 빈 문자열로도 표현한다(`?view=`) — 빈 값은 필터
+// 해제와 같은 의미이므로 스키마 진입 전에 undefined로 정규화해 서비스가 조건 유무만 보게 한다.
+const emptyToUndefined = (value: unknown) =>
+  value === "" || value === null ? undefined : value;
+
+export const adminProductListRequestSchema = z.object({
+  view: z.preprocess(emptyToUndefined, z.enum(["active", "trash"]).optional()),
+  cursor: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
+});
+
+export type AdminProductListRequest = z.infer<typeof adminProductListRequestSchema>;

--- a/src/services/product.integration.test.ts
+++ b/src/services/product.integration.test.ts
@@ -13,6 +13,7 @@ import {
   getProductService,
   incrementProductViewsService,
   getAllProductsService,
+  getAdminProductsPageService,
   getPublicProductsService,
   getAvailableSubCategoriesService,
   getFeaturedTemplatesService,
@@ -346,6 +347,139 @@ describe("product", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].title).toBe("삭제될상품");
+    });
+  });
+
+  describe("getAdminProductsPageService", () => {
+    const setCreatedAt = async (
+      productId: mongoose.Types.ObjectId,
+      createdAt: Date,
+    ) => {
+      await ProductModel.updateOne(
+        { _id: productId },
+        { $set: { createdAt } },
+        { timestamps: false, overwriteImmutable: true },
+      );
+    };
+
+    const createAndFetch = async (title: string) => {
+      await createProductService(buildProductInput({ title }));
+      return ProductModel.findOne({ title }).lean();
+    };
+
+    it("createdAt 내림차순으로 정렬한다", async () => {
+      const older = await createAndFetch("older");
+      const newer = await createAndFetch("newer");
+      await setCreatedAt(older!._id, new Date("2026-01-01T00:00:00.000Z"));
+      await setCreatedAt(newer!._id, new Date("2026-02-01T00:00:00.000Z"));
+
+      const result = await getAdminProductsPageService({});
+
+      expect(result.items.map((p) => p._id)).toEqual([
+        newer!._id.toString(),
+        older!._id.toString(),
+      ]);
+    });
+
+    it("같은 createdAt이면 _id 내림차순으로 tie-break한다", async () => {
+      const sameCreatedAt = new Date("2026-08-01T00:00:00.000Z");
+      const created = [];
+      for (let i = 0; i < 3; i += 1) {
+        const product = await createAndFetch(`상품${i}`);
+        await setCreatedAt(product!._id, sameCreatedAt);
+        created.push(product!._id.toString());
+      }
+
+      const result = await getAdminProductsPageService({});
+
+      expect(result.items.map((p) => p._id)).toEqual([...created].sort().reverse());
+    });
+
+    it("limit을 넘으면 nextCursor로 다음 페이지가 이어지고 행이 중복/누락되지 않는다", async () => {
+      const created = [];
+      for (let i = 0; i < 3; i += 1) {
+        const product = await createAndFetch(`상품${i}`);
+        await setCreatedAt(product!._id, new Date(2026, 0, i + 1));
+        created.push(product!._id.toString());
+      }
+
+      const firstPage = await getAdminProductsPageService({ limit: 2 });
+      expect(firstPage.items).toHaveLength(2);
+      expect(firstPage.nextCursor).not.toBe(null);
+
+      const secondPage = await getAdminProductsPageService({
+        limit: 2,
+        cursor: firstPage.nextCursor!,
+      });
+      expect(secondPage.items).toHaveLength(1);
+      expect(secondPage.nextCursor).toBe(null);
+
+      const paged = [...firstPage.items, ...secondPage.items].map((p) => p._id);
+      expect(new Set(paged).size).toBe(3);
+      expect(paged.sort()).toEqual([...created].sort());
+    });
+
+    it("view가 trash면 소프트 삭제된 상품만, 기본값은 삭제되지 않은 상품만 포함한다", async () => {
+      const active = await createAndFetch("정상상품");
+      const trashed = await createAndFetch("삭제될상품");
+      await deleteProductService(trashed!._id.toString());
+
+      const activeResult = await getAdminProductsPageService({});
+      const trashResult = await getAdminProductsPageService({ view: "trash" });
+
+      expect(activeResult.items.map((p) => p._id)).toEqual([active!._id.toString()]);
+      expect(trashResult.items.map((p) => p._id)).toEqual([trashed!._id.toString()]);
+    });
+
+    it("view 필터와 cursor를 동시에 적용한다", async () => {
+      const products = [];
+      for (let i = 0; i < 3; i += 1) {
+        const product = await createAndFetch(`상품${i}`);
+        await setCreatedAt(product!._id, new Date(2026, 0, i + 1));
+        products.push(product);
+      }
+      const trashed = await createAndFetch("삭제될상품");
+      await deleteProductService(trashed!._id.toString());
+
+      const firstPage = await getAdminProductsPageService({ limit: 2 });
+      const secondPage = await getAdminProductsPageService({
+        limit: 2,
+        cursor: firstPage.nextCursor!,
+      });
+
+      expect(secondPage.items).toHaveLength(1);
+      expect(
+        [...firstPage.items, ...secondPage.items].some((p) => p.title === "삭제될상품"),
+      ).toBe(false);
+    });
+
+    it("빈 DB면 빈 목록과 null 커서를 리턴한다", async () => {
+      const result = await getAdminProductsPageService({});
+
+      expect(result).toEqual({ items: [], nextCursor: null });
+    });
+
+    it("형식이 깨진 cursor는 VALIDATION을 던진다", async () => {
+      await expect(
+        getAdminProductsPageService({ cursor: "!!broken!!" }),
+      ).rejects.toMatchObject({ category: "VALIDATION" });
+    });
+
+    it("잘못된 limit(소수)은 VALIDATION을 던진다", async () => {
+      await expect(
+        getAdminProductsPageService({ limit: 1.5 }),
+      ).rejects.toMatchObject({ category: "VALIDATION" });
+    });
+
+    it("DTO는 문자열 _id를 가지며 discountedPrice/isLiked 등 파생 필드를 포함한다", async () => {
+      await createAndFetch("특별한 청첩장");
+
+      const result = await getAdminProductsPageService({});
+
+      expect(typeof result.items[0]._id).toBe("string");
+      expect(result.items[0].title).toBe("특별한 청첩장");
+      expect(result.items[0].isLiked).toBe(false);
+      expect(typeof result.items[0].discountedPrice).toBe("number");
     });
   });
 

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -3,14 +3,24 @@ import type { ProductJSON, ProductDB, IProduct } from "@/models";
 import { ProductModel, InvitationProductModel } from "@/models";
 import type { ProductDto } from "@/core/schemas";
 import { dbConnect } from "@/db";
-import { calculatePrice, escapeRegExp, findProductCategoriesByTerm, findSubCategoriesByTerm } from "@/core/utils";
+import {
+  calculatePrice,
+  decodeCursor,
+  encodeCursor,
+  escapeRegExp,
+  findProductCategoriesByTerm,
+  findSubCategoriesByTerm,
+  isValidPageLimit,
+} from "@/core/utils";
 import { AppError } from "@/core/domain";
 import type {
+  AdminProductListPage,
   AvailableSubCategory,
   InvitationTheme,
   ProductCategory,
 } from "@/core/domain";
 import {
+  DEFAULT_PAGE_SIZE,
   POPULAR_PRODUCTS_LIMIT,
   PRODUCT_CATEGORIES,
   SUB_CATEGORY_MAP,
@@ -190,6 +200,73 @@ export const getAllProductsService = async (
     .lean();
 
   return products.map((p) => transformProduct(p, userId));
+};
+
+type AdminProductListQuery = {
+  view?: "active" | "trash";
+  cursor?: string;
+  limit?: number;
+};
+
+/**
+ * 관리자 상품 목록 한 페이지 — orders/users(getAdminOrdersPageService,
+ * getAdminUsersPageService)와 동일한 cursor 계약(createdAt desc, _id tie-break,
+ * limit+1)을 쓴다. getAllProductsService와 달리 isFeatured/priority 정렬을 쓰지
+ * 않는다 — 그 정렬은 공개 노출 우선순위 의미라 관리자 목록의 커서 안정성과 맞지 않는다.
+ */
+export const getAdminProductsPageService = async ({
+  view = "active",
+  cursor,
+  limit = DEFAULT_PAGE_SIZE,
+}: AdminProductListQuery): Promise<AdminProductListPage> => {
+  await dbConnect();
+
+  if (!isValidPageLimit(limit)) {
+    throw new AppError("VALIDATION", "잘못된 페이지 크기입니다.");
+  }
+
+  const filter: Record<string, unknown> =
+    view === "trash" ? { deletedAt: { $ne: null } } : { deletedAt: null };
+
+  if (cursor) {
+    const decoded = decodeCursor(cursor);
+    if (!decoded) {
+      throw new AppError("VALIDATION", "잘못된 페이지 커서입니다.");
+    }
+    filter.$or = [
+      { createdAt: { $lt: decoded.createdAt } },
+      {
+        createdAt: decoded.createdAt,
+        _id: { $lt: new mongoose.Types.ObjectId(decoded.id) },
+      },
+    ];
+  }
+
+  const found = await ProductModel.find(filter)
+    .sort({ createdAt: -1, _id: -1 })
+    .limit(limit + 1)
+    .lean<LeanProduct[]>()
+    .catch((err) => {
+      throw new AppError(
+        "INTERNAL",
+        err instanceof Error ? err.message : "상품 목록 조회에 실패했습니다.",
+      );
+    });
+
+  const hasMore = found.length > limit;
+  const products = hasMore ? found.slice(0, limit) : found;
+  const lastProduct = products.at(-1);
+
+  return {
+    items: products.map((product) => transformProduct(product)),
+    nextCursor:
+      hasMore && lastProduct
+        ? encodeCursor({
+            createdAt: lastProduct.createdAt,
+            id: lastProduct._id.toString(),
+          })
+        : null,
+  };
 };
 
 // 공개 상품 목록 — 관리자용 getAllProductsService와 달리 판매 가능한 active 상품만 노출한다.


### PR DESCRIPTION
## Summary

- 상품 목록(`AdminProductsTemplate`)에 "페이지네이션 버튼" 플레이스홀더만 있고 실제 동작이 없었다 — orders/users와 동일한 cursor 기반 페이지네이션(`CursorPagination`, createdAt desc + _id tie-break)을 상품 목록에도 적용했다.
- `getAdminProductsPageService`(신규), `adminProductListRequestSchema`(신규), `AdminProductListPage` 타입을 orders/users 패턴 그대로 추가했다.
- 페이지당 아이템 수만 알 수 있는 커서 페이징 특성상 오해를 주던 "총 N개" 문구는 orders/users와 동일하게 제거했다.

## Test plan

- `npm run tsc` — 통과
- `npx eslint` (변경 파일 대상) — 통과
- `npx vitest run --project component AdminProductsTemplate.test.tsx` — 5/5 통과
- `npx vitest run --project integration src/services/product.integration.test.ts` — 83/83 통과(신규 9건 포함)