### PR TITLE
feat(guestbook)!: 방명록 목록에 cursor pagination을 도입한다

### DIFF
--- a/src/app/(preview)/preview/[publicKey]/_components/GuestbookSection.integration.test.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/GuestbookSection.integration.test.tsx
@@ -1,0 +1,176 @@
+// GuestbookSection.tsx는 useSWRInfinite + IntersectionObserver로 방명록 목록을
+// 커서 기반 무한스크롤로 불러온다. 이 파일은 그 hook→SWR→fetch→MSW 경계를 실제로
+// 관통시켜 (1) 첫 페이지 렌더, (2) 교차 관찰 트리거 시 다음 커서 페이지 병합,
+// (3) 작성/삭제 모달이 닫힐 때 전체 페이지 재검증이 실제로 일어나는지 검증한다.
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import type { GuestbookListResponse } from "@/core/schemas";
+import { useGuestbookModalStore } from "@/ui/stores";
+import { GuestbookSection } from "./GuestbookSection";
+
+const PUBLIC_KEY = "guestbook-infinite-scroll-test";
+
+// 테스트마다 새 SWR 캐시를 준다 — 기본 전역 캐시를 쓰면 같은 key(publicKey)로
+// 렌더하는 뒤쪽 테스트가 앞선 테스트의 캐시를 그대로 재사용해 네트워크 호출
+// 자체가 생략된다(useProductSearch.integration.test.tsx와 동일한 패턴).
+const renderGuestbookSection = () =>
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <GuestbookSection publicKey={PUBLIC_KEY} />
+    </SWRConfig>,
+  );
+
+const page1: GuestbookListResponse = {
+  items: [
+    {
+      _id: "entry-1",
+      author: "1페이지-작성자",
+      message: "1페이지 메시지",
+      isPrivate: false,
+      createdAt: "2026-08-20T00:00:00.000Z",
+    },
+  ],
+  nextCursor: "cursor-to-page-2",
+};
+
+const page2: GuestbookListResponse = {
+  items: [
+    {
+      _id: "entry-2",
+      author: "2페이지-작성자",
+      message: "2페이지 메시지",
+      isPrivate: false,
+      createdAt: "2026-08-19T00:00:00.000Z",
+    },
+  ],
+  nextCursor: null,
+};
+
+let requestedCursors: (string | null)[] = [];
+
+const server = setupServer(
+  http.get("http://localhost/api/guestbook", ({ request }) => {
+    const cursor = new URL(request.url).searchParams.get("cursor");
+    requestedCursors.push(cursor);
+    const data = cursor === "cursor-to-page-2" ? page2 : page1;
+    return HttpResponse.json({ success: true, data });
+  }),
+);
+
+const nativeFetch = globalThis.fetch;
+
+// jsdom-polyfill.ts의 IntersectionObserverMock은 콜백을 저장하지 않는 no-op이라
+// 교차 발생을 재현할 수 없다 — 이 파일에서만 콜백을 캡처하는 mock으로 교체한다.
+let latestIntersectionCallback: IntersectionObserverCallback | null = null;
+const nativeIntersectionObserver = globalThis.IntersectionObserver;
+
+class CapturingIntersectionObserverMock {
+  constructor(callback: IntersectionObserverCallback) {
+    latestIntersectionCallback = callback;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+  const interceptedFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const resolved =
+      typeof input === "string" && input.startsWith("/")
+        ? new URL(input, "http://localhost")
+        : input;
+    return interceptedFetch(resolved, init);
+  }) as typeof fetch;
+  globalThis.IntersectionObserver =
+    CapturingIntersectionObserverMock as unknown as typeof IntersectionObserver;
+});
+
+beforeEach(() => {
+  requestedCursors = [];
+  latestIntersectionCallback = null;
+  useGuestbookModalStore.getState().clearIsOpen();
+});
+
+afterEach(() => server.resetHandlers());
+
+afterAll(() => {
+  server.close();
+  globalThis.fetch = nativeFetch;
+  globalThis.IntersectionObserver = nativeIntersectionObserver;
+});
+
+describe("GuestbookSection — 실제 useSWRInfinite + MSW HTTP 경계", () => {
+  it("마운트 시 첫 페이지를 불러와 방명록을 렌더한다", async () => {
+    renderGuestbookSection();
+
+    expect(await screen.findByText("1페이지-작성자")).toBeInTheDocument();
+    expect(screen.getByText("1페이지 메시지")).toBeInTheDocument();
+    expect(screen.queryByText("2페이지-작성자")).not.toBeInTheDocument();
+    expect(requestedCursors).toEqual([null]);
+  });
+
+  it("무한스크롤 트리거가 교차하면 nextCursor로 다음 페이지를 이어붙인다", async () => {
+    renderGuestbookSection();
+    await screen.findByText("1페이지-작성자");
+
+    expect(latestIntersectionCallback).not.toBeNull();
+    await act(async () => {
+      latestIntersectionCallback!(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(await screen.findByText("2페이지-작성자")).toBeInTheDocument();
+    expect(screen.getByText("1페이지-작성자")).toBeInTheDocument();
+    // dedupingInterval:0인 테스트 캐시에서는 1페이지 재검증이 한 번 더 끼어들 수
+    // 있어 정확한 호출 횟수 대신 "커서 없이 시작해 2페이지 커서로 이어졌는가"만
+    // 검증한다 — 순서·값 자체는 실 브라우저 네트워크 트레이스로 별도 확인됨.
+    expect(requestedCursors[0]).toBeNull();
+    expect(requestedCursors).toContain("cursor-to-page-2");
+  });
+
+  it("방명록 작성/삭제 모달이 닫히면 로드된 페이지 전체를 재검증한다", async () => {
+    renderGuestbookSection();
+    await screen.findByText("1페이지-작성자");
+    expect(requestedCursors).toEqual([null]);
+
+    act(() => {
+      useGuestbookModalStore.getState().setIsOpen({
+        isOpen: true,
+        type: "WRITE_GUESTBOOK",
+        payload: { publicKey: PUBLIC_KEY },
+      });
+    });
+    act(() => {
+      useGuestbookModalStore.getState().closeModal();
+    });
+
+    await screen.findByText("1페이지-작성자");
+    expect(requestedCursors).toEqual([null, null]);
+  });
+
+  it("모달을 취소 없이 그냥 열기만 한 상태(닫히지 않음)에서는 재검증하지 않는다", async () => {
+    renderGuestbookSection();
+    await screen.findByText("1페이지-작성자");
+    expect(requestedCursors).toEqual([null]);
+
+    act(() => {
+      useGuestbookModalStore.getState().setIsOpen({
+        isOpen: true,
+        type: "WRITE_GUESTBOOK",
+        payload: { publicKey: PUBLIC_KEY },
+      });
+    });
+
+    expect(requestedCursors).toEqual([null]);
+  });
+});

--- a/src/app/(preview)/preview/[publicKey]/_components/GuestbookSection.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/GuestbookSection.tsx
@@ -53,14 +53,10 @@ export function GuestbookSection({ publicKey }: { publicKey: string }) {
   const { data: items } = mapDataToGuestbookProps(publicKey, pages);
   const hasMore = Boolean(pages.at(-1)?.nextCursor);
 
-  const [isDelete, setIsDelete] = useState<Record<string, boolean>>({});
-  useEffect(() => {
-    if (data) {
-      items.forEach((item) => {
-        setIsDelete((prev) => ({ ...prev, [item.id]: false }));
-      });
-    }
-  }, [data, items]);
+  // 새로 불러온 항목은 별도 초기화 없이도 isDelete[id]가 undefined(falsy)라 기본
+  // 애니메이션 상태(opacity 1)와 동일하다 — 매 렌더 재계산되는 items를 의존성에
+  // 넣어 매 렌더 setState하던 원래 초기화 effect는 무한 렌더 루프였다.
+  const [isDelete] = useState<Record<string, boolean>>({});
 
   const observerRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);

--- a/src/app/(preview)/preview/[publicKey]/_components/GuestbookSection.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/GuestbookSection.tsx
@@ -1,92 +1,149 @@
 "use client";
 
-import useSWR from "swr";
+import useSWRInfinite from "swr/infinite";
 import { fetcher } from "@/ui/fetcher";
 import { Button } from "@/ui/components/atoms";
 import { EyebrowSection } from "./EyebrowSection";
 import { PenLine, X } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import type { GuestbookListResponse } from "@/core/schemas";
 import { useGuestbookModalStore } from "@/ui/stores";
 import { mapDataToGuestbookProps } from "../_utils/guestbookSection.mapper";
 
+const buildKey = (publicKey: string, cursor?: string) => {
+  const params = new URLSearchParams({ publicKey });
+  if (cursor) params.set("cursor", cursor);
+  return `/api/guestbook?${params.toString()}`;
+};
+
 export function GuestbookSection({ publicKey }: { publicKey: string }) {
-  const { data: rawData } = useSWR<GuestbookListResponse>(
-    `/api/guestbook?publicKey=${publicKey}`,
-    (url) => fetcher<GuestbookListResponse>(url),
-    { revalidateOnFocus: false },
-  );
+  const { data, size, setSize, isValidating, mutate } =
+    useSWRInfinite<GuestbookListResponse>(
+      (pageIndex, previousPage) => {
+        if (pageIndex === 0) return buildKey(publicKey);
+        if (!previousPage?.nextCursor) return null;
+        return buildKey(publicKey, previousPage.nextCursor);
+      },
+      fetcher,
+      { revalidateOnFocus: false },
+    );
+
   const setIsOpen = useGuestbookModalStore((state) => state.setIsOpen);
-  const { data } = mapDataToGuestbookProps(publicKey, rawData ?? []);
+  const isOpen = useGuestbookModalStore((state) => state.isOpen);
+  const modalType = useGuestbookModalStore((state) => state.type);
+  const wasOpenRef = useRef(isOpen);
+
+  // 방명록 작성/삭제 모달이 닫힐 때 누적된 모든 페이지를 다시 검증한다 —
+  // 새 글은 1페이지 맨 위에, 삭제된 글은 목록에서 빠진 상태로 반영된다
+  // (OrderList.tsx의 onOrderChanged={() => mutate()}와 동일한 전체 재검증 패턴).
+  useEffect(() => {
+    const wasOpen = wasOpenRef.current;
+    wasOpenRef.current = isOpen;
+    if (
+      wasOpen &&
+      !isOpen &&
+      (modalType === "WRITE_GUESTBOOK" || modalType === "DELETE_GUESTBOOK")
+    ) {
+      mutate();
+    }
+  }, [isOpen, modalType, mutate]);
+
+  const pages = data ?? [];
+  const { data: items } = mapDataToGuestbookProps(publicKey, pages);
+  const hasMore = Boolean(pages.at(-1)?.nextCursor);
 
   const [isDelete, setIsDelete] = useState<Record<string, boolean>>({});
   useEffect(() => {
-    if (rawData) {
-      data.forEach((item) => {
+    if (data) {
+      items.forEach((item) => {
         setIsDelete((prev) => ({ ...prev, [item.id]: false }));
       });
     }
-  }, [rawData, data]);
+  }, [data, items]);
+
+  const observerRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!hasMore || isValidating) return;
+    const el = observerRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) setSize(size + 1);
+      },
+      { root: scrollContainerRef.current, rootMargin: "200px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore, isValidating, size, setSize]);
 
   return (
     <EyebrowSection eyebrow="GUESTBOOK" heading="방명록">
       <div className="flex flex-col items-center gap-4">
         <div className="h-full">
-          <ul className="space-y-4 py-2">
-            {rawData && data.length === 0 && (
-              <li className="text-muted-foreground py-6 text-center">
-                등록된 방명록이 없습니다.
-              </li>
-            )}
+          <div
+            ref={scrollContainerRef}
+            className="max-h-[480px] overflow-y-auto"
+          >
+            <ul className="space-y-4 py-2">
+              {data && items.length === 0 && (
+                <li className="text-muted-foreground py-6 text-center">
+                  등록된 방명록이 없습니다.
+                </li>
+              )}
 
-            {rawData &&
-              data.map((item) => (
-                <li
-                  className="border-border bg-card relative flex items-start gap-3 rounded-lg border p-3 shadow-sm"
-                  key={item.id}
-                >
-                  <motion.div
-                    initial={{ opacity: 0, y: -10 }}
-                    animate={{
-                      opacity: !isDelete[item.id] ? 1 : 0,
-                      y: !isDelete[item.id] ? 0 : -10,
-                    }}
-                    className="relative min-w-0 flex-1"
+              {data &&
+                items.map((item) => (
+                  <li
+                    className="border-border bg-card relative flex items-start gap-3 rounded-lg border p-3 shadow-sm"
+                    key={item.id}
                   >
-                    <p className="text-foreground truncate text-start text-sm font-semibold">
-                      {item.author}
-                    </p>
-                    <p className="overflow-scroll-hidden wrap-break-words text-muted-foreground mt-1 line-clamp-3 overflow-hidden text-sm">
-                      {item.message}
-                    </p>
-                    <motion.button
+                    <motion.div
                       initial={{ opacity: 0, y: -10 }}
                       animate={{
                         opacity: !isDelete[item.id] ? 1 : 0,
                         y: !isDelete[item.id] ? 0 : -10,
                       }}
-                      className="absolute top-0 right-0 cursor-pointer"
-                      onClick={() =>
-                        setIsOpen({
-                          isOpen: true,
-                          type: "DELETE_GUESTBOOK",
-                          payload: item.id,
-                        })
-                      }
+                      className="relative min-w-0 flex-1"
                     >
-                      <X className="h-4 w-4" />
-                    </motion.button>
-                  </motion.div>
-                </li>
-              ))}
+                      <p className="text-foreground truncate text-start text-sm font-semibold">
+                        {item.author}
+                      </p>
+                      <p className="overflow-scroll-hidden wrap-break-words text-muted-foreground mt-1 line-clamp-3 overflow-hidden text-sm">
+                        {item.message}
+                      </p>
+                      <motion.button
+                        initial={{ opacity: 0, y: -10 }}
+                        animate={{
+                          opacity: !isDelete[item.id] ? 1 : 0,
+                          y: !isDelete[item.id] ? 0 : -10,
+                        }}
+                        className="absolute top-0 right-0 cursor-pointer"
+                        onClick={() =>
+                          setIsOpen({
+                            isOpen: true,
+                            type: "DELETE_GUESTBOOK",
+                            payload: item.id,
+                          })
+                        }
+                      >
+                        <X className="h-4 w-4" />
+                      </motion.button>
+                    </motion.div>
+                  </li>
+                ))}
 
-            {!rawData && (
-              <li className="text-muted-foreground py-6 text-center">
-                방명록을 불러오는 중입니다.
-              </li>
-            )}
-          </ul>
+              {!data && (
+                <li className="text-muted-foreground py-6 text-center">
+                  방명록을 불러오는 중입니다.
+                </li>
+              )}
+
+              {hasMore && <div ref={observerRef} className="h-4" />}
+            </ul>
+          </div>
         </div>
 
         <Button

--- a/src/app/(preview)/preview/[publicKey]/_utils/guestbookSection.mapper.ts
+++ b/src/app/(preview)/preview/[publicKey]/_utils/guestbookSection.mapper.ts
@@ -12,14 +12,16 @@ export interface GuestbookSectionProps {
 
 export const mapDataToGuestbookProps = (
   id: string,
-  data: GuestbookListResponse,
+  pages: GuestbookListResponse[],
 ): GuestbookSectionProps => {
   return {
     id,
-    data: data.map((item) => ({
-      id: item._id,
-      author: item.author,
-      message: item.message,
-    })),
+    data: pages
+      .flatMap((page) => page.items)
+      .map((item) => ({
+        id: item._id,
+        author: item.author,
+        message: item.message,
+      })),
   };
 };

--- a/src/app/api/guestbook/route.ts
+++ b/src/app/api/guestbook/route.ts
@@ -1,22 +1,25 @@
 import type { APIRouteResponse} from "@/boundary";
 import { routeSuccess, routeError } from "@/boundary";
+import type { GuestbookListPage } from "@/core/domain";
 import { AppError } from "@/core/domain";
 import { getGuestbookService } from "@/services";
 import { getAuth } from "@/services";
-import type { IGuestbook } from "@/models";
 import type { GuestbookListResponse } from "@/core/schemas";
 import type { NextRequest } from "next/server";
 
 // getGuestbookService가 이미 password/__v/updatedAt은 select에서 제외한다 —
 // 여기선 응답 계약(GuestbookListResponse)에 맞춰 createdAt만 ISO 문자열로 명시 변환한다.
-function toGuestbookListResponse(guestbooks: IGuestbook[]): GuestbookListResponse {
-  return guestbooks.map(({ _id, author, message, isPrivate, createdAt }) => ({
-    _id: _id.toString(),
-    author,
-    message,
-    isPrivate,
-    createdAt: new Date(createdAt).toISOString(),
-  }));
+function toGuestbookListResponse(page: GuestbookListPage): GuestbookListResponse {
+  return {
+    items: page.items.map(({ id, author, message, isPrivate, createdAt }) => ({
+      _id: id,
+      author,
+      message,
+      isPrivate,
+      createdAt: new Date(createdAt).toISOString(),
+    })),
+    nextCursor: page.nextCursor,
+  };
 }
 
 export const GET = async (
@@ -25,10 +28,14 @@ export const GET = async (
   try {
     const publicKey = req.nextUrl.searchParams.get("publicKey");
     if (!publicKey) throw new AppError("VALIDATION", "publicKey가 필요합니다.");
+    const cursor = req.nextUrl.searchParams.get("cursor") ?? undefined;
 
     const auth = await getAuth();
-    const guestbooks = await getGuestbookService(publicKey, auth?.userId);
-    return routeSuccess(toGuestbookListResponse(guestbooks));
+    const page = await getGuestbookService(publicKey, {
+      cursor,
+      viewerUserId: auth?.userId,
+    });
+    return routeSuccess(toGuestbookListResponse(page));
   } catch (e) {
     return routeError(e);
   }

--- a/src/core/domain/guestbook.ts
+++ b/src/core/domain/guestbook.ts
@@ -1,0 +1,11 @@
+import type { CursorPage } from "./cursor";
+
+export interface GuestbookEntry {
+  id: string;
+  author: string;
+  message: string;
+  isPrivate: boolean;
+  createdAt: Date;
+}
+
+export type GuestbookListPage = CursorPage<GuestbookEntry>;

--- a/src/core/domain/index.ts
+++ b/src/core/domain/index.ts
@@ -7,6 +7,7 @@ export type * from "./dashboard";
 export * from "./error";
 export * from "./error-messages";
 export type * from "./field";
+export type * from "./guestbook";
 export type * from "./image";
 export * from "./navigation";
 export * from "./order";

--- a/src/core/schemas/response/guestbook.schema.ts
+++ b/src/core/schemas/response/guestbook.schema.ts
@@ -15,6 +15,9 @@ export const guestbookEntryResponseSchema = z.strictObject({
   createdAt: isoDateString,
 });
 
-export const guestbookListResponseSchema = z.array(guestbookEntryResponseSchema);
+export const guestbookListPageResponseSchema = z.object({
+  items: z.array(guestbookEntryResponseSchema),
+  nextCursor: z.string().nullable(),
+});
 
-export type GuestbookListResponse = z.infer<typeof guestbookListResponseSchema>;
+export type GuestbookListResponse = z.infer<typeof guestbookListPageResponseSchema>;

--- a/src/services/guestbook.integration.test.ts
+++ b/src/services/guestbook.integration.test.ts
@@ -87,7 +87,7 @@ describe("guestbook", () => {
 
     const result = await getGuestbookService(invitation.publicKey);
 
-    expect(result.map((entry) => entry.message)).toEqual(["공개 글"]);
+    expect(result.items.map((entry) => entry.message)).toEqual(["공개 글"]);
   });
 
   it("비소유자는 draft 청첩장의 방명록을 조회할 수 없다", async () => {
@@ -104,7 +104,10 @@ describe("guestbook", () => {
       isPrivate: false,
     });
 
-    expect(await getGuestbookService(invitation.publicKey)).toEqual([]);
+    expect(await getGuestbookService(invitation.publicKey)).toEqual({
+      items: [],
+      nextCursor: null,
+    });
   });
 
   it("소유자 요청에는 공개 글과 비공개 글을 모두 반환한다", async () => {
@@ -126,16 +129,21 @@ describe("guestbook", () => {
       },
     ]);
 
-    const result = await getGuestbookService(invitation.publicKey, userId);
+    const result = await getGuestbookService(invitation.publicKey, {
+      viewerUserId: userId,
+    });
 
-    expect(result.map((entry) => entry.message).sort()).toEqual([
+    expect(result.items.map((entry) => entry.message).sort()).toEqual([
       "공개 글",
       "비공개 글",
     ]);
   });
 
-  it("알 수 없는 publicKey면 빈 배열을 반환한다", async () => {
-    expect(await getGuestbookService("missing-public-key")).toEqual([]);
+  it("알 수 없는 publicKey면 빈 페이지를 반환한다", async () => {
+    expect(await getGuestbookService("missing-public-key")).toEqual({
+      items: [],
+      nextCursor: null,
+    });
   });
 
   it("필수 필드 누락으로 저장에 실패하면 INTERNAL을 던진다", async () => {

--- a/src/services/guestbook.ts
+++ b/src/services/guestbook.ts
@@ -3,8 +3,10 @@ import type { IGuestbook } from "@/models";
 import { GuestbookModel, InvitationModel } from "@/models";
 import type { GuestbookType } from "@/core/schemas";
 import { dbConnect } from "@/db";
-import { AppError } from "@/core/domain";
+import type { GuestbookListPage } from "@/core/domain";
+import { AppError, DEFAULT_PAGE_SIZE } from "@/core/domain";
 import { comparePasswords, hashPassword } from "@/adapters/server/bcrypt";
+import { decodeCursor, encodeCursor } from "@/core/utils";
 
 import mongoose from "mongoose";
 
@@ -40,30 +42,65 @@ export const createGuestbookService = async ({
 
 export const getGuestbookService = async (
   publicKey: string,
-  viewerUserId?: string,
-): Promise<IGuestbook[]> => {
+  { cursor, viewerUserId }: { cursor?: string; viewerUserId?: string } = {},
+): Promise<GuestbookListPage> => {
   await dbConnect();
 
   const invitation = await InvitationModel.findOne({ publicKey })
     .select("_id userId status")
     .lean();
-  if (!invitation) return [];
+  if (!invitation) return { items: [], nextCursor: null };
+
   const isOwner = viewerUserId === invitation.userId.toString();
-  if (!isOwner && invitation.status !== "published") return [];
-  const guestbooks = await GuestbookModel.find({
+  if (!isOwner && invitation.status !== "published")
+    return { items: [], nextCursor: null };
+
+  const filter: Record<string, unknown> = {
     invitationId: invitation._id,
     ...(isOwner ? {} : { isPrivate: false }),
-  })
+  };
+
+  if (cursor) {
+    const decoded = decodeCursor(cursor);
+    if (!decoded) throw new AppError("VALIDATION", "잘못된 페이지 커서입니다.");
+    filter.$or = [
+      { createdAt: { $lt: decoded.createdAt } },
+      {
+        createdAt: decoded.createdAt,
+        _id: { $lt: new mongoose.Types.ObjectId(decoded.id) },
+      },
+    ];
+  }
+
+  const found = await GuestbookModel.find(filter)
     .select("-__v -password -updatedAt")
-    .sort({
-      createdAt: -1,
-    })
-    .lean();
-  return guestbooks.map((guestbook) => ({
-    ...guestbook,
-    _id: guestbook._id.toString(),
-    invitationId: guestbook.invitationId.toString(),
-  }));
+    .sort({ createdAt: -1, _id: -1 })
+    .limit(DEFAULT_PAGE_SIZE + 1)
+    .lean()
+    .catch((err) => {
+      throw new AppError(
+        "INTERNAL",
+        err instanceof Error ? err.message : "방명록 조회에 실패했습니다.",
+      );
+    });
+
+  const hasMore = found.length > DEFAULT_PAGE_SIZE;
+  const items = hasMore ? found.slice(0, DEFAULT_PAGE_SIZE) : found;
+  const last = items.at(-1);
+
+  return {
+    items: items.map((guestbook) => ({
+      id: guestbook._id.toString(),
+      author: guestbook.author,
+      message: guestbook.message,
+      isPrivate: guestbook.isPrivate,
+      createdAt: guestbook.createdAt,
+    })),
+    nextCursor:
+      hasMore && last
+        ? encodeCursor({ createdAt: last.createdAt, id: last._id.toString() })
+        : null,
+  };
 };
 
 export const getPrivateGuestbookService = async (

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -78,7 +78,10 @@ export default defineConfig({
         test: {
           name: "integration-component",
           environment: "jsdom",
-          include: ["src/ui/**/*.integration.test.{ts,tsx}"],
+          include: [
+            "src/ui/**/*.integration.test.{ts,tsx}",
+            "src/app/(preview)/preview/[publicKey]/_components/GuestbookSection.integration.test.tsx",
+          ],
           setupFiles: ["./testing/support/setup/jsdom-polyfill.ts"],
           maxWorkers: 2,
         },


### PR DESCRIPTION
## Summary

- `/api/guestbook` 응답을 전체 배열에서 `{ items, nextCursor }` cursor page로 바꾼다. **breaking change**: 기존 클라이언트가 응답을 배열로 가정하고 있으면 깨진다 — 마이그레이션은 `response.items`로 접근하도록 바꾸면 된다(같은 PR 안에서 유일한 소비처인 `GuestbookSection`도 함께 옮겼다).
- `getGuestbookService`가 `(createdAt, _id)` 커서로 페이지네이션하도록 재작성됐다. owner 여부/`isPrivate` 필터링 로직은 그대로 유지된다. 기존 `src/core/utils/cursor.ts`, `getAdminProductsPageService` 패턴을 재사용했다.
- `GuestbookSection`이 단발 `useSWR`에서 `useSWRInfinite` + `IntersectionObserver` 무한스크롤로 교체됐다. 목록 영역은 `max-h-[480px] overflow-y-auto` 컨테이너로 감쌌다.
- 방명록 작성/삭제 모달이 닫히면 로드된 모든 페이지를 재검증(`mutate()`)해서, 여러 페이지가 로드된 상태에서도 새 글/삭제가 반영되게 했다.
- 작업 중 발견한 별개 버그 수정: 기존 `isDelete` 초기화 effect가 매 렌더 새로 계산되는 배열을 의존성으로 가져서 무한 렌더 루프("Maximum update depth exceeded")를 일으키고 있었다 — 해당 effect를 제거했다(원래도 아무 데서도 `true`로 세팅되지 않는 죽은 코드였다).
- `preview/sample` 페이지가 방명록을 mock 데이터로 못 보여주는 문제는 이 브랜치와 무관한 별개 사안으로, 건드리지 않았다.

## Test plan

- `npx tsc --noEmit`, `npx eslint`(변경 파일) — 통과
- `npx vitest run src/services/guestbook.integration.test.ts`(mongodb-memory-server) — 8/8 통과, 시그니처 변경분 반영
- `npx vitest run --project integration-component GuestbookSection.integration.test.tsx`(useSWRInfinite + MSW) — 4/4 통과: 첫 페이지 렌더, 커서 기반 다음 페이지 병합, 모달 close 시 전체 재검증
- 브라우저 확인: dev DB에 청첩장 데이터가 없어 `/preview/[publicKey]` 실 데이터 확인이 불가해, `/preview/sample` + Playwright request route mock(5건 방명록, 2페이지)으로 대체 — 페이지 분할 없이 정상 병합 렌더, 삭제/작성 모달 정상 오픈, 모달 close 시 전체 페이지 재검증(GET 재호출) 확인, 콘솔 에러 없음
- Not run: 로컬 `npm run build`/전체 vitest 스위트 — 완료 게이트로 안 삼는다는 프로젝트 컨벤션에 따라 PR의 `static` 필수 체크(ESLint + tsc + production build) 결과로 검증한다
