### PR TITLE
docs(test): 테스트 컨벤션 분류 기준을 다듬는다

### DIFF
--- a/docs/__test/README.md
+++ b/docs/__test/README.md
@@ -6,12 +6,12 @@
 
 ## Key Files
 
-| File             | Test Type   | Tool                           | Purpose                                          |
-| ---------------- | ----------- | ------------------------------ | ------------------------------------------------ |
-| `unit.md`        | Unit        | Vitest                         | 개별 함수와 모듈의 behavior 검증                           |
-| `component.md`   | Component   | Vitest                         | React Component의 UI behavior와 사용자 interaction 검증 |
-| `integration.md` | Integration | Vitest + mongodb-memory-server | 여러 모듈과 실제 데이터 계층의 결합 검증                          |
-| `e2e.md`         | E2E         | Playwright                     | 실제 사용자 관점에서 애플리케이션 전체 흐름 검증                      |
+| File             | Test Type   | Tool                           | Purpose                                                  |
+| ---------------- | ----------- | ------------------------------ | -------------------------------------------------------- |
+| `unit.md`        | Unit        | Vitest                         | 제품 모듈을 직접 실행하고 collaborator를 격리해 검증     |
+| `component.md`   | Component   | Vitest + Testing Library       | React runtime의 UI·Hook behavior와 interaction 검증      |
+| `integration.md` | Integration | Vitest + mongodb-memory-server | Next.js 서버 코드와 실제 MongoDB 데이터 계층의 결합 검증 |
+| `e2e.md`         | E2E         | Playwright Test                | 실제 browser·server·DB를 통과하는 핵심 사용자 목표 검증  |
 
 ## Test Pyramid
 
@@ -54,10 +54,10 @@
 
 각 테스트 레이어는 자신의 책임을 넘어서 검증하지 않는다.
 
-* Unit → 개별 로직
-* Component → UI behavior
-* Integration → 모듈 간 결합
-* E2E → 사용자 시나리오
+- Unit → 제품 모듈을 직접 실행하고 외부 collaborator를 격리한 behavior
+- Component → React runtime에서 관찰하는 UI·Hook behavior
+- Integration → 제품 서버·데이터 코드 ↔ 실제 Mongoose ↔ 격리된 MongoDB의 계약
+- E2E → 실제 browser·app server·DB를 통과하는 핵심 사용자 목표
 
 ### 6. Arrange → Act → Assert
 
@@ -84,63 +84,59 @@ it("유효한 이메일이면 사용자를 생성한다");
 it("존재하지 않는 사용자를 조회하면 404를 반환한다");
 ```
 
-### 9. Test File Naming
+### 9. Test File Naming, Location, and Command
 
-테스트 타입은 파일명에 명시한다.
+파일명, 위치, 실행 명령은 이 문서에서 공통으로 관리한다.
 
-```text
-<target>.unit.test.ts
-<target>.component.test.tsx
-<target>.integration.test.ts
-<target>.e2e.spec.ts
-```
+| Test Type   | File Name                                                           | Location               | Command                    |
+| ----------- | ------------------------------------------------------------------- | ---------------------- | -------------------------- |
+| Unit        | `<target>.unit.test.ts`                                             | 대상 코드 옆 `src/`    | `npm run test:unit`        |
+| Component   | `<target>.component.test.ts` 또는 `<target>.component.test.tsx`     | UI 대상 코드 옆 `src/` | `npm run test:component`   |
+| Integration | `<target>.integration.test.ts` 또는 `<target>.integration.test.tsx` | `test/integration/`    | `npm run test:integration` |
+| E2E         | `<scenario>.spec.ts`                                                | `test/e2e/`            | `npm run test:e2e`         |
+
+위 표는 일반 4-Scope의 기본 명령을 정의한다. 실제 외부 서비스·Production build처럼 명시적으로
+분리한 opt-in contract와 smoke는 해당 개별 문서가 파일, config와 별도 명령을 정의하며 기본
+명령과 CI gate에 포함하지 않는다.
 
 Examples:
 
 ```text
-user.service.unit.test.ts
-UserForm.component.test.tsx
-user.repository.integration.test.ts
-signup.e2e.spec.ts
+calculate-price.unit.test.ts
+LoginForm.component.test.tsx
+order.integration.test.ts
+checkout.spec.ts
 ```
 
-### 10. Test Location
-
-Unit과 Component Test는 구현 코드와 함께 **co-location**한다.
-
-```text
-UserForm.tsx
-UserForm.component.test.tsx
-```
-
-Integration Test와 E2E Test는 별도의 테스트 영역에서 관리한다.
-
-```text
-tests/
-├── integration/
-└── e2e/
-```
+Vitest의 정확한 수집 범위와 실행 환경은 [`vitest.config.ts`](../../vitest.config.ts),
+공개 명령은 [`package.json`](../../package.json)에서 이 규칙과 일치하도록 관리한다.
+공용 setup, DB helper, factory는 `test/support/`에 두며 테스트 파일은 두지 않는다.
+하나의 테스트 파일에는 하나의 Test Type만 둔다. 같은 사용자 시나리오라도 Integration,
+Component, E2E의 관찰 대상은 각각의 파일에서 독립적으로 준비하고 검증한다.
 
 ## Choosing a Test Type
 
 새로운 테스트를 작성할 때는 가장 좁은 범위의 테스트 레이어를 우선 선택한다.
 
 ```text
-순수한 함수/비즈니스 로직인가?
+React rendering, 실제 DB와 network 없이 하나의 제품 모듈을 직접 검증하는가?
         ↓ Yes
        Unit
 
-UI behavior인가?
+React runtime과 jsdom이 필요한 UI·Hook behavior인가?
         ↓ Yes
     Component
 
-여러 실제 모듈의 결합을 검증하는가?
+제품 서버·데이터 코드가 실제 Mongoose와 격리된 MongoDB를 통과하며 경계의 계약을 검증하는가?
         ↓ Yes
    Integration
 
-사용자의 전체 흐름을 검증하는가?
+실제 browser·app server·DB를 통과해야 하는 핵심 사용자 목표인가?
         ↓ Yes
       E2E
 ```
+
+MongoDB를 실제로 사용한다는 사실만으로는 Integration이 되지 않는다. React 렌더링과
+사용자 관찰 결과는 Component, 실제 URL·네트워크·브라우저 흐름은 E2E로 분류한다.
 
 상위 레이어 테스트로 하위 레이어의 모든 behavior를 반복해서 검증하지 않는다.

--- a/docs/__test/component.md
+++ b/docs/__test/component.md
@@ -2,90 +2,78 @@
 
 ## Purpose
 
-Component Test는 React Component가 **사용자가 관찰할 수 있는 UI behavior와 interaction을 올바르게 수행하는지** 검증한다.
+Component Test는 React runtime에서 Component와 Hook이 **사용자가 관찰할 수 있는 UI
+behavior와 interaction을 올바르게 수행하는지** 검증한다. 구현 내부가 아니라 렌더링된
+DOM, React lifecycle과 사용자가 시작한 행동의 공개 효과를 관찰한다.
 
-구현 내부가 아니라 렌더링된 UI와 사용자 행동을 중심으로 테스트한다.
+파일명, 위치, 실행 명령, Arrange → Act → Assert와 공통 격리 원칙은
+[`README.md`](README.md)를 따른다.
 
 ## Scope
 
-Component Test는 다음을 대상으로 한다.
+Component Test는 Vitest의 jsdom 환경에서 실제 React runtime과 Testing Library를 사용한다.
+대상은 하나의 UI 진입점이며, 필요한 경우 여러 실제 하위 Component, Provider, Hook과 Store가
+함께 참여할 수 있다. Component 개수가 아니라 실행 환경과 관찰 경계로 분류한다.
 
-* Component rendering
-* User interaction
-* UI state
-* Form behavior
-* Validation
-* Conditional rendering
-* Loading / Error / Empty state
-* Accessibility behavior
-* Component 간 필요한 UI interaction
+주요 대상은 다음과 같다.
 
-## What to Test
+- React Component의 rendering과 conditional UI
+- 사용자 입력, 선택, 제출, keyboard와 upload interaction
+- loading, success, error와 empty state
+- form 제출, validation과 접근성 계약
+- React state, effect, rerender와 context에 의존하는 Hook
+- 실제 Hook → SWR → fetch → MSW client data flow
+- 여러 Component·Provider·Hook·Store가 참여하는 UI feature slice
+- Router, Server Action, clipboard와 browser adapter로 전달되는 공개 효과
 
-### Rendering
+모든 Component Test는 다음 조건을 충족해야 한다.
 
-필요한 콘텐츠가 화면에 표시되는지 검증한다.
+1. 실제 React runtime에서 Component를 `render`하거나 Hook을 `renderHook`으로 실행한다.
+2. 렌더링된 UI, React lifecycle 또는 사용자가 시작한 공식 경계 효과를 관찰한다.
+3. server·DB·외부 browser 경계는 fixture, MSW 또는 공식 API Mock으로 통제한다.
+4. 실제 browser layout, app server, URL navigation과 Production 외부 서비스를 실행하지 않는다.
 
-```ts
-expect(screen.getByRole("heading", { name: "사용자 정보" }))
-  .toBeInTheDocument();
-```
+파일명이나 `use*`라는 이름은 분류 근거가 아니다. state, effect, rerender, context와 SWR
+cache처럼 React lifecycle이 필요하면 Component다. React 없이 직접 호출할 수 있는 순수
+함수·reducer·Zustand store·mapper·validation은 Unit Test로 분리한다.
 
-### User Interaction
+Server Component와 Page는 server dependency를 fixture 또는 공식 경계 Mock으로 대체하고,
+반환 React tree를 Testing Library로 렌더링해 사용자가 보는 결과를 확인할 때 Component다.
+렌더링하지 않고 실제 MongoDB 결과가 반환 tree의 props에 전달되는지만 확인하면
+[Integration Test](integration.md)다. 렌더링도 실제 DB도 없이 Service 호출과 props 전달만
+확인하면 Unit 또는 server wiring 검증으로 분리한다.
 
-실제 사용자의 행동을 기준으로 테스트한다.
+실제 browser, app server와 DB까지 통과하는 핵심 사용자 목표는 E2E로 분리한다. 실제 DB 없이
+browser 호환성·layout·배포 asset만 확인하면 별도로 정의한 browser contract 또는 smoke가
+담당한다.
 
-```text
-사용자
-  ↓
-click / type / select
-  ↓
-Component
-  ↓
-UI 변화
-```
+## Environment
 
-### State Changes
+Component Test는 React, Vitest, jsdom, Testing Library, `user-event`와
+`@testing-library/jest-dom`을 사용한다. 공용 setup은 각 테스트 후 DOM을 cleanup하고 jsdom에
+없는 Pointer Events, Observer, `matchMedia`, `DataTransfer` 등의 최소 browser API를 보완한다.
 
-사용자 행동에 따라 UI가 올바르게 변경되는지 검증한다.
+polyfill과 Mock은 UI 로직의 입력을 제어하기 위한 수단이며 실제 browser 호환성을 증명하지
+않는다. Component Test는 Production secret, 실제 외부 API, Service, Mongoose와 MongoDB에
+의존하지 않아야 한다.
 
-```ts
-await user.click(screen.getByRole("button", { name: "저장" }));
+## Rendering Boundary
 
