### PR TITLE
docs: loading.tsx 문서화와 컨테이너/템플릿 규칙을 정리한다

### DIFF
--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -6,17 +6,13 @@ Next.js App Router 진입점 — 공유 `layout.tsx`/독립 `error.tsx` 근거�
 
 ## Key Files
 
-| File               | Purpose                                                                                                                             |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `global-error.tsx` | root layout이 렌더 중 던지는 에러의 마지막 안전망 — `error.tsx`는 route segment 하위만 커버해서 root layout(`layout.tsx`) 자체 에러는 못 잡는다. 없이 배포하지 않는다(필수). |
+`global-error.tsx` — root layout이 렌더 중 던지는 에러의 마지막 안전망이다. `error.tsx`는 route segment 하위만 커버해서 root layout(`layout.tsx`) 자체 에러는 못 잡는다. 없이 배포하지 않는다(필수).
 
 root layout을 통째로 대체하기 때문에 생기는 제약:
 
-| 제약              | 내용                                                                                                                                                                                                                                               |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Provider 소멸     | root layout 자체엔 provider가 없지만 `(main)/layout.tsx`의 Provider/Toaster까지 같이 사라진다 — 렌더하는 컴포넌트는 provider 없이도 동작하는 self-contained 컴포넌트여야 한다(예: `organisms/ErrorFallback.tsx` — atoms만 조합, context 의존 없음) |
-| CSS 재import 필요 | root layout이 담당하던 `globals.css` import도 같이 대체된다 — `global-error.tsx` 안에서 별도로 다시 import하지 않으면 스타일이 안 먹는다                                                                                                           |
-| metadata 미지원   | `metadata`/`generateMetadata` export가 안 먹힌다 — Client Component 강제라서다, 필요하면 React `<title>` 컴포넌트로 대체한다(공식문서)                                                                                                             |
+- **Provider 소멸**: root layout 자체엔 provider가 없지만 `(main)/layout.tsx`의 Provider/Toaster까지 같이 사라진다 — 렌더하는 컴포넌트는 provider 없이도 동작하는 self-contained 컴포넌트여야 한다(예: `organisms/ErrorFallback.tsx` — atoms만 조합, context 의존 없음).
+- **CSS 재import 필요**: root layout이 담당하던 `globals.css` import도 같이 대체된다 — `global-error.tsx` 안에서 별도로 다시 import하지 않으면 스타일이 안 먹는다.
+- **metadata 미지원**: `metadata`/`generateMetadata` export가 안 먹힌다 — Client Component 강제라서다, 필요하면 React `<title>` 컴포넌트로 대체한다(공식문서).
 
 ## 라우트 그룹 구성
 
@@ -32,14 +28,21 @@ root layout을 통째로 대체하기 때문에 생기는 제약:
   │   ├── index.tsx         # 배럴
   │   ├── BuyerInfoCard.tsx
   │   ├── TermsAgreementCard.tsx
-  │   └── CheckoutSubmitBar.tsx
+  │   ├── CheckoutSubmitBar.tsx
+  │   └── ...               # 라우트 전용 서브 UI가 늘어날 때마다 추가
   ├── _containers/          # 라우트 전용 client 도메인 로직 + 순수 UI 조립
