### PR TITLE
refactor(checkout): OrderSummary를 컨테이너와 순수 UI로 분리한다

### DIFF
--- a/src/app/(main)/(checkout)/_components/OrderSummary.test.tsx
+++ b/src/app/(main)/(checkout)/_components/OrderSummary.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MOBILE_INVITATION_CATEGORY } from "@/core/domain";
+import type { CheckoutItem } from "@/core/domain";
+import { OrderSummary } from "./OrderSummary";
+
+const ORDER: CheckoutItem = {
+  productId: "product-1",
+  category: MOBILE_INVITATION_CATEGORY,
+  title: "봄날의 청첩장",
+  thumbnail: "https://res.cloudinary.com/demo/image/upload/invitation.jpg",
+  originalPrice: 12000,
+  discountedPrice: 10000,
+  discountAmount: 2000,
+  optionsTotalPrice: 5000,
+  finalPrice: 15000,
+  quantity: 1,
+  selectedFeatures: [
+    {
+      featureId: "feature-1",
+      code: "GUESTBOOK",
+      label: "방명록",
+      price: 5000,
+    },
+  ],
+};
+
+describe("OrderSummary", () => {
+  it("loading 중이면 로딩 안내를 렌더링한다", () => {
+    render(<OrderSummary data={null} loading />);
+
+    expect(screen.getByText("주문 정보를 불러오는 중...")).toBeInTheDocument();
+  });
+
+  it("order가 없으면 상품 정보 없음을 안내한다", () => {
+    render(<OrderSummary data={null} loading={false} />);
+
+    expect(screen.getByText("상품 정보를 찾을 수 없습니다.")).toBeInTheDocument();
+  });
+
+  it("order props로 주문 내역과 총 결제금액을 렌더링한다", () => {
+    render(<OrderSummary data={ORDER} loading={false} />);
+
+    expect(screen.getByText("봄날의 청첩장")).toBeInTheDocument();
+    expect(screen.getByText(/방명록/)).toBeInTheDocument();
+    expect(screen.getByText(/15,000/)).toBeInTheDocument();
+  });
+});

--- a/src/app/(main)/(checkout)/_components/OrderSummary.tsx
+++ b/src/app/(main)/(checkout)/_components/OrderSummary.tsx
@@ -1,15 +1,25 @@
-"use client";
-import { Card, CardContent, CardFooter, CardHeader, CardTitle, TypographyH3, TypographyMuted, TypographyP, TypographySmall } from "@/ui/components/atoms";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  TypographyH3,
+  TypographyMuted,
+  TypographyP,
+  TypographySmall,
+} from "@/ui/components/atoms";
+import { DELIVERY_FEE } from "@/core/domain";
+import type { CheckoutItem } from "@/core/domain";
 import { formatPriceWithComma } from "@/core/utils";
 import { CloudImage } from "@/ui/components/molecules";
-import { DELIVERY_FEE } from "@/core/domain";
 
-import { useCheckoutData } from "@/ui/hooks";
-import type { SelectFeatureDto } from "@/core/schemas";
+interface OrderSummaryProps {
+  data: CheckoutItem | null;
+  loading: boolean;
+}
 
-export const OrderSummary = () => {
-  const { data, loading } = useCheckoutData();
-
+const OrderSummary = ({ data, loading }: OrderSummaryProps) => {
   if (loading) {
     return (
       <main className="bg-background flex min-h-screen items-center justify-center">
@@ -64,7 +74,7 @@ export const OrderSummary = () => {
           {selectedFeatures && selectedFeatures.length > 0 && (
             <div className="space-y-1">
               <TypographySmall className="font-medium">선택 옵션:</TypographySmall>
-              {selectedFeatures.map((option: SelectFeatureDto) => (
+              {selectedFeatures.map((option) => (
                 <div
                   key={option.featureId}
                   className="flex justify-between text-xs"
@@ -159,3 +169,5 @@ export const OrderSummary = () => {
     </div>
   );
 };
+
+export { OrderSummary };

--- a/src/app/(main)/(checkout)/_components/index.tsx
+++ b/src/app/(main)/(checkout)/_components/index.tsx
@@ -1,0 +1,1 @@
+export * from "./OrderSummary";

--- a/src/app/(main)/(checkout)/_containers/OrderSummary.tsx
+++ b/src/app/(main)/(checkout)/_containers/OrderSummary.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { OrderSummary as OrderSummaryView } from "../_components";
+import { useCheckoutData } from "@/ui/hooks";
+
+const OrderSummary = () => {
+  const { data, loading } = useCheckoutData();
+
+  return <OrderSummaryView data={data} loading={loading} />;
+};
+
+export { OrderSummary };

--- a/src/app/(main)/(checkout)/_containers/index.tsx
+++ b/src/app/(main)/(checkout)/_containers/index.tsx
@@ -1,0 +1,1 @@
+export * from "./OrderSummary";

--- a/src/app/(main)/(checkout)/layout.tsx
+++ b/src/app/(main)/(checkout)/layout.tsx
@@ -1,5 +1,5 @@
 import { PageTitle } from "@/ui/components/molecules";
-import { OrderSummary } from "@/ui/components/organisms";
+import { OrderSummary } from "./_containers";
 import React from "react";
 
 const CheckoutLayout = async ({ children }: { children: React.ReactNode }) => {

--- a/src/ui/components/organisms/index.ts
+++ b/src/ui/components/organisms/index.ts
@@ -15,7 +15,6 @@ export * from "./ImagesSection";
 export * from "./LiveDemoSection";
 export * from "./LoginForm";
 export * from "./MobileNav";
-export * from "./OrderSummary";
 export * from "./ParentsInfoSection";
 export * from "./PaymentMethodSelector";
 export * from "./PremiumFeatureDialog";


### PR DESCRIPTION
## Summary

- `OrderSummary`의 실제 소비처가 `(checkout)/layout.tsx` 한 곳이고 현재 해당 그룹의 하위 페이지도 `/payment` 한 곳임을 재확인해 공용 organism에서 route-local로 이동합니다.
- `useCheckoutData()` 호출과 side effect 경계를 `(checkout)/_containers/OrderSummary.tsx`가 소유하도록 분리합니다.
- 순수 마크업은 `(checkout)/_components/OrderSummary.tsx`에서 `data`와 `loading` props만 받아 렌더링하며, 상태별 출력 계약을 component 테스트로 검증합니다.

## Test plan

- `npm run test:component -- src/app/(main)/(checkout)/_components/OrderSummary.test.tsx src/ui/hooks/useCheckoutData.test.ts src/app/(main)/(checkout)/payment/_components/CheckoutForm.test.tsx` — 3파일, 10테스트 통과
- `npx eslint <변경 파일>` — 통과
- `npm run tsc` — 통과
- `npm run build` — 통과

Related to #170