-expect(
-  screen.getByText("저장되었습니다")
-).toBeInTheDocument();
-```
+검증 대상 Component와 assertion이 관찰하는 하위 UI는 실제로 렌더링한다. loading, error,
+empty state처럼 입력 상태를 만들기 위해 custom Hook의 공식 반환 경계를 대체할 수 있지만,
+사용자가 보는 UI까지 stub으로 바꾸어서는 안 된다.
 
-## What Not to Test
+하위 Component를 stub으로 대체한 뒤 Hook 호출 인자나 props 전달만 확인하는 테스트는
+Component가 아니라 Unit 또는 wiring 검증이다. Hook → SWR → fetch 결합 자체가 대상이면
+Hook과 SWR을 Mock하지 않고 실제 구현과 MSW를 사용한다.
 
-Component Test에서는 다음을 직접 검증하지 않는다.
+하나의 UI 진입점 아래 여러 실제 Component, Provider, Hook과 Store를 함께 렌더링해도
+Component Scope를 유지한다. 각 Test File은 React runtime으로 관찰하는 하나의 Component
+또는 Hook behavior만 담당하며, 순수 로직 직접 호출을 함께 두지 않는다.
 
-* React 내부 state
-* private function
-* 특정 hook의 내부 구현
-* 특정 DOM 구조에 대한 불필요한 의존
-* CSS implementation
-* component 내부 함수 호출 횟수
+## User-Observable Results
 
-예:
-
-```ts
-// Avoid
-expect(component.state.isOpen).toBe(true);
-```
-
-대신 사용자에게 보이는 결과를 검증한다.
-
-```ts
-expect(screen.getByRole("dialog")).toBeVisible();
-```
-
-## User-Centric Queries
-
-가능하면 사용자가 UI를 인식하는 방식과 가까운 query를 우선한다.
-
-권장 우선순위:
+사용자가 직접 보는 content와 state를 우선 검증한다. 다음 query 순서를 기본으로 사용한다.
 
 ```text
 getByRole
@@ -99,132 +87,224 @@ getByText
 getByTestId
 ```
 
-`data-testid`는 다른 의미 있는 접근 방법이 없을 때 사용한다.
+`data-testid`는 의미 있는 role, label과 text가 없을 때만 사용한다. 사용자에게 직접 보이지
+않더라도 browser 제출·접근성·focus 계약에 속하는 hidden field, `FormData`, `aria-*`,
+disabled·checked·selected 상태는 공개 Component behavior다.
+
+특정 wrapper 계층, class 이름, 내부 element 순서와 대규모 snapshot은 behavior에 필수적이지
+않으면 검증하지 않는다. React 내부 state, private function과 Component 내부 함수 호출
+횟수도 직접 확인하지 않는다.
 
 ## User Interaction
 
-사용자 interaction은 실제 사용자 행동에 가깝게 작성한다.
+click, type, select, upload와 keyboard 같은 사용자 행동은 테스트마다 생성한 `userEvent`
+instance로 수행한다. `fireEvent`는 `userEvent`가 표현하지 못하는 low-level browser event가
+검증 대상일 때만 사용한다.
 
-```ts
-const user = userEvent.setup();
+`act`는 Observer callback, timer 진행과 외부 Store 갱신처럼 React 밖에서 발생한 상태 변화를
+전달할 때만 사용한다. Component의 event handler나 Mock에서 추출한 callback을 테스트가
+직접 호출해 UI 경로를 우회하지 않는다.
 
-await user.type(
-  screen.getByRole("textbox", { name: "이메일" }),
-  "user@example.com"
-);
+DOM 변화가 없더라도 렌더링된 UI에서 사용자가 시작한 행동이 `action`, `router.push`,
+clipboard 또는 browser adapter 호출로 이어진다면 공식 경계의 인자와 시점을 확인할 수 있다.
+렌더링 없이 호출하거나 내부 callback을 직접 실행한 결과는 Component behavior가 아니다.
 
-await user.click(
-  screen.getByRole("button", { name: "제출" })
-);
-```
+## Client Data Flow
 
-## Mocking
+client fetch 흐름이 대상이면 실제 Hook, SWR와 fetch를 유지하고 MSW가 HTTP 응답만 대체한다.
+실제 Route Handler, Service, Mongoose와 MongoDB는 실행하지 않는다. 각 테스트는 새로운 SWR
+provider와 cache를 사용하며 처리되지 않은 MSW 요청은 즉시 실패시킨다.
 
-Component Test에서는 Component의 외부 경계를 필요한 범위에서 Mock한다.
+일반적으로 요청 key·payload와 loading → success·error·empty의 사용자 상태를 확인한다.
+정확한 호출 횟수는 deduplication이나 revalidation 자체가 계약일 때만 검증한다. SWR 내부
+재검증 횟수에는 결합하지 않는다.
 
-예:
+optimistic UI가 있으면 실패 시 rollback을 확인한다. unmount, 검색어 변경과 중복 제출처럼
+이전 비동기 결과가 늦게 도착할 수 있는 흐름은 stale UI와 중복 side effect가 남지 않는지
+검증한다.
 
-```text
-Component
-   │
-   ├── Mock API
-   ├── Mock Router
-   └── Mock External Service
-```
+## External Boundaries and Mocking
 
-단순히 테스트를 쉽게 만들기 위해 Component 내부 behavior를 Mock하지 않는다.
+Server Action은 전달받은 action 함수 또는 공식 import 경계에서 대체하고 성공·실패 결과에
+따른 UI를 검증한다. Next Router, redirect, clipboard와 browser SDK처럼 jsdom에서 결과를
+직접 관찰할 수 없는 경계는 공식 API를 대체해 호출 인자와 시점을 확인할 수 있다.
 
-## Test Structure
+Cloudinary, PortOne, Kakao와 외부 HTTP API는 실제 호출하지 않는다. HTTP client flow에는
+MSW를 사용하고 browser SDK에는 adapter 경계 Mock을 사용한다. 단순히 테스트를 쉽게 만들기
+위해 검증 대상 Component·Hook의 behavior를 Mock하지 않는다.
 
-기본적으로 Arrange → Act → Assert를 따른다.
+Mock은 가능한 한 전체 모듈을 지우지 않고 실제 export를 유지한 채 필요한 공식 경계만
+대체한다. 테스트가 제외한 경계가 결과 이해에 중요하면 주석으로 대상과 이유를 명시한다.
 
-```ts
-it("유효한 이메일을 입력하면 제출 버튼을 활성화한다", async () => {
-  // Arrange
-  render(<SignupForm />);
+## Async Behavior and Time
 
-  // Act
-  await user.type(
-    screen.getByRole("textbox", { name: "이메일" }),
-    "user@example.com"
-  );
+비동기 DOM은 `findBy*`, 공식 경계 side effect는 `waitFor`로 기다린다. 임의의 sleep과 고정
+지연시간에 의존하지 않는다. loading 상태는 제어 가능한 Promise나 필요한 최소 MSW delay로
+만들고 네트워크 속도 우연에 맡기지 않는다.
 
-  // Assert
-  expect(
-    screen.getByRole("button", { name: "가입하기" })
-  ).toBeEnabled();
-});
-```
+실제 timer를 기본으로 사용한다. debounce와 timeout처럼 시간 자체가 검증 대상일 때만 fake
+timer를 사용하고 종료 전에 복구한다. fake timer와 `userEvent`를 함께 사용하면
+`userEvent.setup({ advanceTimers: vi.advanceTimersByTime })`처럼 timer 진행을 연결한다.
 
-## Naming
+## Browser Limitations
 
-파일명:
+jsdom에서는 DOM 의미, 접근 가능한 role·name, 입력·선택·focus 전이, 조건부 rendering과
+제어된 Observer callback을 검증한다.
 
-```text
-<target>.component.test.tsx
-```
+다음 behavior는 jsdom 결과를 실제 browser 증거로 사용하지 않는다.
 
-Examples:
+- 실제 layout, CSS와 반응형 배치
+- animation, scroll geometry와 portal 위치
+- 실제 browser navigation과 download
+- 결제 popup과 외부 SDK 호환성
+- hydration과 browser별 runtime 차이
 
-```text
-UserForm.component.test.tsx
-LoginForm.component.test.tsx
-UserList.component.test.tsx
-```
-
-테스트 이름은 사용자에게 나타나는 behavior를 설명한다.
-
-```ts
-it("잘못된 이메일을 입력하면 오류 메시지를 표시한다");
-```
+이 영역은 E2E 또는 별도로 정의한 opt-in browser smoke test가 담당한다.
 
 ## Test Data
 
-Component의 rendering에 필요한 최소한의 데이터를 사용한다.
+Component fixture는 client가 실제로 받는 DTO, props와 HTTP response 형태의 순수 객체다.
+Model, Mongoose, Service와 DB를 import하지 않는다. Integration이 만든 결과나 DB 상태를
+이어받지 않고 같은 시나리오를 독립 fixture 또는 factory로 다시 표현한다.
 
-복잡한 객체는 factory를 사용할 수 있다.
-
-```ts
-const user = createUserFixture({
-  name: "홍길동",
-});
-```
-
-불필요한 필드를 과도하게 구성하지 않는다.
+ID·날짜·상태는 결정적인 값으로 만들고 테스트가 변경할 수 있는 객체는 매번 새로 생성한다.
+기본 fixture는 유효한 최소 데이터를 제공하며 각 테스트는 behavior에 필요한 값만 override한다.
 
 ## Isolation and Cleanup
 
-각 테스트는 독립적으로 실행되어야 한다.
+각 테스트는 새로운 render를 사용하고, 사용자 interaction을 수행할 때마다 새로운
+`userEvent` instance를 생성한다. SWR은 테스트별 provider로 독립 cache를 제공하고, MSW
+handler는 각 테스트 후 reset한다. fixture 객체는 공유할 수 있지만 변경 가능한 runtime
+상태는 공유하지 않는다.
 
-* DOM 상태에 의존하지 않는다.
-* Mock 상태를 초기화한다.
-* Timer를 사용했다면 원래 상태로 복구한다.
-* 테스트 간 Component state를 공유하지 않는다.
+테스트가 변경한 Zustand Store, `localStorage`, `sessionStorage`, Mock, fake timer, portal DOM,
+`fetch`, Observer와 browser global은 종료 전에 초기 상태로 복구한다. DOM cleanup만으로
+client cache와 전역 Store가 초기화된다고 가정하지 않는다.
+
+예상하지 않은 React warning, `console.error`, unhandled Promise rejection과 MSW 미처리
+요청은 테스트 실패로 취급한다. Error Boundary처럼 오류 자체가 시나리오인 테스트만 출력을
+명시적으로 대체하고 내용까지 확인한 뒤 복구한다. warning을 숨기는 전역 Mock은 허용하지
+않는다.
+
+## What to Test
+
+- props와 fixture에 따른 rendering과 conditional UI
+- 사용자 interaction에 따른 UI와 접근성 상태 전이
+- form 입력·validation·제출과 공개 browser 계약
+- loading, success, error와 empty state
+- Hook의 state, effect, rerender, context와 cache behavior
+- 실제 Hook → SWR → fetch → MSW client data flow
+- Router, Action과 browser adapter로 전달되는 사용자 시작 효과
+- optimistic update, rollback과 stale response 경쟁 상태
+- 여러 실제 UI 모듈이 참여하는 feature slice
+
+## What Not to Test
+
+Component Test에서는 다음을 직접 또는 함께 검증하지 않는다.
+
+- React 없이 호출할 수 있는 순수 함수·reducer·Store·mapper
+- React 내부 state, private function과 내부 호출 횟수
+- stub UI의 props 전달만 확인하는 wiring
+- 직접 handler·내부 callback 호출로 우회한 결과
+- 특정 DOM wrapper, class 이름과 대규모 snapshot
+- 실제 Route Handler, Service, Mongoose와 MongoDB
+- 실제 Production API와 browser SDK
+- 실제 layout, CSS, navigation, hydration과 browser 호환성
 
 ## Examples
 
-### Good
+다음 예제는 실제 UI에서 사용자 행동을 시작하고 action prop이라는 공식 경계 효과를 확인한다.
 
-```ts
-it("삭제 버튼을 클릭하면 삭제 확인 메시지를 표시한다", async () => {
-  render(<UserList users={users} />);
+```tsx
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LoginForm } from "./LoginForm";
 
-  await user.click(
-    screen.getByRole("button", { name: "삭제" })
-  );
+describe("LoginForm", () => {
+  it("유효한 자격증명을 제출한다", async () => {
+    const action = vi.fn();
+    const user = userEvent.setup();
+    render(<LoginForm action={action} pending={false} />);
 
-  expect(
-    screen.getByRole("dialog", { name: "삭제 확인" })
-  ).toBeVisible();
+    await user.type(screen.getByLabelText("이메일"), "user@example.com");
+    await user.type(screen.getByLabelText("비밀번호"), "password1234");
+    await user.click(screen.getByRole("button", { name: "로그인" }));
+
+    expect(action).toHaveBeenCalledTimes(1);
+  });
 });
 ```
 
-### Bad
+다음 예제는 실제 Hook, SWR와 fetch를 유지하고 MSW가 HTTP 경계만 대체한다. 테스트마다
+새 cache를 사용하며 상대 URL을 테스트 origin으로 변환한 `fetch`도 종료 시 복구한다.
 
-```ts
-it("isOpen state가 true가 된다", () => {
-  // 내부 state 직접 검증
+```tsx
+import type { PropsWithChildren } from "react";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { SWRConfig } from "swr";
+import { useAuth } from "./useAuth";
+
+const session = {
+  role: "ADMIN" as const,
+  email: "admin@example.com",
+  userId: "user-1",
+};
+
+const server = setupServer(
+  http.get("http://localhost/api/auth/me", () =>
+    HttpResponse.json({ success: true, data: session }),
+  ),
+);
+const nativeFetch = globalThis.fetch;
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+  const interceptedFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const resolved =
+      typeof input === "string" && input.startsWith("/")
+        ? new URL(input, "http://localhost")
+        : input;
+    return interceptedFetch(resolved, init);
+  }) as typeof fetch;
+});
+
+afterEach(() => server.resetHandlers());
+
+afterAll(() => {
+  server.close();
+  globalThis.fetch = nativeFetch;
+});
+
+const wrapper = ({ children }: PropsWithChildren) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+    {children}
+  </SWRConfig>
+);
+
+describe("useAuth", () => {
+  it("HTTP 응답의 session을 노출한다", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.session).toEqual(session));
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("session이 없으면 null을 노출한다", async () => {
+    server.use(
+      http.get("http://localhost/api/auth/me", () =>
+        HttpResponse.json({ success: true, data: null }),
+      ),
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.session).toBeNull();
+  });
 });
 ```
-
-Component Test의 목적은 Component의 내부 구현이 아니라 **사용자가 경험하는 결과를 검증하는 것**이다.

--- a/docs/__test/e2e.md
+++ b/docs/__test/e2e.md
@@ -2,95 +2,160 @@
 
 ## Purpose
 
-E2E Test는 실제 사용자 관점에서 애플리케이션의 **완전한 사용자 시나리오가 정상적으로 동작하는지** 검증한다.
+E2E Test는 격리된 실제 browser에서 사용자가 애플리케이션의 URL을 열고 행동했을 때,
+Next.js server와 실제 데이터 계층을 통과한 **핵심 사용자 목표가 끝까지 달성되는지** 검증한다.
+이 프로젝트의 정식 E2E runner는 `@playwright/test`다.
 
-이 프로젝트에서는 Playwright를 사용한다.
+파일명, 위치, 실행 명령, Arrange → Act → Assert와 공통 격리 원칙은
+[`README.md`](README.md)를 따른다.
 
 ## Scope
 
-E2E Test는 다음을 검증한다.
-
-* 주요 사용자 journey
-* 페이지 이동
-* Form submission
-* Authentication flow
-* 핵심 CRUD flow
-* 주요 business workflow
-* Browser와 Server의 실제 결합
-* 사용자에게 중요한 Critical Path
-
-## Application Boundary
-
-E2E Test는 가능한 한 실제 애플리케이션에 가깝게 실행한다.
+일반 E2E는 Playwright Test가 격리된 Browser Context에서 실제 Next.js server의 URL을 열고,
+사용자 행동을 통해 제품의 내부 server·data 경계를 실제로 통과한다.
 
 ```text
