### PR TITLE
refactor(ui): 이미지 컴포넌트를 atom으로 정리한다

### DIFF
--- a/src/app/(admin)/admin/products/_components/ProductTableRow.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRow.tsx
@@ -1,7 +1,6 @@
 import { Eye, Heart, ShoppingCart } from "lucide-react";
-import { Badge, TypographyMuted, TypographySmall } from "@/ui/components/atoms";
+import { AppImage, Badge, TypographyMuted, TypographySmall } from "@/ui/components/atoms";
 import type { Product } from "@/services";
-import { CloudImage } from "@/ui/components/molecules";
 import { ProductTableRowAction } from "./ProductTableRowAction";
 import { ProductTableRowSelect } from "./ProductTableRowSelect";
 import type { ProductCategory, SubCategory } from "@/core/domain";
@@ -17,7 +16,7 @@ export function ProductTableRow({ product, view = "active" }: ProductTableRowPro
     <tr className="hover:bg-muted/50 transition-colors">
       <td className="px-4 py-3">
         <div className="relative h-16 w-16 overflow-hidden rounded">
-          <CloudImage
+          <AppImage
             src={product.thumbnail}
             sizes="128px"
             alt={`${product.title} 이미지`}

--- a/src/app/(main)/(checkout)/_components/OrderSummary.tsx
+++ b/src/app/(main)/(checkout)/_components/OrderSummary.tsx
@@ -1,4 +1,5 @@
 import {
+  AppImage,
   Card,
   CardContent,
   CardFooter,
@@ -12,7 +13,6 @@ import {
 import { DELIVERY_FEE } from "@/core/domain";
 import type { CheckoutItem } from "@/core/domain";
 import { formatPriceWithComma } from "@/core/utils";
-import { CloudImage } from "@/ui/components/molecules";
 
 interface OrderSummaryProps {
   data: CheckoutItem | null;
@@ -58,7 +58,7 @@ const OrderSummary = ({ data, loading }: OrderSummaryProps) => {
         <CardContent className="space-y-4">
           <div className="flex gap-4">
             <div className="bg-muted relative h-24 w-20 shrink-0 overflow-hidden rounded-lg">
-              <CloudImage src={thumbnail} sizes="80px" />
+              <AppImage src={thumbnail} sizes="80px" />
             </div>
             <div className="min-w-0 flex-1">
               <TypographyH3 className="mb-1 truncate font-medium">

--- a/src/app/(main)/(my-order)/my-orders/_components/OrderCard.tsx
+++ b/src/app/(main)/(my-order)/my-orders/_components/OrderCard.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { format } from "date-fns";
 import { toast } from "sonner";
 import {
+  AppImage,
   Badge,
   Button,
   Card,
@@ -18,7 +19,7 @@ import {
   TypographyH3,
   TypographyMuted,
 } from "@/ui/components/atoms";
-import { Alert, CloudImage } from "@/ui/components/molecules";
+import { Alert } from "@/ui/components/molecules";
 import { useCopy } from "@/ui/hooks";
 import { CreditCard, Edit, EllipsisVertical, Link2 } from "lucide-react";
 import type { OrderListItem, OrderStatus } from "@/core/domain";
@@ -137,7 +138,7 @@ const OrderCard = ({ order, onOrderChanged }: OrderCardProps) => {
         <div className="flex items-start justify-between gap-6">
           <div className="flex min-w-0 flex-1 items-start gap-4">
             <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-lg">
-              <CloudImage
+              <AppImage
                 src={product.thumbnail ?? "#"}
                 alt={product.title}
                 sizes="128px"

--- a/src/app/(main)/(products)/products/[category]/[id]/_components/ProductFeatures.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_components/ProductFeatures.tsx
@@ -2,13 +2,13 @@
 
 import { useState } from "react";
 import {
+  AppImage,
   Button,
   Card,
   TypographyH2,
   TypographyH3,
   TypographyMuted,
 } from "@/ui/components/atoms";
-import { CloudImage } from "@/ui/components/molecules";
 import type { PremiumFeature } from "@/core/domain";
 import clsx from "clsx";
 import { Check, ChevronDown, Palette, Type, Settings, FileText } from "lucide-react";
@@ -73,7 +73,7 @@ export function ProductFeatures({ options, images }: ProductFeaturesProps) {
                   key={src}
                   className="relative aspect-[3/4] w-full overflow-hidden rounded-2xl bg-transparent"
                 >
-                  <CloudImage
+                  <AppImage
                     src={src}
                     alt={`상세 이미지 ${index + 1}`}
                     className="object-contain"
@@ -94,7 +94,7 @@ export function ProductFeatures({ options, images }: ProductFeaturesProps) {
                         key={src}
                         className="relative aspect-[3/4] w-full overflow-hidden rounded-2xl bg-transparent"
                       >
-                        <CloudImage
+                        <AppImage
                           src={src}
                           alt={`상세 이미지 ${VISIBLE_IMAGE_COUNT + index + 1}`}
                           className="object-contain"

--- a/src/app/(main)/(products)/products/[category]/[id]/_components/ProductSummary.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_components/ProductSummary.tsx
@@ -2,7 +2,7 @@
 
 import { Share2 } from "lucide-react";
 import { useMemo } from "react";
-import { Badge, TypographyH1, TypographyMuted } from "@/ui/components/atoms";
+import { AppImage, Badge, TypographyH1, TypographyMuted } from "@/ui/components/atoms";
 import type { Product, PremiumFeature } from "@/core/domain";
 import { isProductCategory, calculatePrice } from "@/core/utils";
 import type { SubCategory } from "@/core/domain";
@@ -11,7 +11,6 @@ import { productCategoryLabels, subCategoryLabels } from "@/core/domain";
 import type { CheckoutItem } from "@/core/domain";
 import { ProductLikeBadge } from "./ProductLikeBadge";
 import { ProductOptions } from "./ProductOptions";
-import { CloudImage } from "@/ui/components/molecules";
 import { RatingStars } from "@/ui/components/organisms";
 export function ProductSummary({
   product,
@@ -31,7 +30,7 @@ export function ProductSummary({
       <div className="grid items-start gap-8 lg:grid-cols-2 lg:gap-12">
         {/* Left side - Thumbnail */}
         <div className="group bg-muted border-border relative aspect-square overflow-hidden rounded-2xl border shadow-lg">
-          <CloudImage
+          <AppImage
             src={product.thumbnail}
             alt={`${product.title} 상품 썸네일`}
             loading="eager"

--- a/src/app/(main)/(products)/products/[category]/[id]/_components/ReviewsSection.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_components/ReviewsSection.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { format } from "date-fns";
-import { Button, TypographyH2, TypographyMuted } from "@/ui/components/atoms";
-import { CloudImage } from "@/ui/components/molecules";
+import { AppImage, Button, TypographyH2, TypographyMuted } from "@/ui/components/atoms";
 import { RatingStars } from "@/ui/components/organisms";
 import type { ReviewListPage, ReviewSortType } from "@/core/domain";
 import { REVIEW_SORT_KEYS, REVIEW_SORT_OPTIONS } from "@/core/domain";
@@ -76,7 +75,7 @@ const ReviewsSection = ({ reviews, sort }: ReviewsSectionProps) => {
                       key={url}
                       className="relative h-20 w-20 overflow-hidden rounded-lg"
                     >
-                      <CloudImage src={url} alt="리뷰 이미지" sizes="80px" />
+                      <AppImage src={url} alt="리뷰 이미지" sizes="80px" />
                     </div>
                   ))}
                 </div>

--- a/src/app/(preview)/preview/[publicKey]/_components/GallerySection.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/GallerySection.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from "react";
 import { ChevronLeft, ChevronRight, X } from "lucide-react";
-import { CloudImage } from "@/ui/components/molecules";
-import { Button, Dialog, DialogContent, DialogTitle } from "@/ui/components/atoms";
+import { AppImage, Button, Dialog, DialogContent, DialogTitle } from "@/ui/components/atoms";
 
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { EyebrowSection } from "./EyebrowSection";
@@ -37,7 +36,7 @@ export function GallerySection({
             onClick={() => openLightbox(index)}
             className="bg-muted relative aspect-square w-full overflow-hidden rounded-lg transition-opacity hover:opacity-90"
           >
-            <CloudImage
+            <AppImage
               src={src}
               alt={`Gallery image ${index + 1}`}
               sizes="(max-width: 512px) 50vw, 320px"
@@ -53,7 +52,7 @@ export function GallerySection({
               <DialogTitle>갤러리 이미지 보기</DialogTitle>
             </VisuallyHidden>
             <div className="relative h-[70vh]">
-              <CloudImage
+              <AppImage
                 src={images[currentIndex] || ""}
                 alt={`Gallery image ${currentIndex + 1}`}
                 sizes="(max-width)100vw , 512px"

--- a/src/app/(preview)/preview/[publicKey]/_components/HeroSection.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/HeroSection.tsx
@@ -3,8 +3,7 @@ import { formatInTimeZone } from "date-fns-tz";
 import { ko } from "date-fns/locale";
 
 import type { HeroSectionProps } from "../_utils/heroSection.mapper";
-import { TypographyH1, TypographyMuted } from "@/ui/components/atoms";
-import { CloudImage } from "@/ui/components/molecules";
+import { AppImage, TypographyH1, TypographyMuted } from "@/ui/components/atoms";
 import { ScrollIndicator } from "./ScrollIndicator";
 export function HeroSection({
   groomName,
@@ -19,11 +18,11 @@ export function HeroSection({
     <section className="relative flex h-screen items-center justify-center overflow-hidden">
       {/* Background Image */}
       <div className="absolute inset-0">
-        <CloudImage
+        <AppImage
           src={thumbnailImage}
           alt="inivitation main Thumbnail"
           sizes="(max-width: 768px) 100vw, 512px"
-          priority={true}
+          preload={true}
         />
         <div className="absolute inset-0 bg-black/40" />
       </div>

--- a/src/app/(preview)/preview/[publicKey]/_components/InvitationTemplate.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/InvitationTemplate.tsx
@@ -1,5 +1,5 @@
 import type { InvitationContent } from "@/core/domain";
-import { CloudImage } from "@/ui/components/molecules";
+import { AppImage } from "@/ui/components/atoms";
 import { InteractionOverlay } from "./interactions";
 import { ThemeAmbience } from "./ThemeAmbience";
 import { ThemeSync } from "./ThemeSync";
@@ -62,7 +62,7 @@ export function InvitationTemplate({
           />
           <LocationSection {...mapCoupleInfoToLocationProps(content)} />
           <div className="relative h-[50vh] w-full">
-            <CloudImage
+            <AppImage
               src={thumbnails.divider}
               sizes="(max-width: 512px) 100vw, 512px"
             />
@@ -72,7 +72,7 @@ export function InvitationTemplate({
           )}
           <AccountSection {...mapCoupleInfoToAccountProps(content)} />
           <Footer>
-            <CloudImage
+            <AppImage
               src={thumbnails.footer}
               sizes="(max-width: 512px) 100vw, 512px"
             />

--- a/src/ui/components/atoms/app-image.test.tsx
+++ b/src/ui/components/atoms/app-image.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AppImage } from "./app-image";
+
+describe("AppImage", () => {
+  it("src가 있으면 이미지를 렌더링한다", () => {
+    render(<AppImage src="/product.jpg" alt="상품 이미지" />);
+
+    expect(screen.getByRole("img", { name: "상품 이미지" })).toHaveAttribute(
+      "src",
+    );
+  });
+
+  it("src가 빈 문자열이면 placeholder를 렌더링한다", () => {
+    render(<AppImage src="" alt="상품 이미지" />);
+
+    expect(screen.getByRole("img", { name: "상품 이미지" }).tagName).toBe(
+      "DIV",
+    );
+  });
+
+  it("이미지 로드에 실패하면 placeholder로 교체한다", () => {
+    render(<AppImage src="/missing.jpg" alt="상품 이미지" />);
+
+    fireEvent.error(screen.getByRole("img", { name: "상품 이미지" }));
+
+    expect(screen.getByRole("img", { name: "상품 이미지" }).tagName).toBe(
+      "DIV",
+    );
+  });
+
+  it("실패한 이미지의 src가 바뀌면 새 이미지를 렌더링한다", () => {
+    const { rerender } = render(
+      <AppImage src="/missing.jpg" alt="상품 이미지" />,
+    );
+    fireEvent.error(screen.getByRole("img", { name: "상품 이미지" }));
+
+    rerender(<AppImage src="/replacement.jpg" alt="상품 이미지" />);
+
+    expect(screen.getByRole("img", { name: "상품 이미지" }).tagName).toBe(
+      "IMG",
+    );
+  });
+});

--- a/src/ui/components/atoms/app-image.tsx
+++ b/src/ui/components/atoms/app-image.tsx
@@ -1,8 +1,10 @@
 "use client";
+
 import { cn } from "@/core/utils";
+import { ImageOff } from "lucide-react";
 import type { ImageLoaderProps, StaticImageData } from "next/image";
 import Image from "next/image";
-import React from "react";
+import { useState } from "react";
 
 const cloudinaryLoader = ({ src, width, quality }: ImageLoaderProps) => {
   if (typeof src !== "string" || !src.includes("res.cloudinary.com")) {
@@ -13,26 +15,42 @@ const cloudinaryLoader = ({ src, width, quality }: ImageLoaderProps) => {
   return src.replace("/upload/", `/upload/${params.join(",")}/`);
 };
 
-interface CloudImageProps {
+interface AppImageProps {
   src: string | StaticImageData;
   alt?: string;
   sizes?: string;
   className?: string;
-  priority?: boolean;
+  preload?: boolean;
   loading?: "eager" | "lazy";
-  onError?: () => void;
 }
 
-const CloudImage = ({
+const AppImage = ({
   src,
   alt = "",
   sizes = "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw",
   className,
-  priority = false,
+  preload = false,
   loading,
-  onError,
-}: CloudImageProps) => {
-  if (!src) return null;
+}: AppImageProps) => {
+  const [failedSrc, setFailedSrc] = useState<AppImageProps["src"] | null>(null);
+
+  if (!src || failedSrc === src) {
+    return (
+      <div
+        role="img"
+        aria-label={alt || "이미지를 불러올 수 없습니다"}
+        className={cn(
+          "bg-muted flex h-full w-full items-center justify-center",
+          className,
+        )}
+      >
+        <ImageOff
+          aria-hidden="true"
+          className="text-muted-foreground h-6 w-6"
+        />
+      </div>
+    );
+  }
 
   return (
     <Image
@@ -41,12 +59,12 @@ const CloudImage = ({
       sizes={sizes}
       fill
       alt={alt}
-      className={cn(`object-cover`, className)}
-      priority={priority}
+      className={cn("object-cover", className)}
+      preload={preload}
       loading={loading}
-      onError={onError}
+      onError={() => setFailedSrc(src)}
     />
   );
 };
 
-export { CloudImage };
+export { AppImage };

--- a/src/ui/components/atoms/index.ts
+++ b/src/ui/components/atoms/index.ts
@@ -1,3 +1,4 @@
+export * from "./app-image";
 export * from "./badge";
 export * from "./breadcrumb";
 export * from "./button";

--- a/src/ui/components/molecules/ProductCard.tsx
+++ b/src/ui/components/molecules/ProductCard.tsx
@@ -3,8 +3,7 @@ import Link from "next/link";
 import type { Product, SubCategory } from "@/core/domain";
 import { routes, subCategoryLabels } from "@/core/domain";
 import { calculatePrice } from "@/core/utils";
-import { Badge, TypographyMuted } from "@/ui/components/atoms";
-import { CloudImage } from "./CloudImage";
+import { AppImage, Badge, TypographyMuted } from "@/ui/components/atoms";
 
 export function ProductCard({ product, rank }: { product: Product; rank?: number }) {
   const finalPrice =
@@ -26,11 +25,11 @@ export function ProductCard({ product, rank }: { product: Product; rank?: number
       <div className="bg-muted relative aspect-[1/1.618] overflow-hidden rounded-2xl">
         {/* Thumbnail with zoom on hover */}
         <div className="absolute inset-0 transition-transform duration-700 ease-[cubic-bezier(0.25,0.46,0.45,0.94)] group-hover:scale-[1.06]">
-          <CloudImage
+          <AppImage
             src={product.thumbnail}
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
             alt={`${product.title} 썸네일`}
-            priority={true}
+            preload={true}
           />
         </div>
 

--- a/src/ui/components/molecules/index.ts
+++ b/src/ui/components/molecules/index.ts
@@ -1,7 +1,6 @@
 export * from "./Alert";
 export * from "./AutoCompleteList";
 export * from "./BaseSelect";
-export * from "./CloudImage";
 export * from "./CursorPagination";
 export * from "./Pricing";
 export * from "./ProductCard";

--- a/src/ui/components/organisms/ImagePreviewItem.tsx
+++ b/src/ui/components/organisms/ImagePreviewItem.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { ImageOff, X } from "lucide-react";
-import React, { useState } from "react";
-import { CloudImage } from "@/ui/components/molecules";
-import { Button } from "@/ui/components/atoms";
+import { X } from "lucide-react";
+import { AppImage, Button } from "@/ui/components/atoms";
 interface ImagePreviewItemProps {
   id: string;
   preview: string;
@@ -20,22 +18,9 @@ export const ImagePreviewItem = ({
   onRemove,
   sizes,
 }: ImagePreviewItemProps) => {
-  const [hasError, setHasError] = useState(false);
-
   return (
     <div className="border-border group relative aspect-square overflow-hidden rounded-lg border">
-      {hasError ? (
-        <div className="bg-muted flex h-full w-full items-center justify-center">
-          <ImageOff className="text-muted-foreground h-6 w-6" />
-        </div>
-      ) : (
-        <CloudImage
-          src={preview}
-          alt={`Preview ${id}`}
-          sizes={sizes}
-          onError={() => setHasError(true)}
-        />
-      )}
+      <AppImage src={preview} alt={`Preview ${id}`} sizes={sizes} />
       <Button
         type="button"
         variant="ghost"


### PR DESCRIPTION
## 변경 내용

- CloudImage를 atoms/app-image.tsx의 AppImage로 이동하고 벤더 종속 이름을 제거했습니다.
- 외부 배럴 import 10곳과 재실측에서 확인한 ProductCard 상대 import 1곳을 새 atom으로 전환했습니다.
- falsy src와 이미지 로드 실패 모두 ImageOff placeholder를 렌더링하도록 통합했습니다.
- ImagePreviewItem의 hasError 상태와 공개 onError prop을 제거했습니다.
- Next.js 16에서 deprecated된 priority 전달을 preload로 교체했습니다.
- 커스텀 loader prop을 사용하므로 use client 경계는 유지했습니다.

## 검증

- 영향 component test 8개 파일, 37개 테스트 통과
- 변경 파일 ESLint 통과
- npm run tsc 통과
- git diff --cached --check 통과

Related to #190