### PR TITLE
docs: 비-UI AGENTS.md의 Gotchas 섹션을 제거한다

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -26,9 +26,3 @@
 - **식별자 케이스**: 타입/인터페이스는 PascalCase, 함수/변수는 camelCase다. `export const`의 값을 재귀적으로 뜯어봤을 때 문자열/숫자/불리언 리터럴(또는 그 배열/lookup map)로만 이루어져 있으면 SCREAMING_SNAKE_CASE로 export한다 — 단일 값이든 여러 값 나열이든 키→리터럴 값 lookup map이든 "값이 끝까지 리터럴이냐"가 기준이다. 값 안에 함수·컴포넌트 참조·이종 필드 객체가 하나라도 섞이면 camelCase다. **위치가 `constants/`든 파일 내부 로컬이든 무관하게 적용한다** — 컴포넌트/훅 안 로컬 상수도 대상이다.
 - 같은 아티팩트 타입끼리 파일명 케이스가 겹치지 않게 짓는다 — 파일명만 보고 컴포넌트인지 훅인지 유틸인지 구분할 수 있어야 한다.
 - `{목적}` 기반 파일(도메인 무관 범용 카테고리 — `utils/`, `constants/{목적}.ts`, `hooks/use{목적}.ts`, `services/{목적}.ts`, `schemas/{목적}.schema.ts` 등)에는 도메인/라우트가 드러나는 이름을 쓰지 않는다 — 이름이 도메인에 종속되면 재사용 가능 범위를 파일명만으로 오판하게 된다(예: `postsFormatter.ts` 금지).
-
-## Gotchas
-
-- 지금 `src/proxy.ts`의 matcher는 `/api/*`를 포함하지 않는다 — Route Handler(`src/app/api/`)는 Proxy 보호 대상이 아니다. 인증 필요한 route.ts는 각자 `getAuth()`/`requireAuth()`(쿠키 기반)를 호출해 재검증하는 게 유일한 방어선이다 — Bearer 헤더 검사는 프로젝트 어디에도 없다(과거엔 있었으나 쿠키 기반으로 전환 완료, 이 줄이 그 흔적으로 낡아있었다).
-- Server Function(Server Action)은 별도 라우트가 아니라 호출된 페이지로 가는 POST 요청이다 — matcher가 그 경로를 제외하면 Proxy가 조용히 건너뛰어, Proxy가 막아준다고 착각하기 쉽다.
-- Next.js 16에서 Proxy 기본 런타임은 Node.js다(과거 Edge 런타임 기본에서 변경) — Proxy 파일에 `runtime` config 옵션을 쓰면 에러가 난다.

--- a/src/actions/AGENTS.md
+++ b/src/actions/AGENTS.md
@@ -29,12 +29,6 @@ src/actions/
 - Client Component에서 직접 호출할 Server Action을 컴포넌트 파일 안에 인라인으로 정의하지 않는다 — Client Component는 `"use server"`가 선언된 별도 파일의 export만 import해 호출할 수 있다(인라인 함수 레벨 `"use server"`는 Server Component 전용).
 - `useActionState`로 연결되는 액션의 인자 순서를 `(prevState, formData)` 밖으로 바꾸지 않는다 — 이 훅의 계약이 이 순서를 요구한다.
 
-## Gotchas
-
-- `"use server"` 파일이라 배럴(`index.ts`)로 묶여도 클라이언트엔 실제 코드 대신 RPC 참조만 내려가서 다른 액션의 서버 전용 의존성(mongodb/bcrypt 등)이 새지 않는다.
-- 클라이언트에서 여러 Server Action을 `Promise.all`로 동시에 트리거해도 병렬로 실행되지 않는다 — Next.js가 클라이언트당 순차 디스패치(sequential dispatch)하므로 두 번째 액션은 첫 번째가 끝난 뒤 시작된다. 진짜 병렬 처리가 필요하면 액션 하나 안에서 처리하거나 Route Handler를 쓴다.
-- CSRF 체크(Origin/Host 대조)·요청 본문 1MB 제한·클로저 값 암호화는 프레임워크가 자동으로 처리한다 — 액션 안에 직접 구현하지 않는다.
-
 ## References
 
 즉시 로드(`@import`) 아님 — 트리거 열 키워드에 해당하는 작업일 때만 해당 문서를 읽는다.