-Playwright
-    ↓
-Browser
-    ↓
-Next.js
-    ↓
-API / Server
-    ↓
-Service
-    ↓
-Mongoose
-    ↓
-Test Database
+@playwright/test
+       ↓
+Desktop Chromium
+       ↓
+Next.js URL · routing · cookie
+       ↓
+Route Handler / Server Action / Server Component
+       ↓
+Service → Mongoose → E2E 전용 MongoDB
+       ↓
+사용자가 browser에서 다시 관찰하는 결과
 ```
 
-내부 함수를 직접 호출하지 않는다.
+모든 일반 E2E Test는 다음 조건을 충족해야 한다.
 
-## What to Test
+1. `@playwright/test`가 실제 browser와 격리된 Browser Context를 실행한다.
+2. 테스트 전용 환경에서 실제 Next.js server의 URL·routing·network를 통과한다.
+3. 검증 대상의 제품 경로가 실제 Service·Mongoose와 E2E 전용 MongoDB까지 이어진다.
+4. 사용자가 시작한 행동과 browser에서 관찰하는 결과를 검증한다.
+5. 앱 자체의 Route Handler·Server Action·Service와 business rule을 test double로 우회하지 않는다.
 
-E2E에서는 **비즈니스적으로 중요한 사용자 시나리오**를 우선한다.
+실제 browser만 실행한다는 사실만으로 일반 E2E가 되지는 않는다. 앱의 API를 `page.route`로
+대체해 UI만 검증하면 Component 또는 별도로 정의한 browser contract 범위다. 실제 DB 결과를
+React rendering 없이 확인하면 Integration이다. 외부 결제·메일·storage·지도는 제품의 공식
+adapter 또는 별도 local fake server에서 대체할 수 있다.
 
-예:
+E2E는 여러 화면을 무조건 길게 연결하는 테스트가 아니다. 하나의 테스트는 사용자가 달성하는
+하나의 의미 있는 목표와 그 목표에 필요한 최소 단계만 수행한다.
+
+## What Belongs in E2E
+
+브라우저·routing·인증 cookie·server entry와 DB가 함께 동작해야 신뢰할 수 있고, 실패 비용이
+큰 사용자 목표를 우선한다.
+
+- 실제 로그인과 권한별 접근·redirect
+- 관리자의 상품 등록·수정과 목록 재조회
+- 실제 browser file upload와 저장 결과
+- 주문 생성, 결제 redirect와 주문 내역 확인
+- 실제 URL navigation, popup와 download가 계약인 흐름
+- 데이터 손실, 권한 위반과 중복 결제처럼 치명적인 실패 경로
+- mobile 또는 특정 browser에서만 위험한 핵심 journey
+
+각 흐름의 대표 성공 경로와 치명적인 실패 경로만 E2E에 둔다. validation 조합, UI state,
+Service 오류 분기와 DB constraint의 전체 경우는 Unit·Component·Integration에서 검증하고
+E2E에서 반복하지 않는다.
+
+## Directory Structure
+
+E2E 파일은 사용자 목표 또는 feature journey에 따라 `test/e2e/` 아래에 둔다.
 
 ```text
-회원가입
-→ 로그인
-→ 사용자 페이지 접근
-→ 데이터 생성
-→ 데이터 확인
+test/e2e/
+├── auth.spec.ts
+├── products.spec.ts
+├── checkout.spec.ts
+├── portone-smoke.spec.ts  # 기본 E2E에서 제외한 manual browser smoke
+└── ...                    # 독립된 다른 사용자 목표
 ```
 
-하나의 E2E 테스트는 완전한 사용자 behavior 또는 의미 있는 workflow를 표현한다.
+위 파일명은 책임 영역의 예시이며 허용 목록이 아니다. 관련 시나리오는 하나의 feature
+`*.spec.ts`에 묶을 수 있지만 각 테스트는 독립적으로 실행되어야 한다. 여러 테스트를
+`serial`로 연결해 하나의 workflow를 완성하지 않는다.
 
-## What Not to Test
+## Test Runner and playwright-cli
 
-E2E에서 다음을 과도하게 검증하지 않는다.
+정식 E2E는 `*.spec.ts`에 재현 가능한 단계와 assertion으로 저장되고 `@playwright/test`가 자동
+PASS·FAIL을 판정한다. `playwright-cli`는 별도 테스트 계층이나 runner가 아니다.
 
-* 모든 validation rule
-* 모든 business logic branch
-* 모든 Component state
-* 모든 API response case
-* 내부 함수 호출
-* DB query 구현
+`playwright-cli`는 다음 작업에만 보조적으로 사용한다.
 
-이러한 세부 behavior는 Unit / Component / Integration Test에서 검증한다.
+- 실제 화면 탐색과 접근 가능한 locator 발견
+- 실패한 Playwright Test에 `--debug=cli`로 연결
+- snapshot, trace, console과 request 조사
+- 재현 단계와 assertion 후보 확인
 
-## User-Centric Testing
+CLI 탐색에서 발견한 회귀는 독립된 데이터와 안정된 locator를 가진 `*.spec.ts`로 옮긴다. CLI로
+수동 확인한 결과를 일반 E2E 통과로 기록하지 않는다. 사람이 카드사 인증을 완료하는 흐름은
+[Manual Browser Smoke](#manual-browser-smoke)로 분류한다.
 
-E2E 테스트는 실제 사용자가 애플리케이션을 사용하는 것처럼 작성한다.
+## Application Server
 
-```ts
-await page.getByLabel("이메일").fill("user@example.com");
+기본 E2E 명령은 전용 port에서 E2E MongoDB, 외부 local fake server와 Next.js server를 직접
+시작하고 readiness를 확인한 뒤 테스트를 실행한다. 이미 실행 중인 개발 서버를 신뢰 가능한
+기본 실행에서 재사용하지 않는다. server 재사용은 명시적인 로컬 디버깅 모드에서만 허용한다.
 
