### PR TITLE
refactor(proxy): proxy를 named export로 전환한다

### DIFF
--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -59,7 +59,7 @@ root layout을 통째로 대체하기 때문에 생기는 제약:
 - **`page.tsx`는 Pages 단계만 담당한다** — 실제 데이터를 fetch/조립해서 Template(`src/ui/components/templates/{Name}Template.tsx` 또는 그 라우트 `_components/{Name}Template.tsx`)에 props로 넘기는 것까지만 한다. organism을 배치(grid/flex/spacing 등)하는 코드가 하나라도 있으면 Template 추출이 필수다 — organism 딱 1개를 배치 코드 없이 그대로 렌더하는 경우에 한해서만 `page.tsx`가 직접 렌더할 수 있다. Template은 `layout.tsx`(라우트 그룹 셸)와 다른 층위다 — Template은 항상 그 layout.tsx 안에 중첩된다. (Template 자격 조건 자체 — 순수성 등 — 은 `src/ui/components/templates/AGENTS.md` 소관.)
 - self-fetching 자식(자기 데이터를 직접 fetch하는 Server Component, Suspense 스트리밍)이 필요해도 Template 순수성 규칙에 예외를 두지 않는다 — 그 자식은 `_containers/`에 두고, Template은 `children: ReactNode` prop으로만 받아 배치한다(`<Template ...><ReviewsContainer productId={id} /></Template>`). Template은 `children`이 뭘 하는지 모른 채 자리만 내주므로 데이터 페칭·도메인 로직을 여전히 두지 않는 것과 같다.
 - `_components`/`_containers`/`_types`/`_utils`/`_constants`/`_hooks`를 폴더 + `index.ts`(컴포넌트는 `index.tsx`) 배럴 형태 외의 방식으로 만들지 않는다 — 폴더 안 파일이 1개뿐이어도 예외 없이 이 형태를 유지한다. **배럴은 `page.tsx`/`layout.tsx`가 직접 소비하는 파일만 재export하면 된다** — 같은 폴더 안 다른 파일에서만 내부적으로 쓰이고 `page.tsx`/`layout.tsx`가 직접 import 안 하는 파일(예: `_components/Navigation.tsx`가 `_components/LocationSection.tsx` 내부에서만 쓰이는 경우)은 배럴에 안 올려도 된다 — 배럴 목적이 "그 라우트 밖에서 이 폴더에 뭐가 있는지 알려주는 것"이지 폴더 안 모든 파일을 강제로 노출하는 게 아니다.
-- **`page.tsx`/`layout.tsx`/`loading.tsx`/`error.tsx`/`not-found.tsx`/`proxy.ts`는 `export default`를 쓴다** — Next.js가 강제하는 파일 컨벤션이다.
+- **`page.tsx`/`layout.tsx`/`loading.tsx`/`error.tsx`/`not-found.tsx`/`template.tsx`/`default.tsx`는 `export default`를 쓴다** — Next.js가 강제하는 파일 컨벤션이다. `route.ts`는 반대로 `GET`/`POST` 등 메서드명 named export를 강제한다(`api/AGENTS.md`). `proxy.ts`는 default와 named `proxy`를 모두 지원하므로 강제 대상이 아니며 `src/` 공통 규칙대로 named export를 쓴다.
 
 ## References
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,7 +8,7 @@ import { routes } from "@/core/domain";
  * Auth && User
  */
 
-export default async function proxy(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const tokenCookie = request.cookies.get("token");
 

--- a/src/proxy.unit.test.ts
+++ b/src/proxy.unit.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import { NextRequest } from "next/server";
 import { encrypt } from "@/adapters/server/jose";
-import proxy from "./proxy";
+import { proxy } from "./proxy";
 
 const buildRequest = (path: string, token?: string) => {
   const headers: Record<string, string> = {};


### PR DESCRIPTION
## Summary

- Next.js 공식 문서(16.2.10, `01-app/03-api-reference/03-file-conventions/proxy.md`)는 proxy 파일에 대해 "The file must export a single function, either as a default export or named `proxy`"라고 명시한다. 즉 `export default`는 프레임워크 강제가 아니라 선택이었다.
- `src/AGENTS.md`는 `src/` 안 파일에 `export default`를 금지하고 named export를 강제하는데, `src/proxy.ts`만 근거 없이 이를 벗어나 있었다. named export로 전환해 공통 규칙에 맞췄다. 이제 `src/` 전체에서 `export default`는 `src/app/` 라우트 파일에만 남는다.
- `src/app/AGENTS.md`의 default export 강제 파일 목록을 문서 기준으로 정정했다. `proxy.ts`를 제거하고, 누락돼 있던 `template.tsx`와 `default.tsx`를 추가했으며, `route.ts`가 반대로 메서드명 named export를 강제한다는 점을 함께 명시했다.

## Test plan

- `npx vitest run --project unit src/proxy.unit.test.ts` — 10 passed
- `npm run build` — 성공, 빌드 출력에 `ƒ Proxy (Middleware)` 표시되어 named export가 정상 등록됨을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqQsi9pPxYy57h7nsUcvYF