### PR TITLE
docs: UI 컴포넌트 티어 판정 기준을 교체한다

### DIFF
--- a/docs/security/page-access-control.md
+++ b/docs/security/page-access-control.md
@@ -38,10 +38,6 @@
 - 이 인가 재확인은 page 게이트와 별도의 세션 조회를 새로 만들지 않는다 — 같은 렌더 패스 안이면 위 `cache()` 덕분에 추가 DB 비용 없이 재확인이 가능하다.
 - 관리자 전용 데이터와 특정 유저 소유 데이터를 같은 service 함수가 같이 다뤄야 하는 경우(예: admin은 전체 조회, 유저는 자기 소유만)의 파라미터 형태는 지금 정하지 않는다 — 현재 코드에 그런 인스턴스가 없다(`admin/orders/page.tsx`가 아직 빈 스텁). 실제로 그 필요가 생기는 시점에 그 자리에서 재검토한다(가정만으로 미리 만들지 않는다, `src/services/AGENTS.md` 트랜잭션 섹션과 같은 원칙).
 
-## Gotchas
-
-- React `cache()`의 dedupe 범위는 Server Component render tree 기준이다 — page 게이트와 그 아래 service 재확인이 "같은 렌더 패스"일 때만 DB 재조회가 안 생긴다는 전제가 성립한다. 같은 service 함수를 나중에 route.ts나 Server Action에서도 호출하게 되면, 그 경로에서는 `cache()`가 이 dedupe를 보장한다고 가정하지 않는다 — 그 경로용 세션 조회 비용은 별도로 계산한다.
-
 ## 인증 토큰
 
 > 구현 완료(PR #59, 커밋 `7a553a3`) — access/refresh 이중 토큰은 `token` 단일 쿠키로 이미 마이그레이션됐다, 코드에 access 토큰은 존재하지 않는다.

--- a/src/ui/components/AGENTS.md
+++ b/src/ui/components/AGENTS.md
@@ -1,29 +1,66 @@
 # AGENTS.md — src/ui/components/
 
-> Last updated: 2026-07-18
+> Last updated: 2026-08-31
 
 ## Overview
 
-이 프로젝트의 컴포넌트 조직 구조를 정의한다. Brad Frost의 Atomic Design 원본 5단계(atoms/molecules/organisms/templates/pages) 중 pages만 빼고 그대로 차용한다 — pages 역할은 `src/app/**/page.tsx`가 대신한다(`src/app/AGENTS.md` 참고). 각 티어 세부 정의는 `src/ui/components/atoms/AGENTS.md`/`molecules/AGENTS.md`/`organisms/AGENTS.md`/`templates/AGENTS.md` 소관.
+이 프로젝트는 Brad Frost의 Atomic Design에서 pages를 제외한 atoms, molecules, organisms, templates 네 티어를 사용한다. pages 역할은 `src/app/**/page.tsx`가 담당한다.
 
-컴포넌트는 두 개의 독립된 축으로 판단한다 — 헷갈리면 이 구분으로 돌아온다: **축 A**(atom/molecule/organism/template, 조합 복잡도)와 **축 B**(공용 `src/ui/components/{tier}/` vs 라우트 전용 `_components/`, 물리적 위치). 이 파일의 Critical Convention이 두 축의 판단 기준과 예외를 정의한다.
+티어 판정은 축 A(컴포넌트의 역할)와 축 B(공용 폴더인지 라우트 로컬인지)를 분리해서 수행한다. **이 문서와 각 티어의 `AGENTS.md`가 판정 기준의 유일한 진실 소스다.** 별도 메모나 과거 배치 사례를 기준으로 삼지 않는다.
 
-## Critical Convention
+## 축 A — 티어 판정
 
-- **축 A — 티어 분류.** 원본 Atomic Design 기준 그대로 쓴다: 조합 복잡도/책임 범위로 판단한다. "몇 곳에서 재사용되는가"는 이 축과 무관하다. **"무엇을 조합하는가"를 묻지 않고 "공간적으로 어떻게 배치하는가"(예: CSS grid 배치)만 다루는 건 이 축 자체와 직교하는 문제라 어느 티어에도 억지로 끼워 넣지 않는다** — 소비처가 매번 직접 인라인한다(구 `atoms/grid.tsx` 사례, `atoms/AGENTS.md` Gotchas 참고).
-- **축 B — 물리적 위치.** 원본에 없는, 이 프로젝트가 독자적으로 추가한 것 — 순수성 원칙(핵심 원칙 1)과 소비자 수(`src/app/AGENTS.md` 컨테이너 승격 규칙)로 판단한다. 어떤 티어든 축 B는 동일하게 적용된다. **소비자 수는 직접 호출자가 아니라 실제로 몇 개 라우트에서 최종 렌더되는지로 전이적으로 센다** — 중간에 몇 겹을 거치든(공용 컴포넌트든 라우트 로컬이든) 무관하게 최종 도달 라우트 개수만 본다. 예: organism X의 유일한 소비자가 라우트 로컬 Template Y 하나뿐이고 Template Y도 라우트 1곳 전용이면, organism X도 실질 소비 라우트가 1곳이라 승격 보류 대상이다.
-- 과거 `fields/`·`(preview)/` 서브폴더를 "예외존"처럼 다룬 게 혼란의 원인이었다 — 서브폴더에 있다는 사실 자체는 두 축 어느 쪽 판단에도 영향을 주지 않는다.
-- **핵심 원칙 1 — atoms/molecules/organisms/templates 전부 순수(presentational)하다(축 B 관련).** 도메인 로직·데이터 페칭·Server Actions을 이 4단계 어디에도 두지 않는다 — props로만 데이터/핸들러를 받는다. 도메인 로직이 필요한 화면은 그 로직을 감싸는 **컨테이너**(`src/app/**/_containers/{Name}.tsx`, 라우트 전용)가 순수 organism/molecule을 import해서 props를 채워 넣는 방식으로 만든다. 컨테이너 판정 기준은 `src/app/AGENTS.md`의 `_containers/` 규칙을 따른다.
-  - 예: `_containers/LoginForm.tsx`(컨테이너 — `useActionState`+SWR `mutate`+`router.push` 처리) → `organisms/Form.tsx`(순수 — props로 필드/핸들러/에러만 받음) import.
-  - 컨테이너 승격 규칙은 `src/app/AGENTS.md`의 `_containers/` 규칙과 동일: **소비자가 라우트(또는 그 라우트의 `layout.tsx`) 1곳뿐이면** 그 라우트의 `_containers/`에 머문다. 순수 organism/molecule 자체가 2곳 이상의 라우트/컨테이너에서 재사용되면 그게 공용 자격의 근거다. 단, 유일한 소비자가 라우트가 아니라 **다른 공유 컴포넌트**(그 컴포넌트 자체가 이미 2곳 이상에서 쓰임)라면 이 승격-보류 규칙이 적용되지 않는다 — 그 하위 조각은 그냥 같은 공용 티어 폴더에 남는다(예: `DateField`/`AddressField`/`ImageField`의 유일한 소비자는 `BasicInfoSection`이고, `BasicInfoSection`은 라우트가 아니라 `InvitationFormView`의 하위 조각이므로 `molecules/`에 그대로 남는다 — 라우트 전용 `_components`/`_containers`/`_utils`는 Next.js가 라우트 단위로 주는 private 폴더 개념이지 컴포넌트 단위로 확장할 근거가 없다).
-  - 소비자 1곳이 `page.tsx`가 아니라 `layout.tsx`(라우트 그룹 셸)여도 축 B는 동일하게 적용된다 — 셸 조각 배치 규칙과 구체 사례(Header/AuthButtons/Footer/GuestbookModal 등)는 `src/app/AGENTS.md` 참고. (`src/ui/components/layout/`은 이 정리로 폐기됐다 — atoms/molecules/organisms 3단계 밖의 미분류 폴더였다.)
-  - **컨테이너가 2곳 이상의 라우트/레이아웃에서 진짜 도메인 로직까지 겹치면(`SidebarLayout`처럼 여러 레이아웃이 같은 `useAuth()` 조회+렌더를 반복), 억지로 공용 컴포넌트로 승격하지 않는다** — 각 레이아웃이 자기 파일 안에서 직접 정의한다(`(admin)/admin/layout.tsx`, `(my-order)/layout.tsx`, `(my-profile)/layout.tsx` 각각). 지금은 내용이 동일해 보여도 각 레이어가 독립적으로 진화할 수 있는 컨텍스트라, 공용 컴포넌트로 묶으면 나중에 레이어별로 갈라져야 할 때 오히려 인위적으로 갈라야 한다.
-  - **컨테이너 로직 자체(순수 UI 말고)가 2곳 이상의 라우트에서 100% 동일하게 재사용돼야 하면, 그 로직을 `src/ui/hooks/`의 커스텀 훅으로 뽑는다** — 각 라우트는 자기 `_containers/`에 그 훅을 호출하고 순수 UI를 렌더하는 얇은 컨테이너를 각자 둔다("라우트당 컨테이너 1개" 원칙은 그대로 유지). 공유되는 순수 UI 쪽은 `organisms/`에 남되, 여러 컨테이너가 공유한다는 걸 이름으로 드러낸다 — 이름 짓는 방법 자체는 `src/AGENTS.md`의 추상화 네이밍 규칙 참고.
-  - **예외 2 — 단순 페이지 이동은 `useRouter().push()` 대신 `<Link href>`(또는 `Button asChild`)로 쓰면 위반이 아니다.** 데이터 mutation 없이 그냥 다른 라우트로 이동만 하는 클릭 핸들러는 `next/link`로 대체 가능하면 그렇게 한다 — 그러면 애초에 컨테이너 분리가 필요 없어진다. mutation(폼 제출, store 쓰기 등) 뒤에 이어지는 조건부 리다이렉트는 이 예외 대상이 아니다(컨테이너 소관).
-- **핵심 원칙 2 — atom/molecule 경계는 "누가 조합했는가"다(축 A 관련).** shadcn/Radix 산출물은 내부적으로 여러 하위 요소를 묶은 복합 시스템(`sidebar.tsx`, `dialog.tsx` 등)이어도 통째로 atom 취급한다 — "물리적으로 더 못 쪼갠다"가 기준이 아니라, **조합의 주체가 이 프로젝트 코드가 아니라 외부 라이브러리**라는 게 기준이다(원본 Atomic Design도 atom=우리가 안 쪼갠 것, molecule=우리가 atom을 조합해 만든 것이 전제라 실제로는 원본과 어긋나지 않는다). 커스텀 프리미티브(예: Typography)는 "다른 컴포넌트를 조합하지 않고 그 자체로 완결"되면 atom이다 — 이건 프로젝트가 직접 만들었으므로 "조합했는가"로 그대로 판단 가능.
-- **핵심 원칙 3 — molecule/organism 경계는 "완성됐는가"가 아니라 "단순한가 복잡한가"다(축 A 관련, 원본 그대로).** Brad Frost 원본: molecule은 "relatively simple"(단일 책임의 단순 단위), organism은 "relatively complex... distinct section"(여러 책임을 묶은, 페이지에서 뚜렷이 구분되는 복잡한 구획)이다 — "이대로 바로 쓰이느냐"가 아니라 "책임이 하나냐 여러 개냐"로 판단한다. 예: `TextField`(라벨+입력 필드 하나, 단일 책임)는 그 자체로 완성돼 바로 쓰여도 molecule — `BasicInfoForm`(필드 여러 개+제출 로직을 묶은 폼 섹션 전체)이 organism이다.
-- **핵심 원칙 4 — template은 "페이지 전체 배치"이지 organism의 확장판이 아니다(축 A 관련, 원본 그대로).** organism은 페이지 안의 한 구획(section)이고, template은 그 구획들을 모아 **페이지 하나 전체**를 배치한 것 — 원본 정의상 실제 데이터 없이 placeholder 성격 콘텐츠만 다룬다(이 프로젝트에선 "진짜 데이터 없이 props로만 완성된 콘텐츠를 받는다"로 구현). 세부 규칙(순수성, self-fetching 자식 있을 때 opt-out, page.tsx와의 경계)은 `src/ui/components/templates/AGENTS.md` 참고.
+다음 순서로 판정하고, 앞 단계에서 결론이 나면 뒤 단계는 적용하지 않는다.
+
+1. `page.tsx`가 페이지 몸통 전체를 위임하는 컴포넌트인지 확인한다. 맞으면 조합 재료나 동작 수와 무관하게 template이다.
+2. shadcn/Radix CLI 산출물인지 확인한다. 맞으면 내부 복잡도나 동작 수와 무관하게 atom이다.
+3. 우리가 작성한 코드라면 표시, 입력, 검증, 삭제, 탐색처럼 사용자가 인식하는 동작 종류를 센다. 두 종류 이상이면 조합 수와 무관하게 organism이다.
+4. 동작이 한 종류라면 프로젝트 UI 컴포넌트 조합 수를 본다. 조합이 없으면 atom, 하나 이상이면 molecule이다.
+
+| 조건                               | 판정     |
+| ---------------------------------- | -------- |
+| 페이지 몸통 전체를 위임받음        | template |
+| shadcn/Radix CLI 산출물            | atom     |
+| 우리 코드, 조합 0개, 동작 1종      | atom     |
+| 우리 코드, 조합 1개 이상, 동작 1종 | molecule |
+| 우리 코드, 동작 2종 이상           | organism |
+
+props로 받은 핸들러를 그대로 전달하는 상호작용도 동작으로 센다. 예를 들어 라벨 표시와 `onChange` 전달을 함께 하는 `TextField`는 표시와 입력 두 종류의 동작을 가지므로 organism이다. 반대로 CSS grid처럼 무엇을 조합하는지가 아니라 배치 방식만 반복하는 코드는 티어 컴포넌트로 만들지 않고 소비처에 배치 클래스를 둔다.
+
+## 축 B — 공용 여부
+
+축 A로 티어를 정한 다음 물리적 위치를 판단한다. 소비처 수는 직접 import 수가 아니라 최종 렌더되는 라우트 수를 전이적으로 센다.
+
+- 최종 소비 라우트가 2곳 이상이면 `src/ui/components/{tier}/`의 공용 컴포넌트 후보가 된다.
+- 최종 소비 라우트가 1곳이면 해당 라우트의 `_components/`에 둔다. 데이터 페칭, mutation, 도메인 로직을 소유하면 `_containers/`에 둔다.
+- 유일한 직접 소비자가 이미 여러 라우트에서 쓰이는 공용 컴포넌트라면 그 하위 구현도 공용 티어 폴더에 둘 수 있다.
+- `page.tsx`와 `layout.tsx` 소비를 동일하게 라우트 소비로 센다.
+
+atoms, molecules, organisms, templates는 모두 props 기반의 순수한 표현 컴포넌트다. 데이터 페칭, Server Actions, mutation, 도메인 로직을 두지 않는다. 도메인 타입과 리터럴 상수를 참조하기 위한 `@/core/domain` import는 허용한다.
+
+## 현재 판정 예시
+
+| 컴포넌트                    | 실측 근거                             | 판정     |
+| --------------------------- | ------------------------------------- | -------- |
+| `app-image.tsx`             | 프로젝트 UI 조합 0개, 이미지 표시 1종 | atom     |
+| `Alert.tsx`                 | Typography 조합, 상태 메시지 표시 1종 | molecule |
+| `TextField.tsx`             | 라벨·오류 표시와 입력 전달            | organism |
+| `RatingStars.tsx`           | 별점 표시와 입력                      | organism |
+| `LegalDocumentTemplate.tsx` | terms/privacy 페이지 몸통 전체 위임   | template |
+
+## Structure
+
+```text
+src/ui/components/
+├── atoms/       # 외부 산출물 또는 조합 없는 단일 동작 프리미티브
+├── molecules/   # 프로젝트 UI를 조합한 단일 동작 단위
+├── organisms/   # 두 종류 이상의 동작을 묶은 구획
+└── templates/   # 페이지 몸통 전체 구조
+```
+
+각 폴더는 flat 구조와 `index.ts` 배럴을 유지한다. 파일명 규칙과 세부 예시는 각 티어의 `AGENTS.md`를 따른다.
 
 ## 관련 문서
 
-- 컨테이너 승격 규칙(축 B), 셸 조각 배치 규칙, `_components/` 규칙: `src/app/AGENTS.md`
+- 라우트 로컬 `_components/`와 `_containers/`, page/layout 경계: `src/app/AGENTS.md`
+- 공통 배럴 import와 네이밍 규칙: `src/AGENTS.md`

--- a/src/ui/components/atoms/AGENTS.md
+++ b/src/ui/components/atoms/AGENTS.md
@@ -1,35 +1,44 @@
 # AGENTS.md — src/ui/components/atoms/
 
-> Last updated: 2026-07-18
+> Last updated: 2026-08-31
 
 ## Overview
 
-`atoms/`는 더 이상 쪼갤 수 없는 개별 UI 요소를 모아두는 곳이다 — 두 갈래로 구성된다: shadcn/Radix CLI 산출물(파일 하나가 여러 하위 요소를 묶은 복합 시스템, 예: `sidebar.tsx`)과, 다른 컴포넌트를 조합하지 않고 그 자체로 완결되는 커스텀 프리미티브(Typography류). 다른 컴포넌트를 import해서 조합하지 않으며, 도메인 로직·데이터 페칭도 없다.
+`atoms/`는 shadcn/Radix CLI 산출물과, 프로젝트 UI 컴포넌트를 조합하지 않고 한 종류의 동작만 제공하는 커스텀 프리미티브를 모아둔다.
 
-molecule과의 경계는 "누가 조합했는가"다(`src/ui/components/AGENTS.md` 핵심 원칙 2) — shadcn/Radix 산출물은 조합 주체가 외부 라이브러리라 "물리적으로 더 못 쪼갠다"가 기준이 아니어도 atom 자격이 있고, 커스텀 프리미티브는 조합이 하나라도 있으면 atom 자격이 없다(molecules 소관).
+shadcn/Radix CLI 산출물은 내부에 여러 하위 요소와 상호작용이 있어도 atom이다. 우리가 작성한 컴포넌트는 프로젝트 UI 조합이 0개이고 동작이 한 종류일 때만 atom이다. 동작이 두 종류 이상이면 조합이 없어도 organism으로 판정한다.
+
+## 현재 예시
+
+| 파일                       | 근거                                            |
+| -------------------------- | ----------------------------------------------- |
+| `button.tsx`, `dialog.tsx` | shadcn/Radix 산출물                             |
+| `typography.tsx`           | 프로젝트 UI 조합 없이 텍스트 표시               |
+| `app-image.tsx`            | 프로젝트 UI 조합 없이 이미지 또는 fallback 표시 |
+
+`app-image.tsx`의 로드 실패 fallback도 이미지 표시라는 같은 동작 안의 상태 변화이므로 동작 종류를 늘리지 않는다.
 
 ## Structure
 
-```
+```text
 src/ui/components/atoms/
-├── index.ts               # 배럴 — export *
+├── index.ts
+├── app-image.tsx
 ├── button.tsx
-├── dialog.tsx        # 복합 시스템(Root/Trigger/Content 등)이어도 통째로 atom
-├── typography.tsx        # 커스텀 프리미티브(조합 없음)
-└── ...                     # 완전 flat, 하위 폴더 없음
+├── dialog.tsx
+├── typography.tsx
+└── ...
 ```
 
 ## Critical Convention
 
-- **완전 flat 구조** — 하위 폴더를 만들지 않는다.
-- 파일명은 **소문자 kebab-case**(shadcn/Radix 라이브러리 표준을 그대로 따름, 컴포넌트 PascalCase 원칙과 다른 이 폴더만의 예외).
-- 비즈니스 로직·테마 확장(Tailwind/CVA) 외의 기능을 추가하지 않는다.
-
-## Gotchas
-
-- `grid.tsx`(구 `Grid`)는 결국 완전히 해체돼 삭제됐다 — atom/molecule/organism 축(축 A)은 "무엇을 조합하는가"로 판단하는데, Grid는 조합 대상이 아니라 "공간적으로 어떻게 배치하는가"(CSS `display: grid`)만 다뤄서 이 축 자체와 직교하는 문제였다(atom도 template도 아님, 실제로 admin에선 `Card`(atom)를, `ProductGrid`에선 `ProductCard`(organism)를 감싸 대상이 매번 달랐다). 컴포넌트로 감싸 재사용하는 대신 그 배치 클래스(`grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`)를 소비처 3곳(`organisms/ProductGrid.tsx`, admin `dashboard`/`premium-features` `page.tsx`) 각자가 직접 `<section className="...">`으로 인라인하는 걸로 정리했다 — `slot` prop(호출부마다 고유 문자열을 지어 `data-slot`에 넘겼지만 실제로 읽는 CSS/테스트 셀렉터가 0곳이던 죽은 prop)도 이걸로 자연히 없어졌다.
-- `titled-section.tsx`(구 `SectionLayout`)는 `grid.tsx`와 같이 `layout/`에서 여기로 옮겨졌었지만, 다시 삭제됐다 — 축 A(조합 여부) 판단만 하고 축 B(공용 vs 라우트 전용)를 놓친 실수였다. 실제 소비자 6곳이 전부 `(preview)/preview/[id]/_components/` 하나뿐이라 애초에 atoms 자격이 없었다. title/subTitle 텍스트를 직접 하드코딩하던 것도 `atoms/typography.tsx`의 `TypographyEyebrow`(신규)/`TypographyLead` 조합으로 바뀌면서 atom(조합 없음) 자격도 잃어 molecule 성격이 됐다 — `(preview)/preview/[id]/_components/EyebrowSection.tsx`(라우트 전용, prop명도 `title`/`subTitle`→`eyebrow`/`heading`으로 개명)로 이동 완료.
+- 완전한 flat 구조를 유지하고 하위 폴더를 만들지 않는다.
+- 파일명은 소문자 kebab-case로 짓고 export 이름은 PascalCase를 사용한다.
+- 도메인 로직, 데이터 페칭, Server Actions, mutation을 두지 않는다.
+- 프로젝트 UI 컴포넌트를 하나라도 조합하면 동작 수를 다시 센 뒤 molecule 또는 organism으로 이동한다.
+- 공간 배치만 추상화하는 wrapper를 만들지 않는다. 배치 클래스는 소비처가 소유한다.
 
 ## 관련 문서
 
-- 조합이 시작되는 다음 단계: `src/ui/components/molecules/AGENTS.md`
+- 공통 판정 순서와 공용 여부: `src/ui/components/AGENTS.md`
+- 조합이 시작되는 다음 티어: `src/ui/components/molecules/AGENTS.md`

--- a/src/ui/components/molecules/AGENTS.md
+++ b/src/ui/components/molecules/AGENTS.md
@@ -1,43 +1,43 @@
 # AGENTS.md — src/ui/components/molecules/
 
-> Last updated: 2026-07-18
+> Last updated: 2026-08-31
 
 ## Overview
 
-`molecules/`는 atoms(및/또는 다른 molecule) 2개 이상을 조합해 만든, 단일 책임의 단순 기능 단위를 모아두는 곳이다 — 순수(presentational)해야 하며 도메인 로직·데이터 페칭·Server Actions 의존은 금지된다(`src/ui/components/AGENTS.md` 핵심 원칙 1).
+`molecules/`는 프로젝트 UI 컴포넌트를 하나 이상 조합하면서 사용자가 인식하는 동작은 한 종류인 순수 컴포넌트를 모아둔다. 완성품인지 골격인지는 판정 기준이 아니다.
 
-organism과의 경계는 "완성됐냐"가 아니라 "단순한가 복잡한가"다(핵심 원칙 3, 원본 Atomic Design 기준) — 책임이 하나뿐이면 그 자체로 완성돼 바로 쓰여도 molecule이다. 예: `TextField`(라벨+입력 필드 하나)는 완성돼서 바로 쓰이지만 책임이 단일하니 molecule — `FormField`(children 꽂아야 완성되는 골격)도 단일 책임이라 molecule("미완성 골격이냐 완성품이냐"는 판단 기준이 아니다). 조합 결과가 여러 책임을 동시에 지게 되면(예: 필드 여러 개를 한데 묶은 폼 섹션) organisms 소관이다(`src/ui/components/organisms/AGENTS.md` 참고).
+props로 받은 핸들러를 전달하는 상호작용도 동작으로 센다. 따라서 표시와 입력, 표시와 삭제처럼 동작이 두 종류가 되면 조합이 단순해도 organism이다.
+
+## 현재 예시
+
+| 파일              | 조합                        | 동작             |
+| ----------------- | --------------------------- | ---------------- |
+| `Alert.tsx`       | Typography                  | 상태 메시지 표시 |
+| `ProductCard.tsx` | AppImage, Badge, Typography | 상품 요약 표시   |
+
+`TextField`와 `FormField`는 현재 `organisms/`에 있다. 이름에 `Field`가 붙었는지, 바로 사용할 수 있는지는 molecule 판정 근거가 아니다.
 
 ## Structure
 
-- **완전 flat 구조 — 하위 폴더를 만들지 않는다**(atoms와 동일 이유, Gotchas 참고 — 서브폴더가 "규칙 예외존"으로 오해되는 걸 원천 차단).
-
-```
+```text
 src/ui/components/molecules/
-├── index.ts               # 배럴 — export *
-├── FormField.tsx        # Label(atom)+Alert(molecule) 조합, children 꽂혀야 완성 — 단일 책임
-├── Alert.tsx               # Typography(atom) 조합
-├── TextField.tsx            # FormField(molecule)+Input(atom) 조합, 완성돼 바로 쓰임 — 단일 책임(입력 필드 하나)이라 organism 아님
-├── BaseSelect.tsx            # Select 계열 atom들만 조합, options만 꽂으면 그대로 완성 — 역시 단일 책임
-└── ...                         # PascalCase
+├── index.ts
+├── Alert.tsx
+├── AutoCompleteList.tsx
+├── BaseSelect.tsx
+├── CursorPagination.tsx
+└── ProductCard.tsx
 ```
 
 ## Critical Convention
 
-- 파일명/export는 PascalCase.
-- 소비자가 라우트 1곳뿐인 molecule을 미리 여기로 승격하지 않는다 — 그 라우트의 `_components/` 안에 로컬로 둔다. 라우트 2곳 이상이 실제로 재사용할 때만 승격. 단, 유일한 소비자가 라우트가 아니라 이미 이 폴더/organisms에서 공유 중인 다른 컴포넌트라면 이 규칙 대상이 아니다 — 그 컴포넌트의 구현 디테일로 보고 그냥 여기 둔다(예: `DateField`/`AddressField`/`ImageField`의 유일한 소비자는 `BasicInfoSection`인데, `BasicInfoSection` 자체가 라우트 2곳이 공유하는 `CoupleInfoFormView`의 하위 조각이라 승격 보류 대상이 아니다 — `src/ui/components/AGENTS.md` 핵심 원칙 1 참고).
+- 완전한 flat 구조를 유지하고 하위 폴더를 만들지 않는다.
+- 파일명과 export 이름은 PascalCase로 짓는다.
+- 도메인 로직, 데이터 페칭, Server Actions, mutation을 두지 않는다.
+- 최종 소비 라우트가 한 곳이면 해당 라우트의 `_components/`에 두고, 2곳 이상일 때 공용 폴더로 승격한다.
+- 유일한 직접 소비자가 이미 여러 라우트에서 쓰이는 공용 컴포넌트라면 그 하위 molecule은 이 폴더에 둘 수 있다.
 
-## Gotchas
+## 관련 문서
 
-- 이름-바꿔치기 재export 파일(내부 로직 없이 다른 컴포넌트를 도메인스러운 이름으로만 재export)을 만들지 않는다 — 과거 `ProductThumbnail.tsx`가 `CloudImage.tsx`를 그대로 재export하는 1줄짜리 alias였다(Product 도메인 로직 0개, 소비자도 도메인 무관하게 씀).
-- `CloudImage.tsx` — Cloudinary라는 인프라에 의존하지만 비즈니스 도메인(Product/Order 등)엔 안 묶여있다 — 인프라 의존은 순수성 위반이 아니므로 그대로 유지.
-- `RadioField.tsx`, `SwitchField.tsx` — `FormField`를 안 쓰고 atoms만 직접 조합해서 라벨까지 자체 처리하는 molecule이다. "...Field"라는 이름만 보고 어디 소속인지 판단하지 않는다 — 위치는 이름이 아니라 실제 조합 복잡도(단순=molecule, 복잡=organism)로 판단한다.
-
-## References
-
-즉시 로드(`@import`) 아님 — 트리거 열 키워드에 해당하는 작업일 때만 해당 문서를 읽는다.
-
-| 문서                   | 위치                                 | 트리거                       | 요약                       |
-| ---------------------- | ------------------------------------ | ----------------------------- | -------------------------- |
-| `AGENTS.md`            | `src/ui/components/organisms/`   | 더 복잡한 다음 단계 확인 시   | organism 정의              |
-| `AGENTS.md`            | `src/app/`                           | 라우트 전용 승격 대기 공간 확인 시 | 컨테이너 승격 규칙    |
+- 공통 판정 순서와 공용 여부: `src/ui/components/AGENTS.md`
+- 두 종류 이상의 동작을 다루는 티어: `src/ui/components/organisms/AGENTS.md`

--- a/src/ui/components/organisms/AGENTS.md
+++ b/src/ui/components/organisms/AGENTS.md
@@ -1,36 +1,47 @@
 # AGENTS.md — src/ui/components/organisms/
 
-> Last updated: 2026-07-18
+> Last updated: 2026-08-31
 
 ## Overview
 
-`organisms/`는 molecules(및/또는 atoms, 다른 organisms)를 조합해 만든, 여러 책임을 묶은 복잡한/뚜렷이 구분되는 화면 섹션을 모아두는 곳이다 — molecules와 동일하게 순수(presentational)해야 하며 도메인 로직·데이터 페칭·Server Actions은 두지 않는다(`src/ui/components/AGENTS.md` 핵심 원칙 1). 도메인 로직이 필요한 화면은 라우트의 `_components/{Name}.tsx`(컨테이너)가 이 순수 organism을 import해서 props(데이터/핸들러)를 채워 넣는 방식으로 만든다 — 예: `_components/LoginForm.tsx`(컨테이너)가 `organisms/Form.tsx`(순수)에 필드 설정·onSubmit·에러를 props로 전달.
+`organisms/`는 표시, 입력, 검증, 삭제, 탐색처럼 사용자가 인식하는 동작을 두 종류 이상 묶은 순수 컴포넌트를 모아둔다. 프로젝트 UI 조합 수는 보조 지표이며, 동작이 두 종류 이상이면 조합이 없어도 organism이다.
 
-molecules와의 경계는 "완성됐냐"가 아니라 "단순한가 복잡한가"다(핵심 원칙 3, 원본 Atomic Design 기준) — molecule은 단일 책임의 단순 단위, organism은 그런 단순 단위 여러 개(+atom)를 묶어 만든 복잡한 구획이다(예: `BasicInfoForm.tsx` = 필드 여러 개(molecule)를 묶고 제출 로직까지 아우르는 폼 섹션).
+props로 주입받은 핸들러를 하위 요소에 전달하기만 해도 해당 상호작용을 동작으로 센다. 이 규칙을 적용하지 않으면 핸들러를 props로 받는 순수 컴포넌트 대부분이 표시 한 종류로 잘못 축소된다.
+
+## 현재 예시
+
+| 파일                  | 동작 근거                    |
+| --------------------- | ---------------------------- |
+| `TextField.tsx`       | 라벨·오류 표시와 입력 전달   |
+| `ClipboardButton.tsx` | 아이콘 표시와 복사 클릭 전달 |
+| `RatingStars.tsx`     | 별점 표시와 별점 입력        |
+| `BankField.tsx`       | 은행 선택과 계좌번호 입력    |
+| `BottomActionBar.tsx` | 가시성 표시와 제출 전달      |
+
+`RatingStars.tsx`처럼 프로젝트 UI 조합이 0개여도 동작이 두 종류면 atom이 아니라 organism이다.
 
 ## Structure
 
-```
+```text
 src/ui/components/organisms/
-├── index.ts                        # 배럴 — export *
-└── {Name}.tsx                        # 완성된 화면 섹션(순수, props 기반)
+├── index.ts
+├── BankField.tsx
+├── ClipboardButton.tsx
+├── FormField.tsx
+├── RatingStars.tsx
+├── TextField.tsx
+└── ...
 ```
 
 ## Critical Convention
 
-- 파일명/export는 PascalCase.
-- 소비자가 라우트 1곳뿐인 organism을 미리 여기로 승격하지 않는다 — 도메인 결합 여부와 무관하게, 순수한 완성품 자체가 2개 이상의 라우트/컨테이너에서 재사용될 때만 여기 둔다(`src/ui/components/AGENTS.md` 컨테이너 승격 규칙). 유일한 소비자가 라우트가 아니라 이미 공유 중인 다른 organism/molecule이면 이 규칙 대상이 아니다(같은 예외는 `src/ui/components/AGENTS.md` 참고).
-- 여러 도메인 타입을 동시에 다루거나 2곳 이상에서 재사용되는 구현체의 추상 네이밍 규칙은 `src/AGENTS.md` 참고(이 폴더 전용 규칙 아님, 교차 컨벤션).
+- 완전한 flat 구조를 유지하고 하위 폴더를 만들지 않는다.
+- 파일명과 export 이름은 PascalCase로 짓는다.
+- 도메인 로직, 데이터 페칭, Server Actions, mutation을 두지 않는다. 해당 로직은 라우트의 `_containers/`가 소유하고 organism에는 props로 전달한다.
+- 최종 소비 라우트가 한 곳이면 해당 라우트의 `_components/`에 두고, 2곳 이상일 때 공용 폴더로 승격한다.
+- 여러 도메인이나 라우트에서 쓰는 구현은 특정 소비처 이름을 피하고 역할 중심으로 이름 짓는다.
 
-## Gotchas
+## 관련 문서
 
-- `InvitationFormView`는 청첩장 전체 편집 UI이고 `CoupleInfoSection`은 그 안의 신랑·신부 정보 섹션이다 — 엔티티·편집 흐름에는 `Invitation`, 실제 커플 정보 구획에만 `CoupleInfo`를 사용한다.
-
-## References
-
-즉시 로드(`@import`) 아님 — 트리거 열 키워드에 해당하는 작업일 때만 해당 문서를 읽는다.
-
-| 문서                   | 위치                                | 트리거                             | 요약                          |
-| ---------------------- | ------------------------------------ | ----------------------------------- | ----------------------------- |
-| `AGENTS.md`            | `src/app/`                           | 컨테이너(도메인 로직) 승격 규칙 확인 시 | 컨테이너 및 승격 규칙     |
-| `AGENTS.md`            | `src/ui/components/molecules/`   | 조합 재료 확인 시                   | molecule 정의                 |
+- 공통 판정 순서와 공용 여부: `src/ui/components/AGENTS.md`
+- 라우트 컨테이너 배치: `src/app/AGENTS.md`

--- a/src/ui/components/templates/AGENTS.md
+++ b/src/ui/components/templates/AGENTS.md
@@ -1,35 +1,34 @@
 # AGENTS.md — src/ui/components/templates/
 
-> Last updated: 2026-07-21
-> 신규 도입된 티어 — 아직 이 폴더에 실사례 없음(Gotchas 참고, 강제 소급 적용 안 함).
+> Last updated: 2026-08-31
 
 ## Overview
 
-`templates/`는 페이지 하나의 전체 배치(organism/molecule/atom을 모아 완성한 화면 전체 구조)를 모아두는 곳이다 — 진짜 데이터 없이 순수해야 한다(`src/ui/components/AGENTS.md` 핵심 원칙 1). organism과의 경계는 "범위"다 — organism은 페이지 안 한 구획(section), template은 그 구획들을 모은 페이지 전체. Brad Frost 원본은 이 레벨에서 실제 콘텐츠 대신 placeholder를 쓴다고 정의하는데, 이 프로젝트는 그걸 "진짜 fetch된 데이터 없이, 완성된 콘텐츠를 props로만 받는다"로 구현한다 — 데이터가 어디서 왔는지(fetch냐 하드코딩이냐)는 template이 몰라야 한다.
+`templates/`는 `page.tsx`가 페이지 몸통 전체를 위임하는 순수 컴포넌트를 모아둔다. template은 organism의 복잡한 버전이 아니라 페이지 범위를 소유하는 별도 티어다.
 
-조합 대상 organism/molecule 중 단 하나라도 내부에서 자체 데이터 페칭(예: `useSWR`)을 한다면, 그 페칭 결과가 template 관점에선 "진짜 데이터"라서 순수성이 깨져 애초에 template으로 만들 수 없다 — 이런 경우 도입을 강제하지 않고 지금처럼 라우트 로컬 구성(`_components/`)을 그대로 유지한다(예: `(preview)/preview/[id]`의 `GuestbookSection`류 — `organisms/AGENTS.md` Gotchas 참고).
+페이지 범위는 다른 모든 판정 축보다 우선한다. atom만 사용하거나 동작이 한 종류뿐이어도 페이지 몸통 전체를 담당하면 template이다. template이 반드시 molecule이나 organism을 재료로 사용해야 한다는 조건은 없다.
+
+## 현재 예시
+
+`LegalDocumentTemplate.tsx`는 terms와 privacy 두 `page.tsx`가 제목, 시행일, 섹션 데이터만 전달하고 페이지 몸통 전체를 위임하므로 공용 template이다.
 
 ## Structure
 
-- **완전 flat 구조 — 하위 폴더를 만들지 않는다**(atoms/molecules/organisms와 동일 이유).
-
-```
+```text
 src/ui/components/templates/
-└── {Name}Template.tsx   # PascalCase + Template 접미사, 페이지 전체 배치
+├── index.ts
+└── LegalDocumentTemplate.tsx
 ```
 
 ## Critical Convention
 
-- 파일명/export는 PascalCase + `Template` 접미사 고정(예: `ProductCatalogTemplate.tsx`) — organism과 이름만 보고 구분되어야 한다.
-- **이 폴더로 승격하는 건 2곳 이상의 라우트가 "의도적으로 동일한" 전체 배치를 공유할 때만이다.** 원본 정의상 template은 태생적으로 페이지 하나 전용인 경우가 압도적으로 많다 — 그래서 대부분의 template은 이 폴더가 아니라 그 라우트의 `_components/{Name}Template.tsx`(라우트 로컬)에 머문다. 시각적으로 비슷해 보인다는 이유만으로 승격하지 않는다 — `SidebarLayout` 전례(`src/app/AGENTS.md`)와 동일 사유: 지금 같아 보여도 각 페이지가 독립적으로 진화할 수 있는 컨텍스트면 억지로 합치지 않는다.
-- `page.tsx`가 언제 이 티어를 추출해야 하는지(추출 트리거 — organism 1개+배치 코드 없음 예외 외엔 필수)와, `layout.tsx`(라우트 그룹 셸)와의 층위 구분은 `src/app/AGENTS.md` 소관 — 이 파일에서 중복 서술하지 않는다.
-
-## Gotchas
-
-- 신규 도입(2026-07-21) — 기존 라우트의 `page.tsx` 얇은 래퍼(organism을 배치 코드와 함께 바로 렌더하던 것들)를 지금 일괄 리팩토링하지 않는다. 새 라우트, 또는 컨테이너/순수 분리 리팩토링 대상이 되는 라우트부터 순차 적용한다(`src/app/AGENTS.md`의 private 폴더 도입 때와 동일 정책).
-- 구 `atoms/grid.tsx`는 이 티어 후보로도 검토됐으나 탈락했다 — template은 "페이지 전체" 배치인데 Grid는 페이지 안 한 섹션(구획)만 다뤄서 범위가 안 맞았다. 결국 컴포넌트 자체를 해체하고 소비처마다 배치 클래스를 인라인하는 걸로 정리됨(`src/ui/components/atoms/AGENTS.md` Gotchas 참고).
+- 완전한 flat 구조를 유지하고 하위 폴더를 만들지 않는다.
+- 파일명과 export 이름은 PascalCase + `Template` 접미사로 짓는다.
+- 데이터 페칭, Server Actions, mutation, 도메인 로직을 두지 않고 완성된 콘텐츠를 props로 받는다.
+- 한 라우트만 사용하는 template은 해당 라우트의 `_components/`에 두고, 의도적으로 같은 전체 배치를 공유하는 라우트가 2곳 이상일 때 이 폴더로 승격한다.
+- `page.tsx` 추출 기준과 `layout.tsx` 경계는 `src/app/AGENTS.md`를 따른다.
 
 ## 관련 문서
 
-- 한 단계 아래(organism): `src/ui/components/organisms/AGENTS.md`
-- Pages(`page.tsx`) 역할, private 폴더, layout.tsx 경계: `src/app/AGENTS.md`
+- 공통 판정 순서와 공용 여부: `src/ui/components/AGENTS.md`
+- Pages, private 폴더, layout 경계: `src/app/AGENTS.md`


### PR DESCRIPTION
## 변경 내용

- UI 컴포넌트 공통 문서에 범위 우선, 외부 산출물 면제, 동작 종류 우선 판정 순서를 단일 기준으로 정리했습니다.
- handler forwarding을 동작으로 세는 규칙과 최종 소비 라우트 기준의 공용 배치 규칙을 명시했습니다.
- atoms, molecules, organisms, templates 문서를 PR1~3 이후 실제 파일과 소비처 기준으로 전면 교체했습니다.
- UI 티어 문서의 Gotchas와 stale 사례, template grandfather clause를 삭제했습니다.
- #190 인벤토리에 포함됐지만 실행 단계에서 누락된 page-access-control.md의 Gotchas도 삭제해 src와 docs 전체의 Gotchas 섹션을 0건으로 만들었습니다.

## 문서 구조

- 공통 판정은 조건표와 적용 순서로 중앙화했습니다.
- 각 티어 문서는 고유 기준, 현재 실측 예시, 구조, 필수 규칙만 유지했습니다.
- 존재하지 않는 컴포넌트와 과거 라우트 이름을 예시에서 제거했습니다.

## 검증

- src와 docs 전체에서 Gotchas 섹션 0건 확인
- stale 이름과 삭제된 컴포넌트 참조 부재 확인
- 문서에 든 현재 예시 파일과 terms/privacy 소비처 존재 확인
- 대상 문서 Prettier 검사 통과
- git diff --cached --check 통과
- 문서 전용 변경으로 코드 테스트 미실행

Closes #169
Related to #190