-await page.getByLabel("비밀번호").fill("password");
+현재 일반 E2E는 `next dev`에서 실제 Chromium·Next.js·MongoDB 경로를 검증한다. 이 결과는
+Production build, bundling, asset, hydration과 배포 설정까지 증명하지 않는다. 해당 계약은
+`next build`·`next start`를 사용하는 별도의 opt-in production E2E 또는 deployment smoke가
+담당한다.
 
-await page.getByRole("button", {
-  name: "로그인",
-}).click();
+CI와 신뢰 가능한 기본 실행에서는 테스트 전용 환경변수와 DB를 가진 server를 매번 직접
+시작한다. app process crash, readiness timeout, port 충돌과 cleanup 실패는 테스트 실패다.
+
+## Test Data and Database Isolation
+
+각 테스트는 이전 테스트의 cookie·storage·DB 상태를 전혀 가정하지 않는다. 하나의 E2E DB를
+공유하면 runner를 직렬로 실행하고, 각 테스트 시작 전에 모든 애플리케이션 collection을 정리한
+뒤 기본 사용자·상품과 해당 시나리오에 필요한 데이터만 다시 seed한다. 병렬 실행은 worker별
+독립 DB와 seed를 제공할 때만 허용한다.
+
+선행 데이터와 식별자는 결정적인 테스트 전용 값으로 만들되 서로 충돌하지 않아야 한다. 제품이
+생성하는 ID 자체가 검증 대상이 아니면 정규식이나 이후 사용자 결과로 관찰하고 특정 실행의
+임의 값을 다른 테스트가 이어받지 않는다.
+
+사용자 목표와 무관한 Arrange·Cleanup은 Playwright `request` fixture, 직접 DB helper 또는
+test-only control plane으로 수행할 수 있다. test-only endpoint는 E2E 환경에서만 활성화하고
+Production build에 노출하지 않는다. 검증 대상인 생성·수정·결제·권한 행동과 사용자 결과는
+실제 `page` 흐름을 통과해야 하며 setup helper가 대신해서는 안 된다.
+
+## Authentication State
+
+로그인 자체를 검증하는 시나리오는 실제 로그인 form, cookie 발급과 redirect를 통과한다. 그 외
+인증된 feature는 역할별 storage state를 새로운 Browser Context의 읽기 전용 초기 상태로
+주입할 수 있다.
+
+storage state는 테스트 전용 사용자와 server에서 실행마다 생성한다. 실제 계정 token을
+포함하거나 저장소에 커밋하지 않는다. 테스트가 변경한 cookie, localStorage와 sessionStorage를
+다음 테스트나 state 파일에 다시 저장해 이어받지 않는다.
+
+## External Systems and Network
+
+이메일, 결제, Cloudinary storage, 지도와 외부 HTTP API는 공식 adapter·SDK 또는 외부 origin의
+network 경계에서 local fake server나 결정적인 test double로 대체할 수 있다.
+
+```text
+Browser → 실제 Next.js → 실제 Action / Route → 실제 Service → 실제 MongoDB
+                              │
+                              └→ 공식 Adapter → Local Fake External Service
 ```
 
-내부 selector나 implementation detail에 의존하지 않는다.
+test-only 분기는 제품의 공식 adapter 내부에만 제한하고 실제 SDK와 같은 성공·실패·redirect
+계약을 모사한다. Service, Action, Route Handler와 business rule을 우회해서는 안 된다. 처리되지
+않은 외부 network 요청은 즉시 실패시킨다.
 
-## Selectors
+외부 시스템의 실제 호환성은 기본 E2E가 증명하지 않는다. 실제 secret·비용·사람 개입이 필요한
+검증은 opt-in contract, production smoke 또는 manual browser smoke로 분리한다.
 
-가능하면 의미 있는 사용자 중심 locator를 사용한다.
+## User Interaction and Locators
 
-우선순위:
+click, fill, select, keyboard와 upload는 Playwright locator를 통해 실제 browser에서 수행한다.
+locator는 다음 순서를 기본으로 선택한다.
 
 ```text
 getByRole
@@ -101,109 +166,144 @@ getByText
     ↓
 getByPlaceholder
     ↓
-data-testid
+data-testid 또는 공개 element ID
 ```
 
-CSS selector나 DOM hierarchy에 대한 의존은 최소화한다.
+hidden file input, canvas와 vendor widget처럼 접근 가능한 경로가 없는 요소는 안정적인
+`data-testid`나 명시적으로 공개한 element ID를 사용할 수 있다. styling class와 DOM hierarchy에
+의존하지 않는다. 테스트가 event handler와 browser 내부 callback을 직접 호출해 사용자 경로를
+우회해서는 안 된다.
 
-## Test Data
+## Assertions
 
-E2E Test는 독립적인 test data를 사용한다.
+URL, 보이는 content, 접근성 상태, 실제 download·popup·navigation과 사용자가 목록·상세·주문
+내역에서 다시 조회한 결과를 우선 검증한다. hidden input, storage와 network 기록은 browser
+계약이나 치명적인 중간 전이를 UI로 관찰할 수 없을 때만 보조 증거로 사용한다.
 
-테스트 간 계정이나 데이터 상태를 공유하지 않는다.
+상품 등록과 주문 완료처럼 사용자가 UI에서 결과를 다시 확인할 수 있으면 DB를 반드시 직접
+조회하지 않는다. 금액, 권한과 중복 생성처럼 UI가 노출하지 않는 핵심 불변조건이나 cleanup
+대상 식별에는 DB 조회를 보조 assertion으로 사용할 수 있다. 사용자 결과 없이 DB 상태만
+확인하면 Integration 책임에 가깝다.
 
-필요한 경우 테스트 시작 전에 fixture 또는 API를 통해 test data를 준비한다.
+내부 callback, 함수 호출 횟수, Service 인자와 DB query 구현은 검증하지 않는다. 큰 DOM
+snapshot도 사용자 behavior의 증거로 사용하지 않는다.
 
-## Authentication
+## Async Behavior, Failure, and Diagnostics
 
-인증이 필요한 시나리오는 모든 테스트에서 불필요하게 로그인 과정을 반복하지 않는다.
+Playwright의 locator assertion과 URL·response·popup 같은 관찰 가능한 조건이 제공하는
+auto-wait를 사용한다. `waitForTimeout`과 임의 sleep, 실제 network 속도에 의존하지 않는다.
+timeout을 늘려 race condition이나 readiness 실패를 숨기지 않는다.
 
-공통 인증 상태를 사용할 수 있지만, 인증 자체가 테스트 대상인 경우에는 실제 로그인 flow를 검증한다.
+최초 실패 후 retry에서 통과한 테스트도 flaky failure로 취급한다. retry는 trace와 재현 정보를
+수집하는 진단 수단일 수 있지만 성공 판정을 만드는 수단이 아니다.
 
-```text
-Authentication Test
-→ 실제 login flow
+예상하지 않은 `pageerror`, `console.error`, unhandled rejection, `requestfailed`와 허용되지 않은
+외부 network 요청은 실패로 취급한다. validation과 권한 거부처럼 의도한 4xx·5xx는 해당
+request와 사용자 결과를 테스트에서 명시적으로 확인할 때만 허용한다. 광범위한 전역 allowlist로
+Next.js나 vendor 오류를 숨기지 않는다.
 
-Authenticated Feature Test
-→ 재사용 가능한 authenticated state
-```
+실패 시 trace, screenshot, 관련 console·request와 server log를 보존한다. trace를 조사하거나
+실패한 테스트에 연결할 때 `playwright-cli`를 사용할 수 있다.
 
-## Stability
+## Browser and Visual Coverage
 
-E2E Test는 실제 Browser 환경에서 실행되므로 timing과 asynchronous behavior에 주의한다.
+기본 `core` project는 Desktop Chromium에서의 핵심 사용자 behavior만 증명한다. mobile이 주요
+사용 환경인 journey는 명시적인 mobile device project에서 별도로 실행한다. Firefox와 WebKit은
+지원 정책 또는 실제 위험이 있는 흐름에만 추가한다.
 
-다음 방식을 지양한다.
+element가 보인다는 assertion만으로 pixel-level layout을 증명하지 않는다. 반응형 배치, 겹침과
+잘림이 계약이면 고정 viewport, 안정된 데이터와 animation 조건을 가진 별도 visual assertion
+또는 E2E 시나리오를 사용한다.
 
-```ts
-await page.waitForTimeout(1000);
-```
+## Time-dependent Flows
 
-대신 UI 상태나 네트워크 상태를 기다린다.
+Playwright clock은 browser 시간만 변경하므로 Next.js server와 MongoDB 판단이 포함된 만료·예약
+흐름에 단독으로 사용하지 않는다. 공식 clock 경계를 browser와 server에 일관되게 주입하거나,
+만료 전·후의 결정적인 timestamp를 가진 데이터를 준비한다. 실제 시간이 흐르기를 기다리거나
+OS 시간을 변경하지 않는다.
 
-```ts
-await expect(
-  page.getByText("저장되었습니다")
-).toBeVisible();
-```
+browser timer만의 UI behavior는 Component에서 우선 검증한다. E2E에서는 server와 결합된 사용자
+목표에 필수인 시간 동작만 다룬다.
 
-## Naming
+## Lifecycle and Artifacts
 
-파일명:
+정상, assertion 실패와 실행 중단 경로 모두에서 Browser Context, child process, local fake
+server, DB 연결과 MongoDB instance를 종료한다. 지연된 server 작업과 zombie process를 남기지
+않으며 cleanup 실패도 테스트 실패로 처리한다.
 
