### PR TITLE
refactor(app): page.tsx의 배치 코드를 Template으로 추출한다

### DIFF
--- a/src/app/(admin)/admin/premium-features/_components/PremiumFeaturesTemplate.tsx
+++ b/src/app/(admin)/admin/premium-features/_components/PremiumFeaturesTemplate.tsx
@@ -1,0 +1,69 @@
+import type { PremiumFeature } from "@/core/domain";
+import {
+  Badge,
+  Card,
+  CardContent,
+  TypographyH1,
+  TypographyH3,
+  TypographyLarge,
+  TypographyMuted,
+} from "@/ui/components/atoms";
+
+import { PremiumFeatureCardAction } from "./PremiumFeatureCardAction";
+
+interface PremiumFeaturesTemplateProps {
+  features: PremiumFeature[];
+}
+
+const PremiumFeaturesTemplate = ({
+  features,
+}: PremiumFeaturesTemplateProps) => (
+  <div className="space-y-6">
+    <div className="flex items-center justify-between">
+      <div>
+        <TypographyH1 className="mb-2 text-left text-3xl font-bold">
+          프리미엄 기능 관리
+        </TypographyH1>
+        <TypographyMuted>
+          상품에 추가할 수 있는 유료 기능을 관리합니다.
+        </TypographyMuted>
+      </div>
+    </div>
+
+    <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {features.map((feature) => (
+        <Card key={feature.code}>
+          <CardContent className="space-y-4 p-6">
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <div className="mb-2 flex items-center gap-2">
+                  <TypographyH3 className="text-foreground text-lg font-semibold">
+                    {feature.label}
+                  </TypographyH3>
+                  <Badge variant="outline" className="text-xs">
+                    {feature.code}
+                  </Badge>
+                </div>
+                <TypographyMuted>{feature.description}</TypographyMuted>
+              </div>
+            </div>
+
+            <div className="border-border flex items-center justify-between border-t pt-4">
+              <div>
+                <TypographyMuted className="mb-1">추가 비용</TypographyMuted>
+                <TypographyLarge className="text-primary font-bold">
+                  +{feature.additionalPrice.toLocaleString()}원
+                </TypographyLarge>
+              </div>
+              <div className="flex gap-2">
+                <PremiumFeatureCardAction premiumFeature={feature} />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </section>
+  </div>
+);
+
+export { PremiumFeaturesTemplate };

--- a/src/app/(admin)/admin/premium-features/_components/index.tsx
+++ b/src/app/(admin)/admin/premium-features/_components/index.tsx
@@ -1,1 +1,2 @@
 export { PremiumFeatureCardAction } from "./PremiumFeatureCardAction";
+export { PremiumFeaturesTemplate } from "./PremiumFeaturesTemplate";

--- a/src/app/(admin)/admin/premium-features/new/_components/NewPremiumFeatureTemplate.tsx
+++ b/src/app/(admin)/admin/premium-features/new/_components/NewPremiumFeatureTemplate.tsx
@@ -1,0 +1,49 @@
+import { routes } from "@/core/domain";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  TypographyH1,
+  TypographyMuted,
+} from "@/ui/components/atoms";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+import { PremiumFeatureRegistrationForm } from "../_containers";
+
+const NewPremiumFeatureTemplate = () => (
+  <div className="space-y-6">
+    <div className="flex items-center gap-4">
+      <Link href={routes.admin.premiumFeatures.root}>
+        <Button variant="ghost" size="icon">
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+      </Link>
+      <div>
+        <TypographyH1 className="mb-2 text-left text-3xl font-bold">
+          프리미엄 기능 등록
+        </TypographyH1>
+        <TypographyMuted>
+          상품에 추가할 수 있는 새로운 유료 기능을 등록합니다.
+        </TypographyMuted>
+      </div>
+    </div>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>기능 정보</CardTitle>
+        <CardDescription>
+          프리미엄 기능의 기본 정보를 입력해주세요.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <PremiumFeatureRegistrationForm />
+      </CardContent>
+    </Card>
+  </div>
+);
+
+export { NewPremiumFeatureTemplate };

--- a/src/app/(admin)/admin/premium-features/new/_components/index.tsx
+++ b/src/app/(admin)/admin/premium-features/new/_components/index.tsx
@@ -1,0 +1,1 @@
+export { NewPremiumFeatureTemplate } from "./NewPremiumFeatureTemplate";

--- a/src/app/(admin)/admin/premium-features/new/page.tsx
+++ b/src/app/(admin)/admin/premium-features/new/page.tsx
@@ -1,44 +1,10 @@
 export const dynamic = "force-dynamic";
 
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
-import { routes } from "@/core/domain";
-import { PremiumFeatureRegistrationForm } from "./_containers";
-import { Button, TypographyH1, TypographyMuted, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/components/atoms";
 import { verifySession } from "@/services";
+import { NewPremiumFeatureTemplate } from "./_components";
 
 export default async function NewPremiumFeaturePage() {
   await verifySession("ADMIN");
 
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <Link href={routes.admin.premiumFeatures.root}>
-          <Button variant="ghost" size="icon">
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-        </Link>
-        <div>
-          <TypographyH1 className="text-left mb-2 text-3xl font-bold">
-            프리미엄 기능 등록
-          </TypographyH1>
-          <TypographyMuted>
-            상품에 추가할 수 있는 새로운 유료 기능을 등록합니다.
-          </TypographyMuted>
-        </div>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>기능 정보</CardTitle>
-          <CardDescription>
-            프리미엄 기능의 기본 정보를 입력해주세요.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <PremiumFeatureRegistrationForm />
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <NewPremiumFeatureTemplate />;
 }

--- a/src/app/(admin)/admin/premium-features/page.tsx
+++ b/src/app/(admin)/admin/premium-features/page.tsx
@@ -1,59 +1,12 @@
 export const dynamic = "force-dynamic";
 
-import { Badge, Card, CardContent, TypographyH1, TypographyH3, TypographyLarge, TypographyMuted } from "@/ui/components/atoms";
-
-import { PremiumFeatureCardAction } from "./_components";
+import { PremiumFeaturesTemplate } from "./_components";
 import { getAllPremiumFeatureService, verifySession } from "@/services";
+
 export default async function PremiumFeaturesPage() {
   await verifySession("ADMIN");
 
   const features = await getAllPremiumFeatureService();
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <TypographyH1 className="mb-2 text-left text-3xl font-bold">
-            프리미엄 기능 관리
-          </TypographyH1>
-          <TypographyMuted>
-            상품에 추가할 수 있는 유료 기능을 관리합니다.
-          </TypographyMuted>
-        </div>
-      </div>
 
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {features.map((feature) => (
-          <Card key={feature.code}>
-            <CardContent className="space-y-4 p-6">
-              <div className="flex items-start justify-between">
-                <div className="flex-1">
-                  <div className="mb-2 flex items-center gap-2">
-                    <TypographyH3 className="text-foreground text-lg font-semibold">
-                      {feature.label}
-                    </TypographyH3>
-                    <Badge variant="outline" className="text-xs">
-                      {feature.code}
-                    </Badge>
-                  </div>
-                  <TypographyMuted>{feature.description}</TypographyMuted>
-                </div>
-              </div>
-
-              <div className="border-border flex items-center justify-between border-t pt-4">
-                <div>
-                  <TypographyMuted className="mb-1">추가 비용</TypographyMuted>
-                  <TypographyLarge className="text-primary font-bold">
-                    +{feature.additionalPrice.toLocaleString()}원
-                  </TypographyLarge>
-                </div>
-                <div className="flex gap-2">
-                  <PremiumFeatureCardAction premiumFeature={feature} />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </section>
-    </div>
-  );
+  return <PremiumFeaturesTemplate features={features} />;
 }

--- a/src/app/(admin)/admin/products/new/_components/NewProductTemplate.tsx
+++ b/src/app/(admin)/admin/products/new/_components/NewProductTemplate.tsx
@@ -1,0 +1,33 @@
+import type { PremiumFeature } from "@/core/domain";
+import { routes } from "@/core/domain";
+import { Button, TypographyH1, TypographyMuted } from "@/ui/components/atoms";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+import { ProductRegistrationForm } from "../_containers";
+
+interface NewProductTemplateProps {
+  premiumFeatures: PremiumFeature[];
+}
+
+const NewProductTemplate = ({ premiumFeatures }: NewProductTemplateProps) => (
+  <div className="space-y-6">
+    <div className="flex items-center gap-4">
+      <Link href={routes.admin.products.root}>
+        <Button variant="ghost" size="icon">
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+      </Link>
+      <div>
+        <TypographyH1 className="mb-2 text-left text-3xl font-bold">
+          상품 등록
+        </TypographyH1>
+        <TypographyMuted>새로운 템플릿 상품을 등록합니다.</TypographyMuted>
+      </div>
+    </div>
+
+    <ProductRegistrationForm premiumFeatures={premiumFeatures} />
+  </div>
+);
+
+export { NewProductTemplate };

--- a/src/app/(admin)/admin/products/new/_components/index.tsx
+++ b/src/app/(admin)/admin/products/new/_components/index.tsx
@@ -1,0 +1,1 @@
+export { NewProductTemplate } from "./NewProductTemplate";

--- a/src/app/(admin)/admin/products/new/page.tsx
+++ b/src/app/(admin)/admin/products/new/page.tsx
@@ -1,34 +1,12 @@
 export const dynamic = "force-dynamic";
 
 import { getAllPremiumFeatureService, verifySession } from "@/services";
-import { Button, TypographyH1, TypographyMuted } from "@/ui/components/atoms";
-import { ProductRegistrationForm } from "./_containers";
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
-import { routes } from "@/core/domain";
+import { NewProductTemplate } from "./_components";
 
 export default async function NewProductPage() {
   await verifySession("ADMIN");
 
   const premiumFeatures = await getAllPremiumFeatureService();
 
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <Link href={routes.admin.products.root}>
-          <Button variant="ghost" size="icon">
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-        </Link>
-        <div>
-          <TypographyH1 className="text-left mb-2 text-3xl font-bold">상품 등록</TypographyH1>
-          <TypographyMuted>
-            새로운 템플릿 상품을 등록합니다.
-          </TypographyMuted>
-        </div>
-      </div>
-
-      <ProductRegistrationForm premiumFeatures={premiumFeatures} />
-    </div>
-  );
+  return <NewProductTemplate premiumFeatures={premiumFeatures} />;
 }

--- a/src/app/(main)/(products)/products/[category]/_components/ProductCatalogTemplate.tsx
+++ b/src/app/(main)/(products)/products/[category]/_components/ProductCatalogTemplate.tsx
@@ -1,0 +1,40 @@
+import type { Product, ProductCategory, SubCategory } from "@/core/domain";
+import { TypographyH1, TypographyMuted } from "@/ui/components/atoms";
+
+import { ProductCatalog } from "../_containers";
+
+interface ProductCatalogTemplateProps {
+  products: Product[];
+  category: ProductCategory;
+  categoryLabel: string;
+  initialSubCategory: SubCategory | "all";
+}
+
+const ProductCatalogTemplate = ({
+  products,
+  category,
+  categoryLabel,
+  initialSubCategory,
+}: ProductCatalogTemplateProps) => (
+  <main className="bg-background min-h-screen">
+    <div className="container mx-auto px-4 pt-24 pb-16">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-12 text-center">
+          <TypographyH1 className="mb-4 text-4xl font-bold text-balance md:text-5xl">
+            {categoryLabel}
+          </TypographyH1>
+          <TypographyMuted>
+            당신의 스타일에 맞는 완벽한 {categoryLabel} 상품을 찾아보세요
+          </TypographyMuted>
+        </div>
+        <ProductCatalog
+          products={products}
+          category={category}
+          initialSubCategory={initialSubCategory}
+        />
+      </div>
+    </div>
+  </main>
+);
+
+export { ProductCatalogTemplate };

--- a/src/app/(main)/(products)/products/[category]/_components/index.tsx
+++ b/src/app/(main)/(products)/products/[category]/_components/index.tsx
@@ -1,1 +1,2 @@
 export { ProductCatalog } from "./ProductCatalog";
+export { ProductCatalogTemplate } from "./ProductCatalogTemplate";

--- a/src/app/(main)/(products)/products/[category]/page.tsx
+++ b/src/app/(main)/(products)/products/[category]/page.tsx
@@ -1,7 +1,6 @@
 export const dynamic = "force-dynamic";
 
-import { TypographyH1, TypographyMuted } from "@/ui/components/atoms";
-import { ProductCatalog } from "./_containers";
+import { ProductCatalogTemplate } from "./_components";
 import { getPublicProductsService } from "@/services";
 import { getAvailableSubCategories, isProductCategory } from "@/core/utils";
 import { productCategoryLabels } from "@/core/domain";
@@ -33,27 +32,11 @@ export default async function ProductsPage({
   const currentCategoryLabel = productCategoryLabels[category];
 
   return (
-    <main className="bg-background min-h-screen">
-      {/* <Header /> */}
-      <div className="container mx-auto px-4 pt-24 pb-16">
-        <div className="mx-auto max-w-7xl">
-          {/* Page Header */}
-          <div className="mb-12 text-center">
-            <TypographyH1 className="mb-4 text-4xl font-bold text-balance md:text-5xl">
-              {currentCategoryLabel}
-            </TypographyH1>
-            <TypographyMuted>
-              당신의 스타일에 맞는 완벽한 {currentCategoryLabel} 상품을
-              찾아보세요
-            </TypographyMuted>
-          </div>
-          <ProductCatalog
-            products={products}
-            category={category}
-            initialSubCategory={initialSubCategory}
-          />
-        </div>
-      </div>
-    </main>
+    <ProductCatalogTemplate
+      products={products}
+      category={category}
+      categoryLabel={currentCategoryLabel}
+      initialSubCategory={initialSubCategory}
+    />
   );
 }


### PR DESCRIPTION
## 변경 내용

| 라우트 | 추출한 Template | page.tsx className |
|---|---|---:|
| `/admin/premium-features` | `PremiumFeaturesTemplate` | 14 → 0 |
| `/products/[category]` | `ProductCatalogTemplate` | 5 → 0 |
| `/admin/premium-features/new` | `NewPremiumFeatureTemplate` | 4 → 0 |
| `/admin/products/new` | `NewProductTemplate` | 4 → 0 |

각 Template은 해당 라우트의 `_components/`에 두고 배럴로 노출했습니다. 인가, 데이터 조회, 파라미터 검증과 404 판정은 Server Component인 `page.tsx`에 유지하고, 페이지 몸통 배치만 Template에 위임합니다.

## 검증

- 착수 전 이슈의 2026-08-31 줄 수와 className 수치 재확인
- 변경 파일 ESLint 통과
- 관련 컴포넌트 테스트 5파일, 30건 통과
- TypeScript 검사 통과
- Next.js 프로덕션 빌드 통과

Closes #188