--- a/src/app/api/AGENTS.md
+++ b/src/app/api/AGENTS.md
@@ -25,10 +25,6 @@ src/app/api/
 - Route Handler 안에서 `updateTag()`를 호출하지 않는다 — 공식 문서: `updateTag`는 Server Action 전용이며 Route Handler에서 호출하면 에러가 던져진다. Route Handler에서 캐시를 무효화해야 하면 `revalidateTag`/`revalidatePath`를 쓴다.
 - 응답은 `src/boundary.ts`의 `routeSuccess`(성공)/`routeError`(에러)로만 만든다 — `NextResponse.json(...)`/`Response.json(...)`을 route.ts 안에서 직접 호출하지 않는다. Server Action은 이 계약 대상이 아니다(예상된 실패를 이 envelope 없이 plain 객체로 직접 리턴, `actionError` 사용 — `src/actions/AGENTS.md` 참고). `routeSuccess`/`routeError`가 뭘 하는지는 `src/AGENTS.md`(Key Files), 왜 두 채널이 갈라지는지는 `docs/architecture/error-handling.md` §채널 분리 규칙 참고.
 
-## Gotchas
-
-- 인증이 필요한 Route Handler는 Bearer 헤더를 직접 파싱하지 않고 `services/auth.ts`의 `requireAuth()`를 호출한다(세션 없으면 401 throw) — `couple-info`/`order/create`가 이 패턴을 따른다. `kakaomap`의 `Authorization` 헤더는 별개(외부 Kakao API 인증용)라 해당 없음.
-
 ## References
 
 즉시 로드(`@import`) 아님 — 트리거 열 키워드에 해당하는 작업일 때만 해당 문서를 읽는다.

--- a/src/models/AGENTS.md
+++ b/src/models/AGENTS.md
@@ -30,11 +30,6 @@ src/models/
 - **한 컬렉션 안에서 도메인 하위 타입별로 전용 필드가 생기면 mongoose discriminator로 분리한다** — 모든 하위 타입의 필드를 base 스키마에 평평하게 얹지 않는다(`product.model.ts`의 `previewUrl`이 실제 사례: mobile-invitation 전용 개념인데 원래 base에 있었다). 이미 그 하위 타입을 구분하는 필드가 base 스키마에 있으면(`product.model.ts`의 `category`처럼) 새 판별 필드를 만들지 않고 그 필드를 `discriminatorKey` 옵션으로 재사용한다 — mongoose가 discriminatorKey 경로가 이미 정의돼 있으면 그대로 재사용한다(공식 구현: `Model.discriminator()`가 `model.schema.path(key)`를 먼저 확인해 기존 path가 있으면 그걸 쓴다). discriminator 이름은 그 필드가 실제로 갖는 값과 동일하게 짓는다(`ProductModel.discriminator("mobile-invitation", ...)` → `category: "mobile-invitation"`인 문서에 적용).
 - 하위 타입 전용 필드가 아직 없는 카테고리는 discriminator를 미리 만들지 않는다 — base 모델로 그대로 두다가 그 카테고리에 전용 필드가 실제로 생기는 시점에 같은 패턴으로 추가한다(과설계 방지).
 
-## Gotchas
-
-- `product.model.ts`의 `subCategory` 커스텀 validator가 `this.category`를 참조했다 — document validation(`this`가 Document)에선 동작하지만 update validator(`this`가 Query, `runValidators: true` 켰을 때)에선 `this.category`가 `undefined`라 항상 검증 실패했다(mongoose 공식문서: "this is the Query, not the document being updated"). **`this.get('category')`로는 안 고쳐진다** — Query의 `.get()`은 이번 update payload에 있는 값만 리턴하고, payload에 `category`가 없으면 기존 문서 값을 안 가져온다(공식문서가 이 동작을 명시하지 않아 DB로 직접 검증). 실제 고친 방식: payload에 `category`가 없으면 `this.model.findOne(this.getQuery())`로 기존 문서를 비동기 조회해 폴백한다(mongoose 공식문서의 `pre('findOneAndUpdate')` 예제가 보여주는 패턴을 validator에 적용).
-- discriminator 전용 필드(`product.model.ts`의 `previewUrl`)는 **읽기는 base 모델로 해도 되지만 쓰기(생성/`findOneAndUpdate`)는 반드시 그 discriminator 모델을 골라야 한다** — mongoose가 `find()`/`findOne()` 결과는 discriminatorKey 값을 보고 알아서 올바른 서브타입으로 hydrate해주지만(읽기는 base로 충분), 쓰기 경로는 그 자동 판별이 없다. base 모델로 `findOneAndUpdate`하면 discriminator 전용 필드는 그 모델 스키마에 없는 path라 strict 모드(mongoose 기본값)에 의해 조용히 버려진다 — 에러 없이 그냥 저장이 안 된다(`services/product.ts`의 `getWritableProductModel`이 이 분기를 담당).
-
 ## 관련 문서
 
 - API/도메인 계약 타입과의 경계: `src/core/types/AGENTS.md`

