### PR TITLE
refactor(ui): 이미지 로더를 전역 설정으로 이관한다

### DIFF
--- a/image-loader.ts
+++ b/image-loader.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import type { ImageLoaderProps } from "next/image";
+
+export default function imageLoader({ src, width, quality }: ImageLoaderProps) {
+  if (!src.includes("res.cloudinary.com")) {
+    return src;
+  }
+
+  const params = [`f_auto`, quality ? `q_${quality}` : `q_auto`, `w_${width}`];
+
+  return src.replace("/upload/", `/upload/${params.join(",")}/`);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,8 @@ module.exports = () => {
    */
   const nextConfig: NextConfig = {
     images: {
+      loader: "custom",
+      loaderFile: "./image-loader.ts",
       remotePatterns: [
         {
           protocol: "https",

--- a/src/ui/components/atoms/app-image.tsx
+++ b/src/ui/components/atoms/app-image.tsx
@@ -2,18 +2,9 @@
 
 import { cn } from "@/core/utils";
 import { ImageOff } from "lucide-react";
-import type { ImageLoaderProps, StaticImageData } from "next/image";
+import type { StaticImageData } from "next/image";
 import Image from "next/image";
 import { useState } from "react";
-
-const cloudinaryLoader = ({ src, width, quality }: ImageLoaderProps) => {
-  if (typeof src !== "string" || !src.includes("res.cloudinary.com")) {
-    return src;
-  }
-  const params = [`f_auto`, quality ? `q_${quality}` : `q_auto`, `w_${width}`];
-
-  return src.replace("/upload/", `/upload/${params.join(",")}/`);
-};
 
 interface AppImageProps {
   src: string | StaticImageData;
@@ -54,7 +45,6 @@ const AppImage = ({
 
   return (
     <Image
-      loader={cloudinaryLoader}
       src={src}
       sizes={sizes}
       fill


### PR DESCRIPTION
## 변경 내용

- Cloudinary 변환 로더를 루트 `image-loader.ts`로 분리하고 Next.js 전역 `images.loaderFile`로 연결했습니다.
- `AppImage`에서 함수형 `loader` prop 전달을 제거했습니다.
- Cloudinary가 아닌 로컬 이미지 경로는 기존처럼 그대로 반환합니다.

## Client Component 판정

`AppImage`는 로드 실패 fallback을 위한 `useState`와 `onError`를 사용하므로 `"use client"`를 유지합니다. 이를 제거하려면 현재 fallback 동작을 바꾸는 별도 결정이 필요합니다. 전역 로더 파일의 Client 경계도 Next.js 16 문서 지침에 따라 유지했습니다.

## 검증

- AppImage 컴포넌트 테스트 4건 통과
- 변경 파일 ESLint 통과
- TypeScript 검사 통과
- Next.js 프로덕션 빌드 통과

Closes #189