+  │   └── {Name}Container.tsx
   ├── _types/               # 라우트 전용 타입/interface
   ├── _utils/               # 라우트 전용 순수함수
   ├── _constants/           # 라우트 전용 상수
   └── _hooks/               # 라우트 전용 훅
   ```
-- 라우트 전용 client 컴포넌트가 다음 중 하나라도 포함하면 `_components/`가 아니라 동급의 `_containers/{Name}.tsx`에 둔다: `useSWR`/`useSWRInfinite` + `fetcher` 데이터 페칭, `useActionState` 또는 `startTransition(() => action(...))` Server Action 결합, zustand 스토어 결과로 `toast`/`router.replace` 등을 실행하는 도메인 상태 파생 + side effect.
+- 라우트 전용 client 컴포넌트가 다음 중 하나라도 포함하면 `_components/`가 아니라 동급의 `_containers/{Name}.tsx`에 둔다:
+  - `useSWR`/`useSWRInfinite` + `fetcher` 데이터 페칭
+  - `useActionState` 또는 `startTransition(() => action(...))` Server Action 결합
+  - zustand 스토어 결과로 `toast`/`router.replace` 등을 실행하는 도메인 상태 파생 + side effect
+  - 자기 데이터를 직접 fetch하는 self-fetching Server Component(Suspense 스트리밍용) — client 여부와 무관하게 동일하게 `_containers/`에 둔다, 데이터 소유 여부가 기준이지 client/server가 기준이 아니다
+- self-fetching Server Component 컨테이너는 `page.tsx`와 동일하게 얇게 유지한다 — organism을 배치(grid/flex/spacing, 목록 매핑 등)하는 코드가 하나라도 있으면 그 부분을 별도 순수 컴포넌트(`_components/` 또는 공용 티어)로 추출한다. 위임 하나(`return <XGrid data={data} />` 형태)만 남기면 렌더 없이 직접 호출 + 반환 타입·props 확인만으로 검증 가능해진다 — 안에서 직접 조립하면 page.tsx가 겪던 Unit/Component/Integration 3갈래 애매함이 그대로 재발한다. client 훅 기반 컨테이너(`useSWR` 등)는 이 규칙 대상이 아니다 — Rules of Hooks상 애초에 렌더 없이 호출할 수 없어 조립 코드 유무와 무관하게 항상 Component다.
 - 로컬 UI 상태(`useState` open/close, controlled input), 서버와 무관한 client 계산/타이머(`useMemo`, `setInterval` 기반 훅), mutation 없는 단순 페이지 이동(`<Link>`, `Button asChild`)만 다루면 컨테이너가 아니므로 `_components/`에 둔다.
 - 2개 이상 라우트가 공유하는 순수함수/UI/훅/타입/상수를 라우트 폴더 안에 남겨두지 않는다 — 순수함수는 `src/core/utils/`, UI는 `src/ui/components/`, 훅은 `src/ui/hooks/`, 타입은 `src/core/types/`, 상수는 `src/core/constants/`로 승격한다(각 폴더 AGENTS.md 참고).
 
@@ -51,10 +54,12 @@ root layout을 통째로 대체하기 때문에 생기는 제약:
   - 여러 layout이 겹치는 셸 조각(예: `SidebarLayout`이 admin/my-order/my-profile 3곳에서 쓰이던 것)은 공용 컴포넌트로 승격하지 않고 각 `layout.tsx`가 직접 정의한다 — 지금은 내용이 같아 보여도 각 레이어가 독립적으로 진화할 수 있어서다.
 - 루트 `app/layout.tsx`만 metadata(SEO/OG/Twitter)·전역 CSS import·환경변수 검증을 담당한다 — 하위 `layout.tsx`에서 이걸 중복 정의하지 않는다.
 - `error.tsx`와 `not-found.tsx`를 혼용하지 않는다 — `error.tsx`는 fetch 실패/예외 경계, `not-found.tsx`는 존재하지 않는 리소스 전용이다. 현재는 라우트 개별이 아니라 **라우트 그룹 단위**로 배치돼있다(`(main)/error.tsx`, `(main)/(products)/error.tsx`, `(admin)/error.tsx`, 루트 `not-found.tsx`) — 그룹 내 여러 라우트가 에러 경계를 공유해도 되면 그룹 레벨, 특정 라우트만 다른 처리가 필요하면 그 라우트에 개별 배치한다.
+- `loading.tsx`는 그 세그먼트의 `page.tsx` + 중첩 `layout.tsx` + `not-found.tsx`를 Suspense로 감싸는 fallback UI다 — 같은 세그먼트의 `layout.tsx`/`template.tsx`/`error.tsx`는 감싸지 않는다(공식문서: layout이 `cookies()`/`headers()` 같은 uncached 데이터를 쓰면 그 부분엔 fallback이 안 먹고 layout 렌더가 끝날 때까지 네비게이션이 블록된다). params를 받지 않아 데이터 의존 분기가 구조적으로 불가능하다 — 순수 정적 skeleton/spinner만 둔다. 실제로 스트리밍이 필요한 세그먼트에만 개별 배치한다(`error.tsx`처럼 그룹 단위로 묶지 않는다) — 현재 `(my-order)/my-orders/`, `(products)/products/[category]/`.
 - `page.tsx`에 interface/순수함수/상수/서브 UI 컴포넌트/컨테이너/훅을 인라인으로 쌓지 않는다 — `_components`/`_containers`/`_types`/`_utils`/`_constants`/`_hooks`로 분리한다(새 라우트부터 적용, Gotchas 참고).
-- **`page.tsx`는 Pages 단계만 담당한다** — 실제 데이터를 fetch/조립해서 Template(`src/ui/components/templates/{Name}Template.tsx` 또는 그 라우트 `_components/{Name}Template.tsx`)에 props로 넘기는 것까지만 한다. organism을 배치(grid/flex/spacing 등)하는 코드가 하나라도 있으면 Template 추출이 필수다 — organism 딱 1개를 배치 코드 없이 그대로 렌더하는 경우에 한해서만 `page.tsx`가 직접 렌더할 수 있다. Template은 `layout.tsx`(라우트 그룹 셸)와 다른 층위다 — Template은 항상 그 layout.tsx 안에 중첩된다. (Template 자격 조건 자체 — 순수성, self-fetching 자식 있을 때 opt-out 등 — 은 `src/ui/components/templates/AGENTS.md` 소관.)
+- **`page.tsx`는 Pages 단계만 담당한다** — 실제 데이터를 fetch/조립해서 Template(`src/ui/components/templates/{Name}Template.tsx` 또는 그 라우트 `_components/{Name}Template.tsx`)에 props로 넘기는 것까지만 한다. organism을 배치(grid/flex/spacing 등)하는 코드가 하나라도 있으면 Template 추출이 필수다 — organism 딱 1개를 배치 코드 없이 그대로 렌더하는 경우에 한해서만 `page.tsx`가 직접 렌더할 수 있다. Template은 `layout.tsx`(라우트 그룹 셸)와 다른 층위다 — Template은 항상 그 layout.tsx 안에 중첩된다. (Template 자격 조건 자체 — 순수성 등 — 은 `src/ui/components/templates/AGENTS.md` 소관.)
+- self-fetching 자식(자기 데이터를 직접 fetch하는 Server Component, Suspense 스트리밍)이 필요해도 Template 순수성 규칙에 예외를 두지 않는다 — 그 자식은 `_containers/`에 두고, Template은 `children: ReactNode` prop으로만 받아 배치한다(`<Template ...><ReviewsContainer productId={id} /></Template>`). Template은 `children`이 뭘 하는지 모른 채 자리만 내주므로 데이터 페칭·도메인 로직을 여전히 두지 않는 것과 같다.
 - `_components`/`_containers`/`_types`/`_utils`/`_constants`/`_hooks`를 폴더 + `index.ts`(컴포넌트는 `index.tsx`) 배럴 형태 외의 방식으로 만들지 않는다 — 폴더 안 파일이 1개뿐이어도 예외 없이 이 형태를 유지한다. **배럴은 `page.tsx`/`layout.tsx`가 직접 소비하는 파일만 재export하면 된다** — 같은 폴더 안 다른 파일에서만 내부적으로 쓰이고 `page.tsx`/`layout.tsx`가 직접 import 안 하는 파일(예: `_components/Navigation.tsx`가 `_components/LocationSection.tsx` 내부에서만 쓰이는 경우)은 배럴에 안 올려도 된다 — 배럴 목적이 "그 라우트 밖에서 이 폴더에 뭐가 있는지 알려주는 것"이지 폴더 안 모든 파일을 강제로 노출하는 게 아니다.
-- **`page.tsx`/`layout.tsx`/`error.tsx`/`not-found.tsx`/`proxy.ts`는 `export default`를 쓴다** — Next.js가 강제하는 파일 컨벤션이다.
+- **`page.tsx`/`layout.tsx`/`loading.tsx`/`error.tsx`/`not-found.tsx`/`proxy.ts`는 `export default`를 쓴다** — Next.js가 강제하는 파일 컨벤션이다.
 
 ## References
 

--- a/src/ui/components/molecules/AGENTS.md
+++ b/src/ui/components/molecules/AGENTS.md
@@ -26,7 +26,8 @@ src/ui/components/molecules/
 ├── AutoCompleteList.tsx
 ├── BaseSelect.tsx
 ├── CursorPagination.tsx
-└── ProductCard.tsx
+├── ProductCard.tsx
+└── ...              # 축 A/B 판정마다 추가되는 molecule
 ```
 
 ## Critical Convention