--- a/src/services/AGENTS.md
+++ b/src/services/AGENTS.md
@@ -54,11 +54,6 @@ src/services/
 - **트랜잭션 안에서 `Promise.all`류로 연산을 병렬 실행하지 않는다** — mongoose 공식 문서: "Running operations in parallel is not supported during a transaction... is undefined behaviour and should be avoided." 순차로(`await`를 하나씩) 실행한다.
 - **롤백은 DB 쓰기 되돌리기만 다룬다 — 외부 API 호출 같은 비-DB 부수효과는 트랜잭션 경계 안에 넣지 않는다.** `syncPayment`는 PortOne을 조회만 하고(쓰기 없음) 그 결과를 트랜잭션 시작 전에 이미 받아온 뒤 DB 쓰기만 트랜잭션으로 묶으므로 이 조건을 만족한다 — 트랜잭션 도중 외부 API에 실제로 쓰기 요청을 보내야 하는 경우가 생기면(아직 없음) DB 롤백만으로 부족해 별도 보상 로직이 필요해진다는 것을 그 시점에 재검토한다(가정만으로 지금 보상 로직 자리를 미리 만들지 않는다).
 
-## Gotchas
-
-- `requireAuth()`는 `getAuth()`를 감싸서 세션 없으면 `AppError(UNAUTHENTICATED)`를 throw하는 얇은 헬퍼다 — HTTP status(401)는 여기서 모른다, 각 채널 공용 핸들러가 UNAUTHENTICATED를 자기 형태(route.ts는 401 Response, Server Action은 `ErrorPayload`)로 번역한다. 인증이 필수인 Route Handler·Server Action 둘 다 세션 검증에 이 함수를 공유한다(`src/app/api/AGENTS.md` Gotchas 참고).
-- mongoose에 `mongoose.set('transactionAsyncLocalStorage', true)` 글로벌 옵션이 있다(설치된 버전 8.20.3에 실재 확인) — 켜면 트랜잭션 콜백 안의 모든 연산에 `session`을 자동 주입해 위 "session 빠뜨림" 실수 자체를 없앤다. 지금은 안 켠다 — 트랜잭션을 쓰는 지점이 `syncPayment` 하나뿐이라 켰을 때의 영향 범위(다른 서비스 함수들의 기존 동작)를 실제로 검증할 근거가 부족하다. 트랜잭션 쓰는 지점이 늘어나 session 누락 실수가 반복되면 그때 켤지 재검토한다(가정만으로 미리 켜지 않는다).
-
 ## References
 
 즉시 로드(`@import`) 아님 — 트리거 열 키워드에 해당하는 작업일 때만 해당 문서를 읽는다.

--- a/src/ui/AGENTS.md
+++ b/src/ui/AGENTS.md
@@ -32,11 +32,6 @@ src/ui/
 - `fetcher` 밖에서 client-side fetch를 직접 만들지 않는다 — envelope 파싱/에러 정규화가 `fetcher`에 집중돼있으므로 우회하면 각자 다른 파싱 로직을 재구현하게 된다. GET 조회는 `useSWR`+`fetcher`, mutation은 Server Action이라 클라이언트에 그 외 fetch가 없다.
 - 서버 전용 코드(DB 드라이버, `next/headers` 등)를 이 트리에 두지 않는다 — 새 서버 전용 코드는 `src/`.
 
