### PR TITLE
feat(payment): 실물 상품 주문에 배송 정보를 저장한다

### DIFF
--- a/src/actions/createOrder.ts
+++ b/src/actions/createOrder.ts
@@ -8,7 +8,7 @@ import { actionError } from "@/boundary";
 
 import { validateAndFlatten } from "@/core/utils";
 import { createOrderSchema } from "@/core/schemas";
-import type { PayMethod } from "@/core/domain";
+import type { PayMethod, ProductCategory } from "@/core/domain";
 import { routes } from "@/core/domain";
 export type CreateOrderResult = {
   merchantUid: string;
@@ -35,6 +35,20 @@ export async function createOrder(
   // FormData에서 주문 정보 추출
   const selectedOptionsRaw = formData.get("selectedFeatures") as string;
 
+  // 넷 중 하나라도 값이 있으면 shipping 객체를 구성한다 — 모바일초대장 주문은
+  // ShippingInfoCard 자체가 폼에 없어 이 필드들이 애초에 안 실려있으므로 항상
+  // undefined가 되고, zod의 shipping.optional()을 그대로 통과한다.
+  const shippingReceiver = formData.get("shippingReceiver") as string | null;
+  const shippingPhone = formData.get("shippingPhone") as string | null;
+  const shipAddress = formData.get("ship_address") as string | null;
+  const shipAddressDetail = formData.get("ship_address_detail") as string | null;
+  const hasShippingInput = [
+    shippingReceiver,
+    shippingPhone,
+    shipAddress,
+    shipAddressDetail,
+  ].some((value) => !!value);
+
   const data = {
     buyerName: formData.get("buyerName") as string,
     buyerEmail: formData.get("buyerEmail") as string,
@@ -44,6 +58,7 @@ export async function createOrder(
       productId: formData.get("productId") as string,
       title: formData.get("productTitle") as string,
       thumbnail: formData.get("productThumbnail") as string,
+      category: formData.get("productCategory") as ProductCategory,
       pricing: {
         originalPrice: Number(formData.get("originalPrice")),
         discountedPrice: Number(formData.get("discountedPrice")),
@@ -51,6 +66,14 @@ export async function createOrder(
       quantity: Number(formData.get("productQuantity")),
       selectedFeatures: JSON.parse(selectedOptionsRaw) ?? [],
     },
+    shipping: hasShippingInput
+      ? {
+          receiver: shippingReceiver ?? "",
+          phone: shippingPhone ?? "",
+          address: shipAddress ?? "",
+          addressDetail: shipAddressDetail ?? "",
+        }
+      : undefined,
   };
 
   // Zod 스키마로 유효성 검증

--- a/src/actions/createOrder.ts
+++ b/src/actions/createOrder.ts
@@ -9,7 +9,7 @@ import { actionError } from "@/boundary";
 import { validateAndFlatten } from "@/core/utils";
 import { createOrderSchema } from "@/core/schemas";
 import type { PayMethod, ProductCategory } from "@/core/domain";
-import { routes } from "@/core/domain";
+import { routes, categoryRequiresShipping } from "@/core/domain";
 export type CreateOrderResult = {
   merchantUid: string;
   finalPrice: number;
@@ -35,20 +35,11 @@ export async function createOrder(
   // FormData에서 주문 정보 추출
   const selectedOptionsRaw = formData.get("selectedFeatures") as string;
 
-  // 넷 중 하나라도 값이 있으면 shipping 객체를 구성한다 — 모바일초대장 주문은
-  // ShippingInfoCard 자체가 폼에 없어 이 필드들이 애초에 안 실려있으므로 항상
-  // undefined가 되고, zod의 shipping.optional()을 그대로 통과한다.
-  const shippingReceiver = formData.get("shippingReceiver") as string | null;
-  const shippingPhone = formData.get("shippingPhone") as string | null;
-  const shipAddress = formData.get("ship_address") as string | null;
-  const shipAddressDetail = formData.get("ship_address_detail") as string | null;
-  const hasShippingInput = [
-    shippingReceiver,
-    shippingPhone,
-    shipAddress,
-    shipAddressDetail,
-  ].some((value) => !!value);
+  const category = formData.get("productCategory") as ProductCategory;
 
+  // 모바일초대장 주문은 ShippingInfoCard 자체가 폼에 없어 이 필드들이 애초에 안
+  // 실려있다 — source of truth인 category로 판단하고, 실물 카테고리인데 값이
+  // 비었으면 아래 zod 검증(shipping.optional())을 통과 못 시켜 걸러지게 둔다.
   const data = {
     buyerName: formData.get("buyerName") as string,
     buyerEmail: formData.get("buyerEmail") as string,
@@ -58,7 +49,7 @@ export async function createOrder(
       productId: formData.get("productId") as string,
       title: formData.get("productTitle") as string,
       thumbnail: formData.get("productThumbnail") as string,
-      category: formData.get("productCategory") as ProductCategory,
+      category,
       pricing: {
         originalPrice: Number(formData.get("originalPrice")),
         discountedPrice: Number(formData.get("discountedPrice")),
@@ -66,12 +57,12 @@ export async function createOrder(
       quantity: Number(formData.get("productQuantity")),
       selectedFeatures: JSON.parse(selectedOptionsRaw) ?? [],
     },
-    shipping: hasShippingInput
+    shipping: categoryRequiresShipping(category)
       ? {
-          receiver: shippingReceiver ?? "",
-          phone: shippingPhone ?? "",
-          address: shipAddress ?? "",
-          addressDetail: shipAddressDetail ?? "",
+          receiver: formData.get("shippingReceiver") as string,
+          phone: formData.get("shippingPhone") as string,
+          address: formData.get("ship_address") as string,
+          addressDetail: formData.get("ship_address_detail") as string,
         }
       : undefined,
   };

--- a/src/app/(main)/(checkout)/payment/_components/BuyerInfoCard.tsx
+++ b/src/app/(main)/(checkout)/payment/_components/BuyerInfoCard.tsx
@@ -5,16 +5,17 @@ import { TextField } from "@/ui/components/molecules";
 import type { BuyerInfo } from "@/core/schemas";
 
 interface BuyerInfoCardProps {
+  step: number;
   errors: Partial<Record<keyof BuyerInfo, string[]>>;
 }
 
-export function BuyerInfoCard({ errors }: BuyerInfoCardProps) {
+export function BuyerInfoCard({ step, errors }: BuyerInfoCardProps) {
   return (
     <Card className="border-border">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <span className="bg-primary/10 text-primary flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold">
-            1
+            {step}
           </span>
           구매자 정보
         </CardTitle>

--- a/src/app/(main)/(checkout)/payment/_components/CheckoutForm.test.tsx
+++ b/src/app/(main)/(checkout)/payment/_components/CheckoutForm.test.tsx
@@ -22,7 +22,12 @@ vi.mock("@/ui/stores", () => ({
 vi.mock("@/ui/hooks", () => ({
   usePortOnePayment: usePortOnePaymentMock,
   useCheckoutData: () => ({ data: null as unknown, loading: false }),
-  useCheckoutForm: () => ({ errors: {}, handleSubmit: vi.fn() }),
+  useCheckoutForm: () => ({
+    errors: {},
+    shippingErrors: {},
+    requiresShipping: false,
+    handleSubmit: vi.fn(),
+  }),
 }));
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn() } }));

--- a/src/app/(main)/(checkout)/payment/_components/CheckoutForm.tsx
+++ b/src/app/(main)/(checkout)/payment/_components/CheckoutForm.tsx
@@ -42,7 +42,11 @@ export function CheckoutForm() {
   // 직접 참조해 "주문 없음" 오탐 리다이렉트를 알아서 가드한다(OrderSummary도 동일).
   const { data: order, loading } = useCheckoutData();
 
-  const { errors, handleSubmit } = useCheckoutForm({ order, action, router });
+  const { errors, shippingErrors, requiresShipping, handleSubmit } = useCheckoutForm({
+    order,
+    action,
+    router,
+  });
 
   const [prevActionState, setPrevActionState] = useState(state);
   if (state !== prevActionState) {
@@ -90,6 +94,8 @@ export function CheckoutForm() {
       onAgreedChange={setAgreed}
       errorMessage={errorMessage}
       errors={errors}
+      requiresShipping={requiresShipping}
+      shippingErrors={shippingErrors}
       pending={pending}
       onSubmit={handleFormSubmit}
     />

--- a/src/app/(main)/(checkout)/payment/_components/ShippingInfoCard.tsx
+++ b/src/app/(main)/(checkout)/payment/_components/ShippingInfoCard.tsx
@@ -47,7 +47,8 @@ export function ShippingInfoCard({ step, errors }: ShippingInfoCardProps) {
         <AddressField
           name="ship"
           required
-          error={errors.address?.[0] ?? errors.addressDetail?.[0]}
+          error={errors.address?.[0]}
+          addressDetailError={errors.addressDetail?.[0]}
         />
       </CardContent>
     </Card>

--- a/src/app/(main)/(checkout)/payment/_components/ShippingInfoCard.tsx
+++ b/src/app/(main)/(checkout)/payment/_components/ShippingInfoCard.tsx
@@ -1,41 +1,54 @@
 import { Card, CardContent, CardHeader, CardTitle, Input } from "@/ui/components/atoms";
-import { FormField } from "@/ui/components/molecules";
+import { AddressField, FormField } from "@/ui/components/molecules";
+import type { ShippingInfo } from "@/core/schemas";
 
-// 배송 정보는 아직 저장할 곳이 없다(Order 모델에 주소 필드 없음, 별도 Issue로 등록 예정 —
-// feat/brand-design-tokens plan 참고) — 그래서 아래 입력들은 의도적으로 name 속성이 없다.
-// name이 없는 input은 폼 제출(FormData) 시 자동으로 제외되므로, 여기서 값을 따로
-// 가로채 지우는 코드 없이도 "화면엔 있지만 서버로는 안 감"이 보장된다.
-export function ShippingInfoCard() {
+interface ShippingInfoCardProps {
+  step: number;
+  errors: Partial<Record<keyof ShippingInfo, string[]>>;
+}
+
+// 실물 상품(favor/accessory/guestbook/ceremony) 주문일 때만 렌더된다 — 모바일초대장
+// 주문은 배송이 필요 없어 이 카드 자체가 트리에서 빠진다(CheckoutForm organism 참고).
+// 그래서 여기 렌더되면 모든 필드가 항상 필수다.
+export function ShippingInfoCard({ step, errors }: ShippingInfoCardProps) {
   return (
     <Card className="border-border">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <span className="bg-primary/10 text-primary flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold">
-            2
+            {step}
           </span>
           배송 정보
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid gap-4 sm:grid-cols-2">
-          <FormField id="shippingReceiver" label="받는 분">
-            <Input id="shippingReceiver" type="text" placeholder="홍길동" />
+          <FormField id="shippingReceiver" label="받는 분" error={errors.receiver?.[0]} required>
+            <Input
+              id="shippingReceiver"
+              name="shippingReceiver"
+              type="text"
+              placeholder="홍길동"
+              required
+              aria-invalid={!!errors.receiver?.[0]}
+            />
           </FormField>
-          <FormField id="shippingPhone" label="연락처">
-            <Input id="shippingPhone" type="tel" placeholder="010-1234-5678" />
+          <FormField id="shippingPhone" label="연락처" error={errors.phone?.[0]} required>
+            <Input
+              id="shippingPhone"
+              name="shippingPhone"
+              type="tel"
+              placeholder="010-1234-5678"
+              required
+              aria-invalid={!!errors.phone?.[0]}
+            />
           </FormField>
         </div>
-        <FormField id="shippingAddress" label="배송 주소">
-          <Input
-            id="shippingAddress"
-            type="text"
-            placeholder="도로명 주소를 입력해주세요"
-          />
-        </FormField>
-        <p className="text-muted-foreground text-xs">
-          배송 정보는 저장 준비 중입니다. 실물 상품 주문 시에도 현재는 별도 안내로
-          연락드립니다.
-        </p>
+        <AddressField
+          name="ship"
+          required
+          error={errors.address?.[0] ?? errors.addressDetail?.[0]}
+        />
       </CardContent>
     </Card>
   );

--- a/src/app/(main)/(my-order)/my-orders/_components/PaymentButton.tsx
+++ b/src/app/(main)/(my-order)/my-orders/_components/PaymentButton.tsx
@@ -7,7 +7,7 @@ import { CreditCard } from "lucide-react";
 import { useOrderStore } from "@/ui/stores";
 import type { OrderJSON } from "@/core/domain";
 import type { CheckoutItem } from "@/core/domain";
-import { routes } from "@/core/domain";
+import { routes, MOBILE_INVITATION_CATEGORY } from "@/core/domain";
 import { completePayment } from "@/actions";
 
 const PaymentButton = ({ order }: { order: OrderJSON }) => {
@@ -41,6 +41,9 @@ const PaymentButton = ({ order }: { order: OrderJSON }) => {
 
     const checkoutItem: CheckoutItem = {
       productId: order.product.productId.toString(),
+      // 재결제 흐름은 이 값을 실제로 쓰지 않는다(resumePayment 분기가 ShippingInfoCard
+      // 렌더 전에 걸린다) — 카테고리 정보 없는 레거시 주문 대비 안전한 기본값만 채운다.
+      category: order.product.category ?? MOBILE_INVITATION_CATEGORY,
       title: order.product.title,
       thumbnail: order.product.thumbnail,
       originalPrice: order.product.pricing.originalPrice,

--- a/src/app/(main)/(products)/products/[category]/[id]/_components/ProductSummary.test.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_components/ProductSummary.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 import type { CheckoutItem } from "@/core/domain";
+import { MOBILE_INVITATION_CATEGORY } from "@/core/domain";
 
 const { pushMock, setOrderMock } = vi.hoisted(() => ({
   pushMock: vi.fn(),
@@ -35,6 +36,7 @@ import { ProductSummary } from "./ProductSummary";
 
 const CHECKOUT_ITEM: CheckoutItem = {
   productId: "product-1",
+  category: MOBILE_INVITATION_CATEGORY,
   title: "봄맞이 청첩장",
   thumbnail: "https://example.com/thumb.jpg",
   originalPrice: 10000,

--- a/src/core/domain/checkout.ts
+++ b/src/core/domain/checkout.ts
@@ -1,7 +1,9 @@
 import type { SelectFeatureDto } from "@/core/schemas";
+import type { ProductCategory } from "./product-category";
 
 export interface CheckoutItem {
   productId: string;
+  category: ProductCategory;
 
   title: string;
   thumbnail: string;

--- a/src/core/domain/product-category.ts
+++ b/src/core/domain/product-category.ts
@@ -12,6 +12,12 @@ export const PRODUCT_CATEGORIES = [
 // 판단의 기준이 되는 값이라 리터럴 재입력 대신 이 상수를 쓴다).
 export const MOBILE_INVITATION_CATEGORY = "mobile-invitation" satisfies ProductCategory;
 
+// 모바일초대장만 배송이 필요 없는 유일한 카테고리다 — 이 판단을 쓰는 모든
+// 레이어(클라이언트 폼/서비스 검증/DB conditional required)가 이 함수 하나로
+// 수렴해야 카테고리 추가·rename 시 한 곳만 고치면 된다.
+export const categoryRequiresShipping = (category: ProductCategory | undefined): boolean =>
+  category !== MOBILE_INVITATION_CATEGORY;
+
 export const SUB_CATEGORY_MAP = {
   "mobile-invitation": ["wedding", "first-birthday"],
   favor: ["candle", "diffuser", "soap", "magnet", "handkerchief", "cookie"],

--- a/src/core/schemas/request/order.schema.ts
+++ b/src/core/schemas/request/order.schema.ts
@@ -1,5 +1,14 @@
-import { PAY_METHOD } from "@/core/domain";
+import { PAY_METHOD, PRODUCT_CATEGORIES } from "@/core/domain";
 import * as z from "zod";
+
+export const ShippingInfoSchema = z.object({
+  receiver: z.string().min(2, "받는 분 이름은 2자 이상 입력해주세요."),
+  phone: z.string().regex(/^\d{3}-\d{3,4}-\d{4}$/, {
+    message: "연락처 형식이 올바르지 않습니다.",
+  }),
+  address: z.string().min(1, "주소를 입력해주세요."),
+  addressDetail: z.string().min(1, "상세 주소를 입력해주세요."),
+});
 
 export const BuyerInfoSchema = z.object({
   buyerName: z.string().min(2, { message: "이름은 2자 이상 입력해주세요." }),
@@ -23,6 +32,7 @@ const ProductSnapshotSchema = z.object({
   productId: z.string().min(1, "상품 ID가 필요합니다."),
   title: z.string().min(1, "상품명은 필수입니다."),
   thumbnail: z.string().url("유효한 이미지 경로가 필요합니다."),
+  category: z.enum(PRODUCT_CATEGORIES),
   pricing: z.object({
     originalPrice: z.number().min(0),
     discountedPrice: z.number().min(0),
@@ -47,8 +57,14 @@ export const createOrderSchema = BuyerInfoSchema.extend({
   // 할인은 옵션일 수 있으므로 0을 기본값으로
   discountRate: z.number().min(0).max(1).default(0),
   discountAmount: z.number().min(0).default(0),
+
+  // 실물 카테고리만 필수 — 모바일초대장은 배송이 필요 없어 폼에 입력 자체가 없다.
+  // "카테고리별 필수 여부"라는 교차 필드 규칙은 여기서 강제하지 않고 서비스
+  // 레이어(createOrderService)가 맡는다(REQ-5 수량 검증과 같은 패턴).
+  shipping: ShippingInfoSchema.optional(),
 });
 
 export type SelectFeatureDto = z.infer<typeof SelectedFeatureSchema>;
 export type BuyerInfo = z.infer<typeof BuyerInfoSchema>;
+export type ShippingInfo = z.infer<typeof ShippingInfoSchema>;
 export type CreateOrderDto = z.infer<typeof createOrderSchema>;

--- a/src/core/schemas/request/order.schema.ts
+++ b/src/core/schemas/request/order.schema.ts
@@ -1,11 +1,13 @@
 import { PAY_METHOD, PRODUCT_CATEGORIES } from "@/core/domain";
 import * as z from "zod";
 
+const PhoneSchema = z.string().regex(/^\d{3}-\d{3,4}-\d{4}$/, {
+  message: "연락처 형식이 올바르지 않습니다.",
+});
+
 export const ShippingInfoSchema = z.object({
   receiver: z.string().min(2, "받는 분 이름은 2자 이상 입력해주세요."),
-  phone: z.string().regex(/^\d{3}-\d{3,4}-\d{4}$/, {
-    message: "연락처 형식이 올바르지 않습니다.",
-  }),
+  phone: PhoneSchema,
   address: z.string().min(1, "주소를 입력해주세요."),
   addressDetail: z.string().min(1, "상세 주소를 입력해주세요."),
 });
@@ -13,9 +15,7 @@ export const ShippingInfoSchema = z.object({
 export const BuyerInfoSchema = z.object({
   buyerName: z.string().min(2, { message: "이름은 2자 이상 입력해주세요." }),
   buyerEmail: z.string().email({ message: "유효한 이메일을 입력해주세요." }),
-  buyerPhone: z.string().regex(/^\d{3}-\d{3,4}-\d{4}$/, {
-    message: "연락처 형식이 올바르지 않습니다.",
-  }),
+  buyerPhone: PhoneSchema,
   payMethod: z.enum(PAY_METHOD, {
     message: "결제 수단을 선택해주세요.",
   }),
@@ -45,9 +45,7 @@ export const createOrderSchema = BuyerInfoSchema.extend({
   // 결제 이후 my-orders 흐름에서 채워지는 콘텐츠라 주문 생성 시점엔 없을 수 있다.
   buyerName: z.string().min(2, "이름은 2자 이상 입력해주세요."),
   buyerEmail: z.email("유효한 이메일을 입력해주세요."),
-  buyerPhone: z
-    .string()
-    .regex(/^\d{3}-\d{3,4}-\d{4}$/, "연락처 형식이 올바르지 않습니다."),
+  buyerPhone: PhoneSchema,
 
   // 평면적인 필드들을 'product' 객체로 묶음
   product: ProductSnapshotSchema,

--- a/src/models/order.model.ts
+++ b/src/models/order.model.ts
@@ -1,8 +1,8 @@
 import "server-only";
 import type { Types, Model } from "mongoose";
 import mongoose, { Schema } from "mongoose";
-import type { PayMethod } from "@/core/domain";
-import { PAY_METHOD } from "@/core/domain";
+import type { PayMethod, ProductCategory } from "@/core/domain";
+import { PAY_METHOD, PRODUCT_CATEGORIES, MOBILE_INVITATION_CATEGORY } from "@/core/domain";
 export type { OrderJSON } from "@/core/domain";
 interface ProductPricing {
   originalPrice: number;
@@ -19,9 +19,17 @@ interface ProductSnapShot {
   productId: Types.ObjectId | string;
   title: string;
   thumbnail: string;
+  category: ProductCategory;
   pricing: ProductPricing;
   quantity: number;
   selectedFeatures: SelectedFeatureSnapShot[];
+}
+
+export interface ShippingInfo {
+  receiver: string;
+  phone: string;
+  address: string;
+  addressDetail: string;
 }
 
 const selectedFeatureSnapShotSchema = new Schema<SelectedFeatureSnapShot>(
@@ -49,6 +57,7 @@ const ProductSnapShotSchema = new Schema<ProductSnapShot>(
     },
     title: { type: String, required: true },
     thumbnail: { type: String, required: true },
+    category: { type: String, enum: PRODUCT_CATEGORIES, required: true },
     pricing: {
       originalPrice: { type: Number, required: true },
       discountedPrice: {
@@ -61,6 +70,16 @@ const ProductSnapShotSchema = new Schema<ProductSnapShot>(
       type: [selectedFeatureSnapShotSchema],
       default: [],
     },
+  },
+  { _id: false },
+);
+
+const ShippingInfoSchema = new Schema<ShippingInfo>(
+  {
+    receiver: { type: String, required: true },
+    phone: { type: String, required: true },
+    address: { type: String, required: true },
+    addressDetail: { type: String, required: true },
   },
   { _id: false },
 );
@@ -82,6 +101,9 @@ export interface IOrder {
   buyerEmail: string;
   buyerPhone: string;
   product: ProductSnapShot;
+  // 모바일초대장 카테고리는 배송이 필요 없어 없을 수 있다 — required 여부는
+  // orderSchema.shipping의 conditional required(형제 필드 product.category 참조)가 정한다.
+  shipping?: ShippingInfo;
   finalPrice: number;
   discountRate: number;
   discountAmount: number;
@@ -115,6 +137,16 @@ const orderSchema = new Schema<IOrder>(
 
     // 상품정보
     product: { type: ProductSnapShotSchema, required: true },
+    // 실물 카테고리 주문의 최후 방어선 — createOrderService가 1차로 사용자에게
+    // 보이는 VALIDATION 에러를 던지고, 여기는 그 체크를 우회하는 미래의 다른
+    // 코드 경로까지 막는 안전망이다(도달하면 버그이므로 mongoose 에러 그대로
+    // AppError(INTERNAL)로 감싸지는 게 맞다 — services/AGENTS.md 컨벤션).
+    shipping: {
+      type: ShippingInfoSchema,
+      required: function (this: IOrder) {
+        return this.product.category !== MOBILE_INVITATION_CATEGORY;
+      },
+    },
     finalPrice: { type: Number, required: true },
     discountRate: { type: Number, default: 0, min: 0, max: 1 },
     discountAmount: { type: Number, default: 0 },

--- a/src/models/order.model.ts
+++ b/src/models/order.model.ts
@@ -2,7 +2,7 @@ import "server-only";
 import type { Types, Model } from "mongoose";
 import mongoose, { Schema } from "mongoose";
 import type { PayMethod, ProductCategory } from "@/core/domain";
-import { PAY_METHOD, PRODUCT_CATEGORIES, MOBILE_INVITATION_CATEGORY } from "@/core/domain";
+import { PAY_METHOD, PRODUCT_CATEGORIES, categoryRequiresShipping } from "@/core/domain";
 export type { OrderJSON } from "@/core/domain";
 interface ProductPricing {
   originalPrice: number;
@@ -141,10 +141,17 @@ const orderSchema = new Schema<IOrder>(
     // 보이는 VALIDATION 에러를 던지고, 여기는 그 체크를 우회하는 미래의 다른
     // 코드 경로까지 막는 안전망이다(도달하면 버그이므로 mongoose 에러 그대로
     // AppError(INTERNAL)로 감싸지는 게 맞다 — services/AGENTS.md 컨벤션).
+    //
+    // discriminator로 안 뺀 이유(AGENTS.md 하위타입 전용 필드 규칙 검토 결과):
+    // (1) 판별 필드(product.category)가 base 스키마의 root path가 아니라 product
+    // 서브도큐먼트 안에 있어 mongoose discriminatorKey로 재사용할 수 없다.
+    // (2) 5개 카테고리 중 4개가 이 필드를 요구해 "하위 타입 전용 필드"라기보다
+    // "한 카테고리만 예외인 필드"에 가깝다 — discriminator로 쪼개도 예외 카테고리
+    // (mobile-invitation) 하나만 shipping 없는 서브타입이 되어 얻는 이득이 적다.
     shipping: {
       type: ShippingInfoSchema,
       required: function (this: IOrder) {
-        return this.product.category !== MOBILE_INVITATION_CATEGORY;
+        return categoryRequiresShipping(this.product.category);
       },
     },
     finalPrice: { type: Number, required: true },

--- a/src/services/dashboard.integration.test.ts
+++ b/src/services/dashboard.integration.test.ts
@@ -8,6 +8,7 @@ import {
   clearCollections,
 } from "@testing/support";
 import { getKstMonthRange } from "@/core/utils";
+import { MOBILE_INVITATION_CATEGORY } from "@/core/domain";
 import { OrderModel, ProductModel, UserModel } from "@/models";
 import { createOrderService } from "./order";
 import { createProductService } from "./product";
@@ -261,6 +262,7 @@ describe("getDashboardStatsService", () => {
             productId: defaultProductId,
             title: "스냅샷 확인용 상품명",
             thumbnail: "https://example.com/thumbnail.jpg",
+            category: MOBILE_INVITATION_CATEGORY,
             pricing: { originalPrice: 9900, discountedPrice: 9900 },
             quantity: 1,
             selectedFeatures: [],

--- a/src/services/order.integration.test.ts
+++ b/src/services/order.integration.test.ts
@@ -111,6 +111,7 @@ describe("order", () => {
           product: {
             productId: product!._id.toString(),
             title: productInput.title,
+            category: productInput.category,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 9900, discountedPrice: 9900 },
             quantity: 2,
@@ -139,6 +140,7 @@ describe("order", () => {
           product: {
             productId: product!._id.toString(),
             title: productInput.title,
+            category: productInput.category,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 9900, discountedPrice: 9900 },
             quantity: 6,
@@ -166,6 +168,7 @@ describe("order", () => {
           product: {
             productId: product!._id.toString(),
             title: productInput.title,
+            category: productInput.category,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 9900, discountedPrice: 9900 },
             quantity: 999,
@@ -192,6 +195,7 @@ describe("order", () => {
           product: {
             productId: product!._id.toString(),
             title: productInput.title,
+            category: productInput.category,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 9900, discountedPrice: 9900 },
             quantity: 5,
@@ -210,6 +214,7 @@ describe("order", () => {
           product: {
             productId: missingProductId,
             title: "존재하지 않는 상품",
+            category: MOBILE_INVITATION_CATEGORY,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 9900, discountedPrice: 9900 },
             quantity: 1,
@@ -250,6 +255,7 @@ describe("order", () => {
           product: {
             productId: legacyProductId,
             title: "레거시 주문 상품",
+            category: MOBILE_INVITATION_CATEGORY,
             thumbnail: "https://example.com/legacy.jpg",
             pricing: { originalPrice: 1000, discountedPrice: 1000 },
             quantity: 2,
@@ -264,6 +270,7 @@ describe("order", () => {
           product: {
             productId: legacyProductId,
             title: "레거시 주문 상품",
+            category: MOBILE_INVITATION_CATEGORY,
             thumbnail: "https://example.com/legacy.jpg",
             pricing: { originalPrice: 1000, discountedPrice: 1000 },
             quantity: 1,
@@ -275,6 +282,83 @@ describe("order", () => {
       });
     });
 
+    describe("배송 정보 필수 여부", () => {
+      const buildPhysicalProductId = async () => {
+        const productInput = buildProductInput({
+          category: "favor",
+          subCategory: "candle",
+          minQuantity: 1,
+          maxQuantity: 0,
+        });
+        await createProductService(productInput);
+        const product = await ProductModel.findOne({
+          title: productInput.title,
+        }).lean();
+        return product!._id.toString();
+      };
+
+      it("실물 카테고리인데 배송 정보가 없으면 VALIDATION을 던지고 주문이 생성되지 않는다", async () => {
+        const productId = await buildPhysicalProductId();
+        const input = buildOrderInput({
+          product: {
+            productId,
+            title: "답례품 캔들",
+            category: "favor",
+            thumbnail: "https://example.com/thumbnail.jpg",
+            pricing: { originalPrice: 9900, discountedPrice: 9900 },
+            quantity: 1,
+            selectedFeatures: [],
+          },
+        });
+
+        await expect(createOrderService(input)).rejects.toMatchObject({
+          category: "VALIDATION",
+          message: "배송 정보를 입력해주세요.",
+        });
+        expect(await OrderModel.countDocuments({})).toBe(0);
+      });
+
+      it("실물 카테고리 + 배송 정보를 채우면 order.shipping/product.category가 저장된다", async () => {
+        const productId = await buildPhysicalProductId();
+        const input = buildOrderInput({
+          product: {
+            productId,
+            title: "답례품 캔들",
+            category: "favor",
+            thumbnail: "https://example.com/thumbnail.jpg",
+            pricing: { originalPrice: 9900, discountedPrice: 9900 },
+            quantity: 1,
+            selectedFeatures: [],
+          },
+          shipping: {
+            receiver: "홍길동",
+            phone: "010-1234-5678",
+            address: "서울시 강남구",
+            addressDetail: "101동 202호",
+          },
+        });
+
+        const result = await createOrderService(input);
+
+        expect(result.product.category).toBe("favor");
+        expect(result.shipping).toMatchObject({
+          receiver: "홍길동",
+          phone: "010-1234-5678",
+          address: "서울시 강남구",
+          addressDetail: "101동 202호",
+        });
+      });
+
+      it("모바일초대장 카테고리는 배송 정보 없이도 정상 생성된다(기존 동작 유지)", async () => {
+        const input = buildOrderInputForTest();
+
+        const result = await createOrderService(input);
+
+        expect(result.product.category).toBe(MOBILE_INVITATION_CATEGORY);
+        expect(result.shipping).toBeUndefined();
+      });
+    });
+
     describe("finalPrice 계산", () => {
       it("할인 없으면 상품가*수량 + 옵션가 합산이 finalPrice다", async () => {
         const input = buildOrderInput({
@@ -283,6 +367,7 @@ describe("order", () => {
           product: {
             productId: defaultProductId,
             title: "봄맞이 청첩장",
+            category: MOBILE_INVITATION_CATEGORY,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 10000, discountedPrice: 10000 },
             quantity: 2,
@@ -309,6 +394,7 @@ describe("order", () => {
           product: {
             productId: defaultProductId,
             title: "봄맞이 청첩장",
+            category: MOBILE_INVITATION_CATEGORY,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 10000, discountedPrice: 10000 },
             quantity: 1,
@@ -328,6 +414,7 @@ describe("order", () => {
           product: {
             productId: defaultProductId,
             title: "봄맞이 청첩장",
+            category: MOBILE_INVITATION_CATEGORY,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 10000, discountedPrice: 10000 },
             quantity: 1,
@@ -347,6 +434,7 @@ describe("order", () => {
           product: {
             productId: defaultProductId,
             title: "봄맞이 청첩장",
+            category: MOBILE_INVITATION_CATEGORY,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 1000, discountedPrice: 1000 },
             quantity: 1,
@@ -366,6 +454,7 @@ describe("order", () => {
           product: {
             productId: defaultProductId,
             title: "봄맞이 청첩장",
+            category: MOBILE_INVITATION_CATEGORY,
             thumbnail: "https://example.com/thumbnail.jpg",
             pricing: { originalPrice: 999, discountedPrice: 999 },
             quantity: 1,

--- a/src/services/order.ts
+++ b/src/services/order.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_PAGE_SIZE,
   EXPIRED_ORDER_BATCH_LIMIT,
   INVITATION_INPUT_DEADLINE_DAYS,
+  MOBILE_INVITATION_CATEGORY,
   ORDER_PAGE_SIZE,
   ORDER_STATUSES,
   PENDING_ORDER_EXPIRE_HOURS,
@@ -72,6 +73,19 @@ export const createOrderService = async (
       "VALIDATION",
       `이 상품은 최대 ${maxQuantity}개까지 주문할 수 있습니다.`,
     );
+  }
+
+  // 실물 카테고리(모바일초대장 제외)는 배송 정보가 필수다 — 사용자에게 보이는
+  // 1차 방어선(REQ-5 수량 검증과 같은 패턴). Order 모델의 conditional required는
+  // 이 체크를 우회하는 미래의 다른 코드 경로를 막는 최후 방어선일 뿐이다.
+  if (
+    data.product.category !== MOBILE_INVITATION_CATEGORY &&
+    (!data.shipping?.receiver ||
+      !data.shipping.phone ||
+      !data.shipping.address ||
+      !data.shipping.addressDetail)
+  ) {
+    throw new AppError("VALIDATION", "배송 정보를 입력해주세요.");
   }
 
   const merchantUid = generateUid("ORDER");

--- a/src/services/order.ts
+++ b/src/services/order.ts
@@ -29,7 +29,7 @@ import {
   DEFAULT_PAGE_SIZE,
   EXPIRED_ORDER_BATCH_LIMIT,
   INVITATION_INPUT_DEADLINE_DAYS,
-  MOBILE_INVITATION_CATEGORY,
+  categoryRequiresShipping,
   ORDER_PAGE_SIZE,
   ORDER_STATUSES,
   PENDING_ORDER_EXPIRE_HOURS,
@@ -79,7 +79,7 @@ export const createOrderService = async (
   // 1차 방어선(REQ-5 수량 검증과 같은 패턴). Order 모델의 conditional required는
   // 이 체크를 우회하는 미래의 다른 코드 경로를 막는 최후 방어선일 뿐이다.
   if (
-    data.product.category !== MOBILE_INVITATION_CATEGORY &&
+    categoryRequiresShipping(data.product.category) &&
     (!data.shipping?.receiver ||
       !data.shipping.phone ||
       !data.shipping.address ||

--- a/src/services/payment.integration.test.ts
+++ b/src/services/payment.integration.test.ts
@@ -86,6 +86,7 @@ describe("payment", () => {
           productId: savedProduct!._id.toString(),
           title: productInput.title,
           thumbnail: productInput.thumbnail,
+          category: savedProduct!.category,
           pricing: { originalPrice: 9900, discountedPrice: 9900 },
           quantity,
           selectedFeatures: [],

--- a/src/ui/components/molecules/AddressField.test.tsx
+++ b/src/ui/components/molecules/AddressField.test.tsx
@@ -19,7 +19,7 @@ describe("AddressField", () => {
 
     render(<AddressField name="wedding" defaultValue="서울시 강남구" />);
 
-    expect(screen.getByRole("textbox")).toHaveValue("서울시 강남구");
+    expect(screen.getByRole("textbox", { name: "주소" })).toHaveValue("서울시 강남구");
   });
 
   it("입력 필드 클릭 시 handleDaumAddressPopup을 호출한다", async () => {
@@ -32,7 +32,7 @@ describe("AddressField", () => {
 
     render(<AddressField name="wedding" />);
 
-    await user.click(screen.getByRole("textbox"));
+    await user.click(screen.getByRole("textbox", { name: "주소" }));
 
     expect(handleDaumAddressPopup).toHaveBeenCalledOnce();
   });
@@ -51,6 +51,19 @@ describe("AddressField", () => {
     });
     rerender(<AddressField name="wedding" />);
 
-    expect(screen.getByRole("textbox")).toHaveValue("서울시 서초구");
+    expect(screen.getByRole("textbox", { name: "주소" })).toHaveValue("서울시 서초구");
+  });
+
+  it("상세 주소 필드의 id/name이 name prop을 따라간다(하드코딩 아님)", () => {
+    useDaumPopupMock.mockReturnValue({
+      address: "",
+      handleDaumAddressPopup: vi.fn(),
+    });
+
+    render(<AddressField name="ship" />);
+
+    const detailInput = screen.getByRole("textbox", { name: "상세 주소" });
+    expect(detailInput).toHaveAttribute("id", "shipAddressDetail");
+    expect(detailInput).toHaveAttribute("name", "ship_address_detail");
   });
 });

--- a/src/ui/components/molecules/AddressField.tsx
+++ b/src/ui/components/molecules/AddressField.tsx
@@ -9,8 +9,10 @@ interface AddressFieldProps {
   name: string;
   label?: string;
   error?: string;
+  addressDetailError?: string;
   required?: boolean;
   defaultValue?: string;
+  addressDetailDefaultValue?: string;
 }
 
 /**
@@ -20,8 +22,10 @@ const AddressField = ({
   name,
   label = "주소",
   error,
+  addressDetailError,
   required = false,
   defaultValue = "",
+  addressDetailDefaultValue = "",
 }: AddressFieldProps) => {
   const { handleDaumAddressPopup, address } = useDaumPopup();
   const [weddingAddress, setWeddingAddress] = useState(defaultValue);
@@ -61,6 +65,8 @@ const AddressField = ({
         type="text"
         placeholder="예: 3층 그랜드볼룸"
         required={required}
+        defaultValue={addressDetailDefaultValue}
+        error={addressDetailError}
       >
         상세 주소
       </TextField>

--- a/src/ui/components/molecules/AddressField.tsx
+++ b/src/ui/components/molecules/AddressField.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Input } from "@/ui/components/atoms";
-import { FormField } from "@/ui/components/molecules";
+import { FormField, TextField } from "@/ui/components/molecules";
 import { useDaumPopup } from "@/adapters/browser/daum";
 import { useState } from "react";
 
@@ -54,6 +54,16 @@ const AddressField = ({
         onClick={handleDaumAddressPopup}
         aria-invalid={!!error}
       />
+
+      <TextField
+        id={`${name}AddressDetail`}
+        name={`${name}_address_detail`}
+        type="text"
+        placeholder="예: 3층 그랜드볼룸"
+        required={required}
+      >
+        상세 주소
+      </TextField>
     </FormField>
   );
 };

--- a/src/ui/components/organisms/BasicInfoSection.tsx
+++ b/src/ui/components/organisms/BasicInfoSection.tsx
@@ -60,20 +60,13 @@ export function BasicInfoSection({ data, subwayStations }: BasicInfoSectionProps
           예식장명
         </TextField>
 
-        {/* Address */}
-        <AddressField required name="venue" defaultValue={data?.address} />
-
-        {/* Address Detail */}
-        <TextField
-          id="venueAddressDetail"
-          name="venue_address_detail"
-          type="text"
-          placeholder="예: 3층 그랜드볼룸"
-          defaultValue={data?.addressDetail}
+        {/* Address (+ 상세 주소는 AddressField 내부에서 함께 렌더) */}
+        <AddressField
           required
-        >
-          상세 주소
-        </TextField>
+          name="venue"
+          defaultValue={data?.address}
+          addressDetailDefaultValue={data?.addressDetail}
+        />
 
         {/* 인근 지하철 역 */}
         <ComboboxField

--- a/src/ui/components/organisms/CheckoutForm.test.tsx
+++ b/src/ui/components/organisms/CheckoutForm.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/adapters/browser/daum", () => ({
+  useDaumPopup: () => ({ address: "", handleDaumAddressPopup: vi.fn() }),
+}));
+
+import { CheckoutForm } from "./CheckoutForm";
+
+const baseProps = {
+  loading: false,
+  paymentStatus: "IDLE" as const,
+  agreed: false,
+  onAgreedChange: vi.fn(),
+  errorMessage: null as string | null,
+  errors: {},
+  shippingErrors: {},
+  pending: false,
+  onSubmit: vi.fn(),
+};
+
+describe("CheckoutForm (organism)", () => {
+  it("실물 상품 주문이면 배송 카드를 2번으로 보여주고 결제수단은 3번이 된다", () => {
+    render(<CheckoutForm {...baseProps} requiresShipping />);
+
+    expect(screen.getByText("배송 정보")).toBeInTheDocument();
+    const headings = screen.getAllByText(/^[123]$/);
+    expect(headings.map((el) => el.textContent)).toEqual(["1", "2", "3"]);
+  });
+
+  it("모바일초대장 주문이면 배송 카드가 없고 결제수단이 2번으로 당겨진다", () => {
+    render(<CheckoutForm {...baseProps} requiresShipping={false} />);
+
+    expect(screen.queryByText("배송 정보")).not.toBeInTheDocument();
+    const headings = screen.getAllByText(/^[12]$/);
+    expect(headings.map((el) => el.textContent)).toEqual(["1", "2"]);
+  });
+});

--- a/src/ui/components/organisms/CheckoutForm.tsx
+++ b/src/ui/components/organisms/CheckoutForm.tsx
@@ -47,7 +47,6 @@ export function CheckoutForm({
 
   // 배송 카드는 실물 상품 주문일 때만 트리에 들어간다 — 번호 배지는 그에 맞춰
   // 매번 다시 매긴다(카드를 숨긴다고 결제수단 배지가 "3"으로 남아 건너뛰지 않도록).
-  const shippingStep = requiresShipping ? 2 : undefined;
   const paymentStep = requiresShipping ? 3 : 2;
 
   return (
@@ -55,9 +54,7 @@ export function CheckoutForm({
       <PaymentPendingOverlay visible={paymentStatus === "PENDING"} />
       <form onSubmit={onSubmit} className="space-y-6 pb-24">
         <BuyerInfoCard step={1} errors={errors} />
-        {requiresShipping && shippingStep && (
-          <ShippingInfoCard step={shippingStep} errors={shippingErrors} />
-        )}
+        {requiresShipping && <ShippingInfoCard step={2} errors={shippingErrors} />}
         <TermsAgreementCard agreed={agreed} onAgreedChange={onAgreedChange} />
         <PaymentMethodSelector step={paymentStep} error={errors.payMethod?.[0]} />
 

--- a/src/ui/components/organisms/CheckoutForm.tsx
+++ b/src/ui/components/organisms/CheckoutForm.tsx
@@ -1,7 +1,7 @@
 import { AlertCircle } from "lucide-react";
 
 import type { PayStatus } from "@/core/domain";
-import type { BuyerInfo } from "@/core/schemas";
+import type { BuyerInfo, ShippingInfo } from "@/core/schemas";
 
 import { Spinner } from "@/ui/components/molecules";
 import { PaymentPendingOverlay } from "@/app/(main)/(checkout)/payment/_components/PaymentPendingOverlay";
@@ -19,6 +19,8 @@ interface CheckoutFormProps {
   onAgreedChange: (agreed: boolean) => void;
   errorMessage: string | null;
   errors: Partial<Record<keyof BuyerInfo, string[]>>;
+  requiresShipping: boolean;
+  shippingErrors: Partial<Record<keyof ShippingInfo, string[]>>;
   pending: boolean;
   onSubmit: (e: React.FormEvent) => void;
 }
@@ -30,6 +32,8 @@ export function CheckoutForm({
   onAgreedChange,
   errorMessage,
   errors,
+  requiresShipping,
+  shippingErrors,
   pending,
   onSubmit,
 }: CheckoutFormProps) {
@@ -41,14 +45,21 @@ export function CheckoutForm({
     );
   }
 
+  // 배송 카드는 실물 상품 주문일 때만 트리에 들어간다 — 번호 배지는 그에 맞춰
+  // 매번 다시 매긴다(카드를 숨긴다고 결제수단 배지가 "3"으로 남아 건너뛰지 않도록).
+  const shippingStep = requiresShipping ? 2 : undefined;
+  const paymentStep = requiresShipping ? 3 : 2;
+
   return (
     <div className="relative">
       <PaymentPendingOverlay visible={paymentStatus === "PENDING"} />
       <form onSubmit={onSubmit} className="space-y-6 pb-24">
-        <BuyerInfoCard errors={errors} />
-        <ShippingInfoCard />
+        <BuyerInfoCard step={1} errors={errors} />
+        {requiresShipping && shippingStep && (
+          <ShippingInfoCard step={shippingStep} errors={shippingErrors} />
+        )}
         <TermsAgreementCard agreed={agreed} onAgreedChange={onAgreedChange} />
-        <PaymentMethodSelector error={errors.payMethod?.[0]} />
+        <PaymentMethodSelector step={paymentStep} error={errors.payMethod?.[0]} />
 
         {errorMessage && (
           <div className="border-destructive/50 bg-destructive/10 text-destructive flex items-start gap-3 rounded-lg border p-4 text-sm">

--- a/src/ui/components/organisms/PaymentMethodSelector.test.tsx
+++ b/src/ui/components/organisms/PaymentMethodSelector.test.tsx
@@ -5,7 +5,7 @@ import { PaymentMethodSelector } from "./PaymentMethodSelector";
 
 describe("PaymentMethodSelector", () => {
   it("결제 수단 6종을 라디오로 렌더링하고 기본값(카드)이 선택돼 있다", () => {
-    render(<PaymentMethodSelector />);
+    render(<PaymentMethodSelector step={3} />);
 
     const radios = screen.getAllByRole("radio");
     expect(radios).toHaveLength(6);
@@ -14,7 +14,7 @@ describe("PaymentMethodSelector", () => {
 
   it("다른 결제 수단을 클릭하면 그 항목만 선택 상태로 바뀐다", async () => {
     const user = userEvent.setup();
-    render(<PaymentMethodSelector />);
+    render(<PaymentMethodSelector step={3} />);
 
     const easyPay = screen.getByRole("radio", { name: "간편결제 카카오페이·네이버페이 등" });
     await user.click(easyPay);
@@ -24,7 +24,7 @@ describe("PaymentMethodSelector", () => {
   });
 
   it("error prop이 있으면 에러 메시지를 보여준다", () => {
-    render(<PaymentMethodSelector error="결제 수단을 선택해주세요." />);
+    render(<PaymentMethodSelector step={3} error="결제 수단을 선택해주세요." />);
 
     expect(screen.getByText("결제 수단을 선택해주세요.")).toBeInTheDocument();
   });

--- a/src/ui/components/organisms/PaymentMethodSelector.tsx
+++ b/src/ui/components/organisms/PaymentMethodSelector.tsx
@@ -50,13 +50,13 @@ const PAYMENT_METHODS: RadioFieldOption<PayMethod>[] = [
   },
 ];
 
-const PaymentMethodSelector = ({ error }: { error?: string }) => {
+const PaymentMethodSelector = ({ step, error }: { step: number; error?: string }) => {
   return (
     <Card className="border-border">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <span className="bg-primary/10 text-primary flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold">
-            3
+            {step}
           </span>
           결제 수단 {error && <Alert type="error">{error}</Alert>}
         </CardTitle>

--- a/src/ui/components/organisms/ProductOptions.tsx
+++ b/src/ui/components/organisms/ProductOptions.tsx
@@ -115,6 +115,7 @@ const ProductOptions = ({
 
     const checkoutData: CheckoutItem = {
       productId: product._id.toString(),
+      category: product.category,
       title: product.title,
       thumbnail: product.thumbnail,
       originalPrice: product.price,

--- a/src/ui/hooks/useCheckoutForm.test.ts
+++ b/src/ui/hooks/useCheckoutForm.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import type { CheckoutItem } from "@/core/domain";
+import { MOBILE_INVITATION_CATEGORY } from "@/core/domain";
 import { useCheckoutForm } from "./useCheckoutForm";
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
@@ -9,6 +10,7 @@ import { toast } from "sonner";
 
 const buildOrder = (overrides?: Partial<CheckoutItem>): CheckoutItem => ({
   productId: "product-1",
+  category: MOBILE_INVITATION_CATEGORY,
   title: "봄맞이 청첩장",
   thumbnail: "https://example.com/thumb.jpg",
   originalPrice: 10000,
@@ -21,13 +23,14 @@ const buildOrder = (overrides?: Partial<CheckoutItem>): CheckoutItem => ({
   ...overrides,
 });
 
-const buildSubmitEvent = () => {
+const buildSubmitEvent = (extraFields?: Record<string, string>) => {
   const form = document.createElement("form");
   const fields = {
     buyerName: "홍길동",
     buyerEmail: "test@example.com",
     buyerPhone: "010-1234-5678",
     payMethod: "CARD",
+    ...extraFields,
   };
   Object.entries(fields).forEach(([name, value]) => {
     const input = document.createElement("input");
@@ -112,6 +115,50 @@ describe("useCheckoutForm", () => {
     expect(action).toHaveBeenCalledTimes(1);
     const formData = action.mock.calls[0][0] as FormData;
     expect(formData.get("productId")).toBe("product-1");
+    expect(formData.get("productCategory")).toBe(MOBILE_INVITATION_CATEGORY);
     expect(result.current.errors).toEqual({});
+  });
+
+  it("실물 카테고리인데 배송 정보가 비어있으면 shippingErrors에 담고 action을 호출하지 않는다", () => {
+    const routerReplace = vi.fn();
+    const action = vi.fn();
+    const order = buildOrder({ category: "favor" });
+    const { result } = renderHook(() =>
+      useCheckoutForm({ order, action, router: { replace: routerReplace } as never }),
+    );
+
+    expect(result.current.requiresShipping).toBe(true);
+
+    act(() => {
+      result.current.handleSubmit(buildSubmitEvent());
+    });
+
+    expect(action).not.toHaveBeenCalled();
+    expect(result.current.shippingErrors.receiver).toBeDefined();
+  });
+
+  it("실물 카테고리 + 배송 정보를 채우면 formData에 담아 action을 호출한다", () => {
+    const routerReplace = vi.fn();
+    const action = vi.fn();
+    const order = buildOrder({ category: "favor" });
+    const { result } = renderHook(() =>
+      useCheckoutForm({ order, action, router: { replace: routerReplace } as never }),
+    );
+
+    act(() => {
+      result.current.handleSubmit(
+        buildSubmitEvent({
+          shippingReceiver: "홍길동",
+          shippingPhone: "010-1234-5678",
+          ship_address: "서울시 강남구",
+          ship_address_detail: "101동 202호",
+        }),
+      );
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    const formData = action.mock.calls[0][0] as FormData;
+    expect(formData.get("productCategory")).toBe("favor");
+    expect(result.current.shippingErrors).toEqual({});
   });
 });

--- a/src/ui/hooks/useCheckoutForm.ts
+++ b/src/ui/hooks/useCheckoutForm.ts
@@ -4,11 +4,11 @@ import { useState, startTransition } from "react";
 import type React from "react";
 import { toast } from "sonner";
 import { validateAndFlatten } from "@/core/utils";
-import type { BuyerInfo } from "@/core/schemas";
-import { BuyerInfoSchema } from "@/core/schemas";
+import type { BuyerInfo, ShippingInfo } from "@/core/schemas";
+import { BuyerInfoSchema, ShippingInfoSchema } from "@/core/schemas";
 import type { CheckoutItem } from "@/core/domain";
 import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
-import { routes } from "@/core/domain";
+import { routes, MOBILE_INVITATION_CATEGORY } from "@/core/domain";
 
 interface UseCheckoutFormOptions {
   order: CheckoutItem | null;
@@ -24,10 +24,16 @@ export function useCheckoutForm({
   const [errors, setErrors] = useState<
     Partial<Record<keyof BuyerInfo, string[]>>
   >({});
+  const [shippingErrors, setShippingErrors] = useState<
+    Partial<Record<keyof ShippingInfo, string[]>>
+  >({});
+
+  const requiresShipping = order?.category !== MOBILE_INVITATION_CATEGORY;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setErrors({});
+    setShippingErrors({});
 
     if (!order) {
       toast.error("주문 정보를 찾을 수 없습니다. 다시 시도해주세요.");
@@ -49,8 +55,23 @@ export function useCheckoutForm({
       return;
     }
 
+    if (requiresShipping) {
+      const shippingParsed = validateAndFlatten<ShippingInfo>(ShippingInfoSchema, {
+        receiver: formData.get("shippingReceiver") as string,
+        phone: formData.get("shippingPhone") as string,
+        address: formData.get("ship_address") as string,
+        addressDetail: formData.get("ship_address_detail") as string,
+      });
+
+      if (!shippingParsed.success) {
+        setShippingErrors(shippingParsed.error);
+        return;
+      }
+    }
+
     const {
       productId,
+      category,
       originalPrice,
       discountedPrice,
       quantity,
@@ -59,6 +80,7 @@ export function useCheckoutForm({
       title,
     } = order;
     formData.append("productId", productId);
+    formData.append("productCategory", category);
     formData.append("productTitle", title);
     formData.append("productThumbnail", thumbnail);
     formData.append("productQuantity", String(quantity));
@@ -68,5 +90,5 @@ export function useCheckoutForm({
     startTransition(() => action(formData));
   };
 
-  return { errors, handleSubmit };
+  return { errors, shippingErrors, requiresShipping, handleSubmit };
 }

--- a/src/ui/hooks/useCheckoutForm.ts
+++ b/src/ui/hooks/useCheckoutForm.ts
@@ -8,7 +8,7 @@ import type { BuyerInfo, ShippingInfo } from "@/core/schemas";
 import { BuyerInfoSchema, ShippingInfoSchema } from "@/core/schemas";
 import type { CheckoutItem } from "@/core/domain";
 import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
-import { routes, MOBILE_INVITATION_CATEGORY } from "@/core/domain";
+import { routes, categoryRequiresShipping } from "@/core/domain";
 
 interface UseCheckoutFormOptions {
   order: CheckoutItem | null;
@@ -28,7 +28,7 @@ export function useCheckoutForm({
     Partial<Record<keyof ShippingInfo, string[]>>
   >({});
 
-  const requiresShipping = order?.category !== MOBILE_INVITATION_CATEGORY;
+  const requiresShipping = categoryRequiresShipping(order?.category);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/ui/stores/order.store.test.ts
+++ b/src/ui/stores/order.store.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useOrderStore } from "./order.store";
 import type { CheckoutItem } from "@/core/domain";
+import { MOBILE_INVITATION_CATEGORY } from "@/core/domain";
 
 const mockOrder: CheckoutItem = {
   productId: "product-1",
+  category: MOBILE_INVITATION_CATEGORY,
   title: "청첩장",
   thumbnail: "https://example.com/thumb.png",
   originalPrice: 10000,

--- a/src/ui/stores/order.store.ts
+++ b/src/ui/stores/order.store.ts
@@ -45,9 +45,9 @@ export const useOrderStore = create<OrderState>()(
       // v1: CheckoutItem에 필수 category 필드가 추가됨 — 그 이전(version < 1)에
       // persist된 order는 category가 없어 그대로 두면 배송 필요 여부 판단과
       // FormData 직렬화가 깨진다. 버려서 사용자가 상품 페이지에서 다시 담게 한다.
-      migrate: (persistedState) => {
+      migrate: (persistedState): Pick<OrderState, "order" | "resumePayment"> => {
         const state = persistedState as Pick<OrderState, "order" | "resumePayment">;
-        return { ...state, order: null };
+        return { ...state, order: null as CheckoutItem | null };
       },
       partialize: (state): Pick<OrderState, "order" | "resumePayment"> => ({
         order: state.order,

--- a/src/ui/stores/order.store.ts
+++ b/src/ui/stores/order.store.ts
@@ -41,6 +41,14 @@ export const useOrderStore = create<OrderState>()(
     {
       name: "order-storage",
       storage: createJSONStorage(() => sessionStorage),
+      version: 1,
+      // v1: CheckoutItem에 필수 category 필드가 추가됨 — 그 이전(version < 1)에
+      // persist된 order는 category가 없어 그대로 두면 배송 필요 여부 판단과
+      // FormData 직렬화가 깨진다. 버려서 사용자가 상품 페이지에서 다시 담게 한다.
+      migrate: (persistedState) => {
+        const state = persistedState as Pick<OrderState, "order" | "resumePayment">;
+        return { ...state, order: null };
+      },
       partialize: (state): Pick<OrderState, "order" | "resumePayment"> => ({
         order: state.order,
         resumePayment: state.resumePayment,

--- a/testing/support/factories/order.factory.ts
+++ b/testing/support/factories/order.factory.ts
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import type { CreateOrderDto } from "@/core/schemas";
+import { MOBILE_INVITATION_CATEGORY } from "@/core/domain";
 
 export const buildOrderInput = (
   overrides?: Partial<CreateOrderDto & { userId: string }>,
@@ -15,6 +16,9 @@ export const buildOrderInput = (
     productId: new mongoose.Types.ObjectId().toString(),
     title: "봄맞이 청첩장",
     thumbnail: "https://example.com/thumbnail.jpg",
+    // 기본값은 배송이 필요 없는 카테고리로 둔다 — 배송 관련 테스트가 아닌
+    // 대다수 기존 테스트가 shipping fixture 없이도 그대로 통과하게 하기 위함.
+    category: MOBILE_INVITATION_CATEGORY,
     pricing: { originalPrice: 9900, discountedPrice: 9900 },
     quantity: 1,
     selectedFeatures: [],


### PR DESCRIPTION
## Summary

- 구매자 정보는 이미 Order 컬렉션에 저장되는데 배송 정보는 저장할 스키마가 없어 폼 입력이 조용히 유실되고 있었음(`ShippingInfoCard`가 의도적으로 `name` 없이 렌더). 작업 중이던 AddressField 연동 diff가 `name`을 붙이면서 이 안전장치가 깨졌는데 저장 계층은 그대로였고, 재사용한 `AddressField`의 상세주소 필드가 청첩장 도메인 id/name을 하드코딩하고 있어 값이 들어가도 엉뚱한 필드명으로 제출되는 버그도 있었음.
- `Order` 모델에 `product` 스냅샷과 동일한 패턴으로 `shipping` 서브도큐먼트를 추가하고, `CheckoutItem`/zod 스키마/FormData 전체에 `product.category`를 실어날라 "이 주문에 배송이 필요한가"(모바일초대장만 예외)를 클라이언트·서버 양쪽에서 판단할 수 있게 함.
- 검증은 2단계: `createOrderService`가 사용자에게 보이는 VALIDATION 에러를 1차로 던지고(REQ-5 수량 검증과 같은 패턴), Order 스키마의 `shipping` conditional required가 서비스 레이어를 우회하는 미래의 다른 코드 경로를 막는 최후 방어선 역할을 함.
- 배송이 필요 없는 주문(모바일초대장)은 배송 카드 자체가 트리에서 빠지고, 카드 번호 배지(1/2/3)는 하드코딩 대신 동적으로 계산되도록 바꿈.
- `AddressField`의 상세주소 id/name을 `venue` 하드코딩에서 `name` prop 기반으로 고쳐, `ship`/`venue` 두 소비처가 서로 다른 필드명으로 정상 제출되게 함(청첩장 쪽 결과는 기존과 동일해 무변경).

## Test plan

- `npm run tsc` — 에러 0
- `npm run test:unit` — 27 files / 239 tests 전부 통과
- `npm run test:component` — 109 files / 415 tests 전부 통과(신규: `CheckoutForm.test.tsx`(organism) 배지 번호 동적 계산 검증, `AddressField.test.tsx`에 상세주소 필드 name prop 파라미터화 회귀 테스트 추가, `useCheckoutForm.test.ts`에 배송 필수/입력 케이스 추가)
- `npm run test:integration` — 16 files 통과, 1건 실패(`order.integration.test.ts`의 레거시 수량 폴백 테스트)는 이 브랜치와 무관한 기존 버그(#161에서도 동일하게 확인) — 신규 추가한 "배송 정보 필수 여부" 3개 케이스(실물+배송없음→VALIDATION, 실물+배송있음→저장 확인, 모바일초대장→배송 없이도 정상 생성)는 전부 통과.
- `npm run lint` — 에러 2건은 다른 워크트리(`fix-admin-product-edit-modal`)의 생성된 `.next` 타입 파일이라 이 PR과 무관.

Base가 `dev`가 아니라 `refactor/mobile-invitation-category`(#161)인 이유: `MOBILE_INVITATION_CATEGORY` 상수와 배송 필요 여부 판단이 그 PR의 rename에 의존함 — #161이 `dev`에 머지되면 이 PR의 base도 `dev`로 옮긴다.