-```text
-<scenario>.e2e.spec.ts
-```
+실제 개인정보와 Production credential을 사용하지 않는다. storage state, trace, screenshot,
+video와 request log는 민감한 artifact로 취급해 저장소에 커밋하지 않고 CI 접근 권한과 보존
+기간을 제한한다. Authorization, cookie, 결제 secret과 form 비밀번호를 일반 log에 출력하지
+않으며 필요한 진단 정보는 redaction한다.
 
-Examples:
+임시 storage state와 성공 실행의 불필요한 로컬 artifact는 종료 후 정리한다. 실패 분석을 위해
+보존하는 artifact의 위치와 수명은 runner 설정에서 관리한다.
 
-```text
-signup.e2e.spec.ts
-login.e2e.spec.ts
-user-management.e2e.spec.ts
-checkout.e2e.spec.ts
-```
+## Manual Browser Smoke
 
-Test name은 사용자 시나리오를 설명한다.
+실제 PortOne 결제처럼 실제 secret·비용과 사람의 카드사 인증이 필요한 테스트는 일반 E2E가
+아니다. 별도 Playwright config와 명시적인 opt-in 명령을 가진 manual browser smoke로 관리하며
+기본 CI gate에 포함하지 않는다.
 
-```ts
-test("사용자는 회원가입 후 로그인할 수 있다", async ({ page }) => {
-  // ...
-});
-```
+manual smoke는 worker 하나와 retry 없이 실행한다. 성공, assertion 실패와 중단 여부에 관계없이
+생성한 결제·파일 등 외부 자원을 `finally`에서 정리한다. 정리에 실패하면 payment ID와 수동
+복구 절차를 남기고 smoke를 실패로 처리한다.
 
-## Critical Path
+## What Not to Test
 
-모든 기능을 E2E로 테스트하지 않는다.
+일반 E2E에서는 다음을 반복하거나 함께 검증하지 않는다.
 
-다음과 같은 **핵심 사용자 흐름**을 우선한다.
-
-* 서비스 접근
-* 인증
-* 핵심 business workflow
-* 데이터 생성/수정/삭제
-* 결제 또는 중요한 transaction
-* 주요 권한 흐름
+- 모든 validation 입력과 business rule 분기
+- Component의 loading·error·empty state 전체 조합
+- Service 오류 매핑과 Mongoose schema·index의 세부 behavior
+- 앱 자체 API·Action을 intercept해 만든 UI 전용 흐름
+- 사용자 결과 없이 직접 DB 상태만 확인하는 테스트
+- 내부 함수, callback, 호출 횟수와 DOM 구조
+- 실제 Production DB, 실제 개인정보와 Production credential
+- 기본 명령에서 실제 결제·메일·storage와 사람 개입
+- Desktop Chromium 결과를 mobile·Firefox·WebKit 증거로 확대하는 것
+- `next dev` 결과를 Production build·deployment 증거로 사용하는 것
 
 ## Examples
 
+다음 예제는 실제 login, 상품 등록 form, upload, server와 DB 경로를 통과한 뒤 사용자가 목록에서
+결과를 다시 확인한다. 각 테스트 전에 E2E harness가 DB를 reset하고 기본 관리자 계정을 다시
+seed한다는 전제다.
+
 ```ts
-test("사용자는 새로운 사용자를 생성할 수 있다", async ({ page }) => {
-  await page.goto("/users");
+import { expect, test } from "@playwright/test";
 
-  await page.getByRole("button", {
-    name: "사용자 추가",
-  }).click();
+const image = {
+  name: "product.png",
+  mimeType: "image/png",
+  buffer: Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  ),
+};
 
-  await page.getByLabel("이름").fill("홍길동");
+test("ADMIN은 invitation 상품을 등록하고 목록에서 확인한다", async ({
+  page,
+}) => {
+  await page.goto("/login");
+  await page.getByLabel("이메일").fill("admin-e2e@example.com");
+  await page.getByLabel("비밀번호").fill("Admin-e2e1!");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page).not.toHaveURL(/\/login/);
 
-  await page.getByRole("button", {
-    name: "저장",
-  }).click();
+  await page.goto("/admin/products/new");
+  await page.getByLabel("상품명 *").fill("E2E 초대장");
+  await page
+    .getByLabel("상품 설명 *")
+    .fill("사용자 목표를 검증하는 충분히 긴 상품 설명입니다.");
+  await page.getByLabel("기본 가격 *").fill("10000");
+  await page.locator("#thumbnail-input").setInputFiles(image);
+  await page.locator("#subCategory").click();
+  await page.getByRole("option", { name: "청첩장" }).click();
 
-  await expect(
-    page.getByText("홍길동")
-  ).toBeVisible();
+  await page.getByRole("button", { name: "상품 등록" }).click();
+
+  await expect(page).toHaveURL(/\/admin\/products$/);
+  await expect(page.getByText("E2E 초대장")).toBeVisible();
 });
 ```
-
-E2E Test의 목적은 내부 구현의 정확성을 증명하는 것이 아니라 **사용자에게 중요한 전체 시스템 behavior가 정상적으로 동작한다는 것을 검증하는 것**이다.

--- a/docs/__test/integration.md
+++ b/docs/__test/integration.md
@@ -2,162 +2,307 @@
 
 ## Purpose
 
-Integration Test는 여러 실제 모듈이 결합되었을 때 **각 모듈이 서로 올바르게 상호작용하는지** 검증한다.
+Integration Test는 제품의 서버·데이터 코드가 실제 Mongoose와 격리된 MongoDB에
+연결되었을 때 **경계 사이의 계약이 올바르게 동작하는지** 검증한다.
 
-이 프로젝트에서는 특히 **Mongoose와 MongoDB 데이터 계층의 실제 동작**을 검증하는 데 사용한다.
+파일명, 위치, 실행 명령, Arrange → Act → Assert와 공통 격리 원칙은
+[`README.md`](README.md)를 따른다.
 
 ## Scope
 
-주요 대상:
+실제 MongoDB 통과는 Integration의 필요조건이지만 충분조건은 아니다. 테스트는
+프로덕션 import 경로를 사용하면서 서버 또는 데이터 계층의 계약을 관찰해야 한다.
+별도의 Repository 계층은 없으며, 일반적인 업무 흐름에서 Service가 Mongoose Model을
+통해 MongoDB에 직접 접근한다.
 