-## Gotchas
-
-- 서비스 레이어가 던지는 에러 타입(`src/core/types/error.ts`)은 이 경계 + 서비스 레이어 전용이다 — 서비스 함수가 이미 이 타입을 던지는 경우 Server Action이 받아서 리턴값으로 번역한다(`src/actions/AGENTS.md` Gotchas 참고).
-- 세션 토큰은 Bearer 헤더가 아니라 httpOnly 쿠키로 전달된다(목표 설계·트레이드오프는 `docs/security/page-access-control.md` "인증 토큰" 참고) — `fetcher`는 토큰을 다루지 않는다(쿠키가 동일 origin이라 자동으로 실림), 클라이언트도 토큰 값을 들고 있지 않는다(`useAuth.ts`가 `useSWR`로 노출하는 세션도 role/email/userId 같은 파생 정보만 담는다).
-
 ## References
 
 즉시 로드(`@import`) 아님 — 트리거 열 키워드에 해당하는 작업일 때만 해당 문서를 읽는다.

--- a/src/ui/context/AGENTS.md
+++ b/src/ui/context/AGENTS.md
@@ -25,10 +25,6 @@ src/ui/context/
 - 도메인 폴더 안 파일은 `type.ts`/`reducer.ts`로 고정한다 — 폴더명이 이미 도메인을 특정하므로 파일명에 도메인명을 반복하지 않는다(`productFilter/productFilterType.ts` 금지).
 - Provider/hook은 reducer.ts에서 `createStateContext` 호출 결과로 export한다 — 별도 `provider.tsx` 파일로 쪼개지 않는다(지금까지는 파일 1개로 충분했음).
 
-## Gotchas
-
-- 없음.
-
 ## 관련 문서
 
 - 전역 상태(Zustand)와의 경계: `src/ui/stores/AGENTS.md` — 앱 전체 범위면 Context가 아니라 Zustand(`src/ui/stores/`)로 간다.

--- a/src/ui/hooks/AGENTS.md
+++ b/src/ui/hooks/AGENTS.md
@@ -19,12 +19,8 @@ src/ui/hooks/
 ## Critical Convention
 
 - 파일명은 camelCase, `use` 접두사 필수 — 데이터 페칭 훅은 도메인을 PascalCase로 이어붙이고(`useCoupleInfo.ts`), 페칭 외 공유 로직 훅은 목적을 PascalCase로 이어붙인다(`useCountdown.ts`).
-- **"use client" 지시어를 파일 최상단에 고정한다 — 예외 없다.** 훅은 정의상 React hook을 호출하므로 client 전용이다. 호출하는 쪽 컴포넌트가 이미 client 경계 안이라서 괜찮겠거니 하고 생략하지 않는다 — `index.ts` 배럴이 형제 파일 전체를 하나의 모듈 그래프로 묶기 때문에, 이 파일 하나가 경계 선언 없이 hook을 쓰면 그 배럴을 조금이라도 참조하는 아무 Server Component에서나 빌드 에러가 난다(Gotchas 참고).
+- **"use client" 지시어를 파일 최상단에 고정한다 — 예외 없다.** 훅은 정의상 React hook을 호출하므로 client 전용이다. 호출하는 쪽 컴포넌트가 이미 client 경계 안이라서 괜찮겠거니 하고 생략하지 않는다 — `index.ts` 배럴이 형제 파일 전체를 하나의 모듈 그래프로 묶기 때문에, 이 파일 하나가 경계 선언 없이 hook을 쓰면 그 배럴을 조금이라도 참조하는 아무 Server Component에서나 빌드 에러가 난다.
 - 외부 SDK를 초기화하는 훅(`useKakaoLoader` 등)을 여기 두지 않는다 — 훅이라도 연동 대상 하나에 강결합돼 있으면 `src/adapters/browser/{service}/`의 "연동 대상 1개 = 폴더 1개" 소관이다(`src/adapters/AGENTS.md` 참고).
-
-## Gotchas
-
-- 없음.
 
 ## 관련 문서
 

--- a/src/ui/stores/AGENTS.md
+++ b/src/ui/stores/AGENTS.md
@@ -2,7 +2,7 @@
 
 > Last updated: 2026-08-26
 > 이 폴더는 프로젝트 고유 선택 — 전역 클라이언트 상태(Zustand) 레이어.