--- a/src/ui/components/templates/AGENTS.md
+++ b/src/ui/components/templates/AGENTS.md
@@ -17,7 +17,8 @@
 ```text
 src/ui/components/templates/
 ├── index.ts
-└── LegalDocumentTemplate.tsx
+├── LegalDocumentTemplate.tsx
+└── ...                        # {Name}Template.tsx — 페이지 몸통 전체를 공유하는 라우트가 2곳 이상일 때 추가
 ```
 
 ## Critical Convention


### PR DESCRIPTION
## Summary

- `src/app/AGENTS.md`에 `loading.tsx` 규칙을 신설한다(Suspense가 감싸는 범위, params 없어 데이터 의존 분기 불가, 세그먼트별 개별 배치).
- 존재하지 않는 "Template self-fetching opt-out" 참조를 제거하고, self-fetching Server Component는 `_containers/`에 두고 Template엔 `children` prop으로만 조립하는 구체 규칙으로 대체 — Template 순수성 규칙에 예외를 두지 않는다.
- self-fetching 컨테이너도 `page.tsx`처럼 배치 코드가 생기면 강제로 하위 컴포넌트로 추출하게 해, 테스트 스코프가 파일 위치만으로 판정되게 한다.
- `molecules/`, `templates/` Structure 트리에 `...` 성장 표시를 추가해 고정 목록처럼 안 보이게 한다.
- `format-fit` 기준으로 `src/app/AGENTS.md`의 1행 표·비교축 없는 표 2개를 산문/정의 목록으로 바꾼다.

## Test plan

- Not run: 문서만 수정, 별도 실행 없음.