-* Service + Repository
-* Repository + Mongoose
-* Mongoose Model + MongoDB
-* API Route + Service + Repository
-* 여러 모듈의 실제 결합
+주요 대상은 다음과 같다.
+
+- `dbConnect` → Mongoose → MongoDB
+- Mongoose Model → MongoDB
+- Service → Mongoose Model → MongoDB
+- Server Action → Service → Mongoose Model → MongoDB
+- Route Handler → Service → Mongoose Model → MongoDB
+- Server Component / Page → Service → Mongoose Model → MongoDB
+- 여러 Service와 Model이 참여하는 transaction과 상태 전이
+
+모든 Integration Test는 다음 조건을 충족해야 한다.
+
+1. 실제 Mongoose와 격리된 MongoDB 인스턴스를 통과한다.
+2. 검증 대상 경로는 프로덕션 import와 실제 연결 구조를 사용한다.
+3. 해당 경계의 반환 결과, 오류, 저장 상태 또는 직접 관찰 가능한 계약을 검증한다.
+4. React UI를 렌더링하거나 사용자 관찰 결과와 브라우저 흐름을 함께 검증하지 않는다.
+
+Service를 반드시 통과해야 하는 것은 아니다. `dbConnect`, schema validation,
+index·unique constraint, middleware·hook, transaction helper처럼 데이터 계층 자체가
+대상이면 Mongoose와 MongoDB의 경계를 직접 검증한다. 반대로 MongoDB에 한 번
+접근했다는 이유만으로 무관한 서버·UI 테스트를 Integration으로 분류하지 않는다.
+
+Server Action은 함수를 직접 호출해 action 결과와 DB 효과를 검증한다. Next.js의 RPC
+전송 자체는 포함하지 않는다.
+
+Route Handler는 `Request` 또는 `NextRequest`로 handler를 직접 호출해 요청 해석,
+HTTP status, 응답 envelope와 DB 결과를 검증한다. 실제 서버, URL routing과 네트워크
+전송은 포함하지 않는다.
+
+Server Component와 Page는 함수를 호출한 뒤 반환된 React tree의 타입·props·데이터
+전달만 확인할 때 Integration으로 허용한다. 하위 Component를 렌더링하거나 사용자
+관찰 결과를 검증하면 Component Test로 분리한다.
+
+같은 사용자 시나리오라도 Service 결과와 DB 상태는 Integration에서 검증하고, React
+렌더링은 factory 또는 fixture로 동등한 입력을 만들어 Component Test에서 독립적으로
+검증한다. 실제 URL·네트워크·브라우저 탐색은 E2E가 담당한다.
+
+## Directory Structure
+
+Integration Test는 대상 제품 코드 옆 `src/`에 두지 않고 `test/integration/`에서
+관리한다. 디렉터리는 검증을 시작하는 서버 진입점 또는 데이터 책임에 따라 나눈다.
+
+```text
+test/integration/
+├── actions/    # Server Action과 Service, MongoDB 결합
+├── app/        # Route Handler, Server Component, Page
+├── db/         # Mongoose와 MongoDB 연결
+├── services/   # Service와 Mongoose Model 결합
+└── ...         # 검증 대상 제품 코드의 다른 소유 경계
+```
+
+위 디렉터리는 현재 책임 영역의 예시이며 허용 목록이 아니다. 테스트가 Integration인지
+먼저 [Scope](#scope)에 따라 판정한 뒤 `test/integration/` 아래에 배치한다. 첫 번째
+하위 디렉터리는 검증 대상 제품 코드의 소유 경계에 맞추며, 기존 경계로 표현할 수 없을
+때만 새 최상위 디렉터리를 추가한다.
 
 ## Database
 
-Integration Test에서는 실제 MongoDB behavior를 검증하기 위해 `mongodb-memory-server`를 사용한다.
+Integration Test는 Vitest의 Node 환경에서 실행하며, 실제 MongoDB behavior와
+transaction을 검증하기 위해 `mongodb-memory-server`의 단일 노드 replica set을
+사용한다.
 
 ```text
 Integration Test
        ↓
-Service
-       ↓
-Repository
+제품 서버·데이터 코드
        ↓
 Mongoose
        ↓
-mongodb-memory-server
-       ↓
-MongoDB
+mongodb-memory-server replica set
 ```
 
-Mongoose Model 자체를 Mock하지 않는다.
+검증 대상 경로의 Mongoose Model과 Service는 Mock하지 않는다. Production MongoDB에도
+연결하지 않는다.
 
 ## Why mongodb-memory-server
 
-Integration Test는 실제 MongoDB와 유사한 동작을 필요로 하지만 개발자 또는 CI 환경의 외부 MongoDB에 의존해서는 안 된다.
+Integration Test에는 실제 MongoDB의 query, index, transaction behavior가 필요하지만
+개발자 또는 CI 환경의 외부 MongoDB에 의존해서는 안 된다. 테스트 실행 시 고정된
+MongoDB 버전의 독립 replica set을 생성하고 `MONGO_TEST_URI`를 주입한다.
 
-따라서 테스트 실행 시 독립적인 MongoDB 인스턴스를 생성한다.
+## Environment
 
-## What to Test
+`npm run test:integration`은 개발자의 `.env`, 실제 secret과 외부 서비스 연결 없이
+실행되어야 한다. 제품 모듈의 import에 필요한 비밀이 아닌 형식상 값은 setup에서
+안전하고 결정적인 테스트 전용 값으로 주입한다. 예를 들어 `JWT_SECRET`,
+`ENTRY_JWT_SECRET`, `PORTONE_API_SECRET`의 실제 값에 의존하지 않는다.
 
-* Document 생성
-* 조회
-* 수정
-* 삭제
-* Query 조건
-* Index / Constraint behavior
-* Mongoose Schema behavior
-* Service와 Repository의 결합
-* 실제 DB 상태에 따른 business behavior
-
-## What Not to Test
-
-Integration Test에서는 다음을 반복해서 검증하지 않는다.
-
-* 순수 함수의 모든 분기
-* React UI
-* Browser interaction
-* 실제 Production MongoDB
-* 외부 API의 실제 동작
+특정 테스트가 필수 설정을 요구하면 suite 실행 초기에 누락된 환경변수의 이름과 원인을
+명시해 실패해야 한다. 테스트가 `process.env`를 변경하면 종료 전에 원래 값으로 복구한다.
+실제 외부 secret과 서비스를 통과하는 검증은 이 문서와 기본 Integration project의
+범위 밖이다. 도입할 때 별도의 opt-in contract 또는 smoke 문서·project·명령을 먼저
+정의한다.
 
 ## Test Data
 
-테스트마다 필요한 데이터를 명시적으로 생성한다.
+Integration Test는 `@test/support`의 순수 factory로 유효한 입력을 만들고 검증에 필요한
+값만 override한다. factory는 DB에 쓰지 않으며, 테스트 간에 Document나 식별자를
+공유하지 않는다.
 
-```text
-Arrange
-  ↓
-Create Test Data
-  ↓
-Act
-  ↓
-Assert
-  ↓
-Cleanup
-```
+검증 대상 코드를 Arrange와 Assert에 다시 사용하지 않는다. Service 쓰기 동작은 factory와
+Model로 선행 데이터를 준비하고, 실행 후 Model의 직접 조회나 필요한 경우 raw collection으로
+저장 상태를 확인한다. Service 읽기 동작도 Model 또는 factory로 데이터를 준비한다. 같은
+Service를 Arrange·Act·Assert에 반복 사용해 서로의 결함을 가려서는 안 된다. 여러 호출에
+걸친 Service 자체의 상태 전이가 대상이면 각 단계의 DB 상태를 독립적으로 관찰한다.
 
-테스트 간 DB 상태를 공유하지 않는다.
+시간을 검증하는 테스트만 공식 clock 경계 또는 fake timer를 사용하고 종료 전에 복구한다.
+MongoDB driver, session, TTL과 timeout이 사용하는 실제 타이머를 전역으로 고정하지 않는다.
+factory의 ID와 난수 데이터는 테스트별로 충돌하지 않아야 하며, 실패를 재현할 수 있도록
+명시값이나 seed를 사용할 수 있어야 한다. 정렬·만료·중복처럼 값 자체가 결과에 영향을
+주면 Arrange에서 값을 명시한다.
 
 ## Isolation
 
-각 테스트는 다른 테스트의 DB 상태에 의존하지 않아야 한다.
+Integration project는 하나의 replica set을 공유하므로 테스트 파일을 직렬로 실행한다.
+각 테스트는 이전 상태를 가정하지 않고, Arrange 전에 `clearCollections`로 모든 애플리케이션
+컬렉션의 document를 삭제한 뒤 필요한 데이터만 생성한다. 정리 실패는 테스트 실패로
+취급한다. 일반 격리를 transaction rollback에 의존해서는 안 된다.
 
-필요한 경우:
+공용 DB에서 파일 병렬 실행을 활성화하면 한 테스트의 cleanup이 다른 테스트의 데이터를
+삭제하므로 허용하지 않는다. 병렬 실행은 worker마다 독립 DB를 제공할 때만 허용한다.
 
-* Collection cleanup
-* Database reset
-* Fixture recreation
+일반 cleanup은 document만 삭제하고 collection과 index는 유지한다. unique·TTL·compound
+index 테스트는 assertion 전에 `Model.init()` 등으로 index 생성 완료를 기다린다. 전역
+setup에서 `syncIndexes()`처럼 기존 index를 변경하거나 삭제할 수 있는 작업은 실행하지
+않는다. index 구조를 변경하는 테스트는 전용 DB를 사용하고 종료 시 폐기한다.
 
-등을 사용한다.
+각 suite는 Mongoose 연결과 session을 닫고, global teardown은 replica set을 중지한다.
+테스트가 만든 timer, background job, 환경변수 변경과 Mock도 종료 전에 복구한다. 정리되지
+않은 handle이나 지연된 DB 쓰기가 남으면 테스트 실패로 취급한다.
+
+## Transactions and Failure Paths
+
+transaction 성공은 반환값과 commit 이후의 DB 상태를 확인한다. 실패는 중간 쓰기 이후
+오류를 발생시켜 오류 결과와 rollback 이후의 DB 상태를 모두 확인한다. transaction 검증은
+실제 transaction을 지원하는 replica set에서만 수행한다.
+
+이메일, 결제, storage 같은 비DB side effect는 MongoDB rollback 대상이 아니다. 공식
+adapter 경계에서 대체하고 DB commit이 실패하면 호출되지 않는지 확인한다. 이미 실행된
+외부 효과의 보상이나 outbox behavior는 해당 흐름을 대상으로 하는 별도 Integration Test로
+검증한다.
+
+DB를 변경하는 성공 경로는 변경된 상태와 보존되어야 할 핵심 불변조건을 확인한다. 실패
+경로는 의도하지 않은 변경이 없음을 확인한다. 읽기 전용 Service는 실제 MongoDB에 준비한
+데이터로 결과를 검증하면 충분하며 의미 없는 전체 DB snapshot을 만들지 않는다. `dbConnect`,
+schema, index처럼 document 변경이 목적이 아닌 테스트는 연결 재사용, validation 오류,
+constraint 적용 등 해당 경계의 직접 관찰 결과를 검증한다.
+
+## What to Test
+
+- Document 생성·조회·수정·삭제와 보존되어야 할 불변조건
+- query 조건, 정렬, pagination과 atomic update
+- schema validation, default, discriminator와 middleware·hook
+- index와 unique·TTL·compound constraint
+- Service와 실제 Mongoose Model의 결합
+- transaction commit, rollback과 여러 Model의 상태 전이
+- DB 상태에 따른 domain 결과와 오류
+- Server Action과 Route Handler의 반환 계약 및 DB 효과
+- Server Component와 Page가 반환 React tree에 전달하는 데이터
+
+## What Not to Test
+
+Integration Test에서는 다음을 반복하거나 함께 검증하지 않는다.
+
+- 순수 함수의 모든 분기
+- React 렌더링과 사용자 관찰 결과
+- Hook → SWR → fetch → MSW 흐름
+- browser interaction과 실제 URL·네트워크 전송
+- 실제 Production MongoDB
+- 외부 API의 실제 동작
+- 검증 대상 Service나 그 반환값을 Mock해 만든 인위적인 연결
+- 다른 테스트 파일이 만든 DB 상태를 이어받는 시나리오
 
 ## Mocking
 
-Integration Test에서는 **검증 대상인 실제 내부 dependency를 Mock하지 않는다.**
+검증 대상 경로인 Service → Mongoose Model → MongoDB는 절대 Mock하지 않는다. 테스트
+대상 Service나 반환값을 Mock해 연결을 인위적으로 만들면 Integration으로 인정하지 않는다.
 
-예:
+인증 session이나 현재 시각처럼 현재 테스트의 독립된 선행 조건은 제품의 공식 경계에서
+부분 Mock할 수 있다. 테스트에는 제외한 경계와 이유를 명시하고, 그 경계 자체는 별도
+Integration Test가 담당해야 한다. 모듈 전체를 대체하지 말고 실제 구현을 유지한 채 필요한
+export만 대체한다.
 
-```text
-Service
-  ↓
-Repository       ← Mock ❌
-  ↓
-Mongoose         ← 실제 사용
-  ↓
-Memory MongoDB   ← 실제 사용
-```
-
-외부 시스템이 테스트 범위를 벗어나는 경우에는 해당 외부 시스템만 Mock할 수 있다.
+PortOne, Cloudinary, Nodemailer, Kakao와 공공 API처럼 네트워크·비용·외부 부작용이 있는
+시스템은 Adapter 또는 SDK 경계에서 대체하고 호출 인자와 시점을 검증한다. Integration
+runner는 모든 외부 네트워크를 차단하고, 처리되지 않은 요청을 즉시 실패시키도록 구성한다.
+Hook → SWR → fetch → MSW는 Component Test이고, 실제 외부 API 호환성은 이 문서의
+범위 밖인 opt-in contract 또는 smoke test가 담당한다.
 
 ## API Integration
 
-Next.js Route Handler의 API behavior와 데이터 계층의 결합을 검증할 수 있다.
+Route Handler는 실제 HTTP server를 띄우지 않고 exported handler를 직접 호출한다.
 
 ```text
-Request
-   ↓
+Request / NextRequest
+          ↓
 Route Handler
-   ↓
-Service
-   ↓
-Repository
-   ↓
-Mongoose
-   ↓
-MongoDB
+          ↓
+실제 Service → Mongoose Model → MongoDB
+          ↓
+Response contract + DB state
 ```
 
-이 테스트에서는 HTTP endpoint의 behavior와 실제 DB 상태를 함께 검증한다.
-
-## Naming
-
-파일명:
-
-```text
-<target>.integration.test.ts
-```
-
-Examples:
-
-```text
-user.repository.integration.test.ts
-user.service.integration.test.ts
-user.api.integration.test.ts
-```
+쓰기 endpoint는 HTTP status와 응답 envelope뿐 아니라 DB 변경과 핵심 불변조건을 확인한다.
+읽기 endpoint는 실제 DB에 준비한 데이터와 응답 계약을 확인하며 불필요한 DB snapshot은
+만들지 않는다.
 
 ## Examples
 
+다음 예제는 Service 결과와 독립된 Model 조회로 저장 상태를 검증하고, 실패 경로에서
+의도하지 않은 저장이 없음을 확인한다.
+
 ```ts
-it("사용자를 생성한 후 MongoDB에서 조회할 수 있다", async () => {
-  const created = await userService.create(input);
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose from "mongoose";
+import { dbConnect } from "@/db";
+import { ProductModel } from "@/models";
+import { createProductService } from "@/services/product";
+import { buildProductInput, clearCollections } from "@test/support";
 
-  const found = await userRepository.findById(created.id);
+describe("createProductService", () => {
+  beforeEach(async () => {
+    await dbConnect();
+    await clearCollections();
+  });
 
-  expect(found?.email).toBe(input.email);
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  it("상품을 생성하고 기본값을 저장한다", async () => {
+    const input = buildProductInput();
+
+    const result = await createProductService(input);
+
+    expect(result).toBe(true);
+    const saved = await ProductModel.findOne({ title: input.title }).lean();
+    expect(saved).toMatchObject({ title: input.title, status: "active" });
+  });
+
+  it("schema validation에 실패하면 상품을 저장하지 않는다", async () => {
+    const input = buildProductInput({ title: undefined as unknown as string });
+
+    await expect(createProductService(input)).rejects.toMatchObject({
+      category: "INTERNAL",
+    });
+
+    expect(await ProductModel.countDocuments()).toBe(0);
+  });
 });
 ```
 
-Integration Test의 핵심은 **실제 모듈 간 결합이 올바르게 동작하는지 검증하는 것**이다.
+Route Handler는 실제 server 대신 `NextRequest`로 직접 호출한다. 읽기 경로이므로 실제
+MongoDB에 준비한 데이터와 응답 계약을 확인하고, 변경되지 않은 DB snapshot은 만들지 않는다.
+
+```ts
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/products/route";
+import { dbConnect } from "@/db";
+import { MobileInvitationProductModel } from "@/models";
+import { buildProductInput, clearCollections } from "@test/support";
+
+describe("GET /api/products", () => {
+  beforeEach(async () => {
+    await dbConnect();
+    await clearCollections();
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  it("공개 상품을 응답 envelope에 담아 반환한다", async () => {
+    const input = buildProductInput({ title: "공개 상품" });
+    await MobileInvitationProductModel.create(input);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/products"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual([
+      expect.objectContaining({ title: input.title }),
+    ]);
+  });
+});
+```

--- a/docs/__test/unit.md
+++ b/docs/__test/unit.md
@@ -2,166 +2,294 @@
 
 ## Purpose
 
-Unit Test는 하나의 함수 또는 독립적인 모듈의 **behavior를 빠르고 격리된 환경에서 검증**한다.
+Unit Test는 하나의 공개 behavior를 소유한 제품 모듈을 직접 실행하고, 모듈 바깥의
+collaborator를 통제해 **입력 변환, 규칙, 위임, 오류와 반환 계약을 빠르게 검증**한다.
+Unit은 반드시 순수 함수일 필요가 없다.
 
-주요 목적은 비즈니스 로직과 규칙이 다양한 입력 조건에서 올바르게 동작하는지 확인하는 것이다.
+파일명, 위치, 실행 명령, Arrange → Act → Assert와 공통 격리 원칙은
+[`README.md`](README.md)를 따른다.
 
 ## Scope
 
-Unit Test는 다음을 대상으로 한다.
+Unit의 경계는 실행한 파일이나 함수 개수가 아니라 하나의 공개 behavior를 소유한 제품
+모듈을 기준으로 정한다. 대상 모듈과 내부 구현 세부사항인 helper·value object는 함께 실제로
+실행할 수 있다. 독립 책임과 공개 계약을 가진 collaborator만 공식 경계에서 대체한다.
 
-* 순수 함수
-* Business Logic
-* Domain Logic
-* 데이터 변환
-* Validation Logic
-* 조건 분기
-* 계산 및 정책
-* 독립적인 Service Logic
+주요 대상은 다음과 같다.
 
-Unit Test에서는 실제 외부 시스템과의 결합을 검증하지 않는다.
+- 순수 함수, 계산, mapper와 domain policy
+- Zod schema와 Mongoose에서 분리된 순수 validator
+- React 없이 직접 호출하는 reducer와 Zustand Store
+- Service를 대체하고 직접 호출하는 Server Action과 Route Handler
+- Service를 대체하고 렌더링 없이 직접 호출하는 Server Component와 Page
+- `fetch` 또는 vendor SDK를 대체하고 직접 호출하는 server·browser adapter
+- 입력 정규화, collaborator 위임, 오류 매핑과 반환 계약을 소유한 orchestration 모듈
 
-## What to Test
+모든 Unit Test는 다음 조건을 충족해야 한다.
 
-### Input → Output
+1. 검증 대상으로 선택한 제품 모듈과 내부 helper를 실제로 실행한다.
+2. 실제 MongoDB, 실제 HTTP network와 React rendering을 사용하지 않는다.
+3. 대상 바깥의 collaborator만 공식 import·함수·SDK 경계에서 대체한다.
+4. 하나의 공개 behavior와 그 결과 또는 공개 side effect를 검증한다.
 
-동일한 입력에 대해 올바른 결과를 반환하는지 검증한다.
+React element를 반환한다는 사실만으로 Component Test가 되지는 않는다. Testing Library로
+렌더링하지 않고 Page 함수를 직접 호출해 입력 정규화, Service 위임과 반환 element의 직접
+child type·props만 확인하면 server wiring Unit이다. 실제 MongoDB 결과가 props에 전달되는지
+확인하면 [Integration Test](integration.md), fixture로 반환 UI를 렌더링해 사용자 결과를
+확인하면 [Component Test](component.md)다. Unit에서는 깊은 React tree나 DOM 결과를
+검증하지 않는다.
+
+## Environment
+
+Unit의 기본 실행 환경은 Vitest의 Node 환경이다. `window`, `sessionStorage`와 `File` 같은
+소수의 Web API가 필요한 browser adapter는 테스트에서 최소 global stub을 제공하고 종료 전에
+복구한다. 실제 DOM 또는 storage event처럼 jsdom의 동작 자체가 필요할 때만 파일 단위로 jsdom
+환경을 사용한다.
+
+파일 단위 jsdom이 필요하면 테스트 파일 첫 줄에 다음 directive를 둔다.
 
 ```ts
-it("100점 이상이면 합격을 반환한다", () => {
-  expect(evaluateScore(100)).toBe("PASS");
-});
+// @vitest-environment jsdom
 ```
 
-### Business Rules
+jsdom을 사용하더라도 React를 render하지 않고 lifecycle을 관찰하지 않으면 Unit이다. 반대로
+환경 이름이 Node여도 실제 network나 MongoDB를 사용하면 Unit으로 인정하지 않는다.
 
-```ts
-it("관리자 사용자는 모든 문서를 조회할 수 있다", () => {
-  expect(canReadDocument(admin, document)).toBe(true);
-});
-```
+## Unit Boundary and Mocking
 
-### Boundary Conditions
+대상 모듈의 반환값이나 business behavior를 Mock하지 않는다. 같은 Unit에 속한 private helper도
+Mock하지 않는다. 내부 helper를 대체해야만 테스트할 수 있다면 독립 제품 모듈로 추출해 공개
+collaborator 경계를 만든다.
 
-* 최소값
-* 최대값
-* 빈 값
-* null / undefined
-* 경계값
-* 잘못된 입력
-
-## What Not to Test
-
-Unit Test에서는 다음을 직접 검증하지 않는다.
-
-* MongoDB 동작
-* Mongoose 동작
-* HTTP 통신
-* 실제 외부 API
-* React rendering
-* Browser behavior
-* 구현 세부사항
-
-예를 들어 내부에서 `map()`을 사용했는지보다 최종 behavior를 검증한다.
-
-## Dependencies and Mocking
-
-외부 dependency는 Unit Test의 격리를 위해 Mock할 수 있다.
+다음과 같이 Unit 바깥의 공식 경계는 대체할 수 있다.
 
 ```text
 Unit Under Test
       │
-      ├── Mock Repository
-      ├── Mock API Client
-      └── Mock External Service
+      ├── Mock Service
+      ├── Mock fetch / Vendor SDK
+      ├── Mock Router / cache invalidation
+      └── Injected clock / environment
 ```
 
-단, 테스트 대상 자체를 Mock해서는 안 된다.
+모듈 전체를 무조건 비우지 않고 가능한 한 실제 export를 유지하면서 필요한 공식 경계만
+대체한다. Mock이 정상 결과를 대신 만들어 테스트 대상의 logic을 우회해서는 안 된다.
 
-### Mocking Rule
+여러 내부 모듈이 함께 실제로 실행되어도 하나의 공개 behavior에 속하면 Unit 범위를 유지한다.
+반면 여러 독립 제품 모듈의 계약을 한 파일에서 동시에 증명하거나 실패 원인을 특정하기
+어려우면 대상별로 분리한다.
 
-> **Mock은 dependency를 격리하기 위해 사용하며, behavior 자체를 만들어내기 위해 사용하지 않는다.**
+## Pure Rules and Mongoose Boundary
 
-Mock 호출 횟수나 내부 구현보다 실제 결과를 우선 검증한다.
+Zod schema, 계산과 Mongoose에서 분리된 validator는 입력과 출력으로 직접 검증한다. 대표값과
+경계값을 사용하고 누락 위험이 큰 규칙의 반복 입력은 `it.each`로 명시할 수 있다.
 
-## Test Structure
+Mongoose Model·Schema의 casting, default, middleware, discriminator와 validation 적용은 DB
+없는 Unit으로 검증하지 않는다. 순수 규칙은 함수로 추출해 Unit에서 검증하고, Mongoose에
+실제로 적용되는지는 실제 Mongoose → MongoDB 경계를 사용하는 Integration에서 확인한다.
 
-기본 구조는 Arrange → Act → Assert를 따른다.
+## Orchestration Contracts
 
-```ts
-it("유효한 사용자를 생성한다", async () => {
-  // Arrange
-  const input = createUserInput();
+Action, Route Handler, Page와 adapter 같은 orchestration 모듈은 다음 공개 계약을 검증한다.
 
-  // Act
-  const result = await createUser(input);
+- 외부 입력의 parsing·normalization·validation
+- 올바른 collaborator에 전달되는 입력 형태
+- validation 실패 시 collaborator가 호출되지 않는 short-circuit
+- dependency 결과의 반환 DTO·HTTP response 변환
+- 알려진 오류의 매핑과 예상하지 못한 오류의 전파
+- 한 번만 실행되어야 하는 side effect와 의미 있는 호출 순서
 
-  // Assert
-  expect(result.email).toBe(input.email);
-});
-```
+호출 인자·순서·횟수가 공개 계약이면 결과·오류 계약과 함께 검증할 수 있다. 단순히 구현에
+Mock이 있다는 이유로 `toHaveBeenCalledTimes(1)`을 추가하지 않으며 순수 함수나 내부 helper의
+호출 방식은 확인하지 않는다.
 
-## Naming
+공개 계약을 바꾸는 의미 있는 분기만 검증한다. 구현의 모든 `if`를 그대로 복제하거나 coverage
+수치를 채우기 위한 사례를 만들지 않는다. 같은 계약을 반복하는 입력은 대표값과 경계값으로
+줄인다.
 
-파일명:
+## HTTP and Browser Adapters
 
-```text
-<target>.unit.test.ts
-```
+Unit에서 `fetch`는 공식 collaborator 경계다. 실제 network 요청을 모두 차단하고 직접 Mock해
+adapter가 만든 URL·method·header·body와 응답 parsing·오류 정규화를 검증한다. Hook → SWR →
+fetch 흐름은 MSW를 사용하는 Component Test이며, 실제 외부 API 호환성은 별도의 opt-in
+contract 또는 smoke test가 담당한다.
 
-Examples:
+PortOne과 같은 React 독립 browser adapter는 adapter 함수를 실제로 실행하고 vendor SDK를
+Mock한다. `sessionStorage`나 `window`가 필요하면 해당 파일에만 최소 환경을 제공한다. React를
+사용하는 browser Widget과 결제 버튼의 adapter 연결은 Component, 실제 popup과 browser 동작은
+E2E 또는 browser smoke가 담당한다.
 
-```text
-user.service.unit.test.ts
-calculate-price.unit.test.ts
-validate-email.unit.test.ts
-```
+## Assertions
 
-테스트 이름은 behavior를 설명한다.
+순수 규칙은 입력에 대한 결과와 오류를 검증한다. orchestration은 결과·오류 계약을 우선하고,
+공개 계약인 collaborator 인자, 미호출, 순서와 횟수를 함께 확인한다.
 
-```ts
-it("중복된 이메일이면 사용자 생성을 거부한다");
-```
+DTO, 오류 envelope와 HTTP 응답처럼 전체 shape 자체가 공개 계약이면 `toEqual`로 정확히
+비교한다. assertion과 무관한 필드는 `objectContaining` 등으로 제외할 수 있지만 계약상 필수
+필드가 빠져도 통과하게 만들지 않는다. 큰 객체와 React element tree를 snapshot으로 고정하지
+않는다. 날짜와 ID는 결정적으로 만들거나 의미 있는 형식과 관계를 명시적으로 검증한다.
+
+## Async Behavior and Runtime State
+
+dependency의 성공과 실패는 명시적으로 resolve·reject하는 Promise로 제어하고 결과를 반드시
+`await`한다. 임의의 sleep, 실제 network 지연과 polling 간격에 의존하지 않는다. 호출 순서나
+중복 실행 방지가 계약이면 제어 가능한 deferred Promise로 실행 중 상태를 만든다.
+
+실제 timer를 기본으로 사용한다. 시간 계산이 검증 대상일 때만 system time 또는 fake timer를
+고정하고 종료 전에 복구한다. 시간, 난수, 환경변수, `fetch`와 browser global을 바꾸는 테스트는
+`it.concurrent`로 실행하지 않는다.
+
+환경변수와 import 시점 singleton·cache 자체가 대상일 때만 값을 먼저 stub한 뒤 동적으로
+import한다. `resetModules()`는 해당 테스트의 최소 범위에서만 사용하며 공통 초기화로 두지
+않는다. 가능하면 설정·clock·cache를 주입하거나 공식 reset 경계를 제공한다. import 순서에
+우연히 의존해서는 안 된다.
+
+테스트 종료 시 미해결 Promise, timer와 listener를 남기지 않는다. 예상하지 않은
+`console.error`, warning, unhandled rejection과 실제 network 요청은 실패로 취급한다. 로깅이나
+오류 보고가 공개 side effect인 경우만 해당 경계를 테스트 안에서 대체해 내용까지 확인하고
+복구한다. 출력을 숨기는 전역 console Mock은 허용하지 않는다.
 
 ## Test Data
 
-테스트 목적이 명확하다면 필요한 데이터를 테스트 내부에서 직접 정의한다.
+제품 모듈이 직접 받는 입력, DTO와 domain value 형태의 결정적인 plain object를 사용한다.
+변경 가능한 객체는 테스트마다 새로 만들고 반복이 크면 DB와 React에 의존하지 않는 순수
+builder·factory만 공유한다. 테스트 의도에 중요한 값은 factory 기본값에 숨기지 않고
+Arrange에서 명시한다.
 
-반복적으로 사용되는 복잡한 데이터는 factory를 사용할 수 있다.
+Mongoose document를 만드는 Integration factory와 UI 상태를 전제하는 Component fixture는
+재사용하지 않는다. ID, 날짜와 seed는 실패를 재현할 수 있는 값으로 만든다.
 
-```ts
-const user = createUserFixture({
-  role: "admin",
-});
-```
+## Isolation and Cleanup
 
-테스트 간 mutable data를 공유하지 않는다.
+각 테스트는 다른 테스트의 상태와 실행 순서를 가정하지 않는다. Mock, stubbed environment,
+global, timer, module state와 mutable Store를 종료 전에 원상 복구한다. 같은 runtime 전역을
+변경하는 테스트는 병렬 실행하지 않는다.
 
-## Isolation
+## What to Test
 
-각 테스트는 독립적으로 실행되어야 한다.
+- 순수 함수, schema, mapper와 domain policy의 결과·경계값
+- React 없이 직접 호출하는 reducer와 Zustand Store behavior
+- Action·Route·Page의 입력 정규화, 위임, 반환과 오류 계약
+- validation 실패의 short-circuit와 side effect 억제
+- adapter의 요청 구성, 응답 parsing과 오류 정규화
+- 공개 계약인 collaborator 인자·순서·횟수
+- deterministic time·environment·module state behavior
 
-* 테스트 간 상태 공유 금지
-* 전역 mutable state 최소화
-* Mock 상태 초기화
-* 실행 순서 의존 금지
+## What Not to Test
+
+Unit Test에서는 다음을 직접 또는 함께 검증하지 않는다.
+
+- 실제 MongoDB와 Mongoose 적용 behavior
+- 실제 HTTP network와 외부 API 호환성
+- React rendering, lifecycle과 사용자 interaction
+- 실제 browser navigation, popup과 layout
+- 대상 모듈의 Mock 반환값으로 만든 business behavior
+- private helper의 호출 방식과 구현의 모든 분기
+- 깊은 React element tree와 대규모 snapshot
+- 여러 독립 제품 모듈의 계약을 한 번에 묶은 흐름
 
 ## Examples
 
-### Good
+순수 함수는 경계값과 전체 반환 계약을 직접 확인한다.
 
 ```ts
-it("빈 장바구니에서는 결제할 수 없다", () => {
-  expect(() => checkout([])).toThrow();
+import { describe, expect, it } from "vitest";
+import { formatSignedPercent } from "./percent";
+
+describe("formatSignedPercent", () => {
+  it("previous가 0이면 null을 반환한다", () => {
+    expect(formatSignedPercent(1000, 0)).toBeNull();
+  });
+
+  it("증가율의 label과 direction을 반환한다", () => {
+    expect(formatSignedPercent(1125, 1000)).toEqual({
+      label: "+12.5%",
+      direction: "up",
+    });
+  });
 });
 ```
 
-### Bad
+Server Action은 실제 함수를 호출하고 Service라는 공식 collaborator만 대체한다. 입력 검증이
+실패하면 Service를 호출하지 않고, 정상 경로에서는 변환한 입력과 반환 envelope를 확인한다.
 
 ```ts
-it("checkout 내부에서 validateCart가 호출된다", () => {
-  expect(validateCart).toHaveBeenCalled();
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services", () => ({ getUserEmail: vi.fn() }));
+
+import { getUserEmail } from "@/services";
+import { findUserEmail } from "./findUserEmail";
+
+const buildFormData = () => {
+  const formData = new FormData();
+  formData.set("name", "홍길동");
+  formData.set("phone", "010-1234-5678");
+  return formData;
+};
+
+describe("findUserEmail", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("입력 검증에 실패하면 Service를 호출하지 않는다", async () => {
+    const result = await findUserEmail(null, new FormData());
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { category: "VALIDATION" },
+    });
+    expect(getUserEmail).not.toHaveBeenCalled();
+  });
+
+  it("정규화한 입력을 Service에 전달하고 결과를 반환한다", async () => {
+    vi.mocked(getUserEmail).mockResolvedValue("user@example.com");
+
+    const result = await findUserEmail(null, buildFormData());
+
+    expect(getUserEmail).toHaveBeenCalledWith({
+      name: "홍길동",
+      phone: "010-1234-5678",
+    });
+    expect(result).toEqual({
+      success: true,
+      data: { email: "user@example.com" },
+    });
+  });
 });
 ```
 
-첫 번째 테스트는 behavior를 검증하고, 두 번째 테스트는 구현 방식을 검증한다.
+HTTP adapter는 실제 network 대신 `fetch` 경계를 대체하고 parsing과 오류 정규화를 검증한다.
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchSeoulOpenApi } from "./request";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("fetchSeoulOpenApi", () => {
+  it("API rows를 domain 입력으로 반환한다", async () => {
+    const body = JSON.stringify({
+      SearchSTNBySubwayLineInfo: {
+        RESULT: { CODE: "INFO-000", MESSAGE: "정상 처리되었습니다" },
+        row: [{ STATION_NM: "서울" }],
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(body, { status: 200 })),
+    );
+
+    await expect(
+      fetchSeoulOpenApi("SearchSTNBySubwayLineInfo", [1, 1000]),
+    ).resolves.toEqual([{ STATION_NM: "서울" }]);
+  });
+
+  it("network 오류를 외부 서비스 오류로 정규화한다", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("failed")));
+
+    await expect(
+      fetchSeoulOpenApi("SearchSTNBySubwayLineInfo", [1, 1000]),
+    ).rejects.toMatchObject({ category: "EXTERNAL_SERVICE" });
+  });
+});
+```


### PR DESCRIPTION
## Summary

- `docs/__test/{README,unit,component,integration,e2e}.md`의 unit/component/integration/e2e 경계를 파일 타입이 아니라 관찰 가능한 behavior와 런타임 경계 기준으로 재정의한다.
- README에 파일명·위치·실행 명령 공유 표를 추가한다.
- 이 커밋은 오늘 머지된 4개 PR(#202~#205)이 실제로 참고·의존한 문서 버전이다 — 그 PR들은 이 파일들을 읽기만 하고 수정하지 않았으므로 겹치는 파일이 없다.

## Test plan

- Not run: 문서만 수정, 별도 실행 없음.