-> **목표 설계, 마이그레이션 진행 전** — 아래 Critical Convention은 공식 가이드 기준 목표 아키텍처다. 현재 코드는 아직 이 형태가 아니다(Gotchas 참고). 문서를 먼저 확정하고 이 문서 기준으로 코드를 리팩토링한다.
+> **목표 설계, 마이그레이션 진행 전** — 아래 Critical Convention은 공식 가이드 기준 목표 아키텍처다. 현재 코드는 아직 이 형태가 아니다. 문서를 먼저 확정하고 이 문서 기준으로 코드를 리팩토링한다.
 
 ## Overview
 
@@ -32,13 +32,6 @@ src/ui/stores/
 - **여러 필드를 객체/배열로 한 번에 select할 땐 `useShallow`(`zustand/react/shallow`)로 감싼다** — v5부터 selector 결과의 얕은 비교가 자동이 아니다, 감싸지 않으면 매 렌더마다 새 객체/배열이 만들어져 selector가 매번 다른 값으로 보여 리렌더가 안 걸러진다(공식 문서 "Selecting multiple state slices" 참고).
 - 액션 안에서 현재 상태를 읽어야 하면 클로저 대신 `get()`을 쓴다 — `(set, get) => ({ ... })`(공식 문서 "Read from state in actions"). `set`은 기본적으로 얕은 merge라 일부 필드만 갱신할 땐 나머지를 직접 스프레드할 필요 없다 — 전체 교체가 필요할 때만 `set(newState, true)`(두 번째 인자)를 쓴다, 이때 다른 슬라이스 필드까지 날아갈 수 있으니 결합 store에선 특히 주의(공식 문서 "Overwriting state").
 - 전부 named export로 통일한다 — `src/AGENTS.md`의 `src/` 전체 default export 금지 규칙 참고.
-
-## Gotchas
-
-- **지금 코드는 위 목표 아키텍처로 아직 마이그레이션되지 않았다** — `order.store.ts`/`admin.modal.store.ts`/`guestbook.modal.store.ts` 3개가 각자 전역 `create()`(slices 아님, Context 아님)로 분리돼있다. 실제 위험은 낮다 — 셋 다 Client Component 전용으로만 쓰이고(RSC/Server Action에서 import 없음, grep 확인됨) 초기값도 고정값(`isOpen: false` 등)이라 요청 간 상태 누수 시나리오가 실질적으로 없다. 그래도 공식 권장과는 다른 상태이니 다음 리팩토링 대상.
-- 결합 store 하나로 합치면 Provider를 **어디까지 감싸야 하는지**가 새로운 문제가 된다 — `admin-modal` 슬라이스는 `/admin` 라우트에서만, `guestbook-modal`은 `/preview`에서만, `order`는 `/checkout`·`/my-orders`·`/products`에서만 쓰인다. 세 도메인이 라우트를 공유하지 않으므로 Provider를 root layout까지 올려야 전부 커버되는데, 그러면 그 도메인을 안 쓰는 페이지도 슬라이스 인스턴스 생성 비용을 진다(가벼운 비용이지만 트레이드오프는 있다).
-- `order.store.ts`만 zustand `persist` 미들웨어(sessionStorage)를 씀 — 새로고침에도 유지돼야 하는 상태(주문 진행 중 데이터)라 그런 것으로 보인다. 결합 store로 합친 뒤엔 `persist`의 `partialize`로 `order` 슬라이스만 골라 저장해야 한다(위 Critical Convention).
-- 지금 `admin.modal.store.ts`/`guestbook.modal.store.ts`는 curried `create<State>()(...)` 형태가 아니다(`order.store.ts`만 미들웨어 때문에 curried) — 이것도 리팩토링 대상.
 
 ## 관련 문서
 


### PR DESCRIPTION
## 변경 내용

- UI 컴포넌트 티어 문서를 제외한 AGENTS.md 9곳에서 Gotchas 섹션을 삭제했습니다.
- 삭제된 섹션을 가리키던 본문 참조 2곳을 정리했습니다.
- Gotchas 내용은 다른 섹션으로 흡수하지 않았습니다.

## 검증

- 대상 9개 문서의 Gotchas 문자열 부재 확인
- git diff --cached --check 통과
- 문서 전용 변경으로 테스트 미실행

Related to #169