### PR TITLE
ci: 배럴 파일 재등장을 빌드 실패로 막는다

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,6 +32,7 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm ci
       - run: npm run lint
+      - run: npm run lint:barrels
       - run: npm run tsc
       - name: Build
         run: npm run build

--- a/docs/decisions/0004-explicit-module-paths-over-barrels.md
+++ b/docs/decisions/0004-explicit-module-paths-over-barrels.md
@@ -55,3 +55,4 @@ Next.js가 파일 규약으로 강제하는 `src/app/` 라우트 파일은 이 �
 - [ADR-0002](0002-adapter-runtime-segments.md)
 - [#207](https://github.com/rhsiddlsidhd/tie-knot/issues/207)
 - [#210](https://github.com/rhsiddlsidhd/tie-knot/issues/210)
+- [#213](https://github.com/rhsiddlsidhd/tie-knot/pull/213), [#214](https://github.com/rhsiddlsidhd/tie-knot/pull/214), [#215](https://github.com/rhsiddlsidhd/tie-knot/pull/215), [#216](https://github.com/rhsiddlsidhd/tie-knot/pull/216), [#217](https://github.com/rhsiddlsidhd/tie-knot/pull/217), [#218](https://github.com/rhsiddlsidhd/tie-knot/pull/218), [#219](https://github.com/rhsiddlsidhd/tie-knot/pull/219)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "lint:barrels": "node scripts/check-no-barrels.mjs",
     "tsc": "next typegen && tsc --noEmit",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",

--- a/scripts/check-no-barrels.mjs
+++ b/scripts/check-no-barrels.mjs
@@ -1,0 +1,30 @@
+// ADR-0004: src/ 안에 배럴(index.ts/index.tsx)을 두지 않는다.
+//
+// 배럴 파일이 없으면 `@/services` 같은 디렉터리 지정 import는 모듈 해석 단계에서
+// 실패하므로 `npm run tsc`가 잡는다. 따라서 이 검사 하나로 두 규칙이 함께 강제된다.
+import fs from "node:fs";
+import path from "node:path";
+
+const SRC = path.join(process.cwd(), "src");
+
+const walk = (dir, out = []) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (/^index\.tsx?$/.test(entry.name)) out.push(path.relative(process.cwd(), full));
+  }
+  return out;
+};
+
+const found = walk(SRC).sort();
+
+if (found.length > 0) {
+  console.error(
+    `배럴 파일 ${found.length}개를 찾았다. src/ 안에는 index.ts/index.tsx를 두지 않는다.\n` +
+      `심볼이 정의된 파일을 직접 지정해 import한다 — docs/decisions/0004-explicit-module-paths-over-barrels.md\n`,
+  );
+  found.forEach((f) => console.error(`  ${f}`));
+  process.exit(1);
+}
+
+console.log("배럴 없음 — src/ 안에 index.ts/index.tsx가 없다.");

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -19,7 +19,7 @@
 - matcher 없이 Proxy를 배포하지 않는다 — 공식 문서: matcher가 없으면 정적 파일(`_next/static`)·이.미지 최적화(`_next/image`)·`public/` 자산까지 모든 요청에서 실행돼, 의도치 않게 CSS/JS/이미지 로딩을 막을 수 있다
 - Proxy 안에서 느린 데이터 페칭(외부 API 호출 등)을 하지 않는다 — 공식 문서: Proxy는 느린 데이터 페칭 용도가 아니며, 세션 관리·인가의 전체 솔루션으로 쓰여서도 안 된다(낙관적 체크 용도로만).
 - 프로젝트당 두 번째 proxy 파일을 만들지 않는다 — 공식 문서: 프로젝트당 `proxy.ts` 단 하나만 지원한다. 로직을 나누고 싶으면 별도 모듈로 쪼갠 뒤 그 안에서 import해서 조립한다.
-- **`src/` 안에 배럴(`index.ts`/`index.tsx`)을 만들지 않고, 디렉터리를 가리키는 import도 쓰지 않는다 — 심볼이 실제로 정의된 파일을 지정한다**(`@/services/auth`, `@/models/user.model`). 모듈 그래프가 심볼이 아니라 모듈 단위로 계산되므로, 배럴은 쓰지 않는 형제 모듈까지 그래프에 끌어들여 `vitest related`·`--changed`·watch·mutation 도구를 무력화한다. 근거와 측정값은 `docs/decisions/0004-explicit-module-paths-over-barrels.md` 참고.
+- **`src/` 안에 배럴(`index.ts`/`index.tsx`)을 만들지 않고, 디렉터리를 가리키는 import도 쓰지 않는다 — 심볼이 실제로 정의된 파일을 지정한다**(`@/services/auth`, `@/models/user.model`). 모듈 그래프가 심볼이 아니라 모듈 단위로 계산되므로, 배럴은 쓰지 않는 형제 모듈까지 그래프에 끌어들여 `vitest related`·`--changed`·watch·mutation 도구를 무력화한다. 근거와 측정값은 `docs/decisions/0004-explicit-module-paths-over-barrels.md` 참고. `npm run lint:barrels`가 CI에서 이를 강제한다 — 배럴이 없으면 디렉터리 지정 import는 모듈 해석 단계에서 실패하므로 `npm run tsc`가 함께 잡는다.
 - **`src/` 안 파일은 `export default`를 쓰지 않는다 — 전부 named export로 짓는다.** 단 `src/app/`의 Next.js 라우트 파일은 프레임워크가 `export default`를 강제하므로 예외이며, 대상 파일 목록은 `src/app/AGENTS.md`를 따른다.
 - 폴더의 공개 API를 재수출 목록으로 선언하지 않는다 — 무엇을 외부에서 써도 되는지는 각 계층 `AGENTS.md`의 역할 경계가 규정한다.
 - 로컬 상태로 충분한 걸 곧바로 Context나 Zustand로 확장하지 않는다 — 클라이언트 상태 범위는 로컬 → Context API(`src/ui/context/`) → Zustand(`src/ui/stores/`) 순으로만 넓힌다.


### PR DESCRIPTION
## Summary

- ADR-0004 마이그레이션의 마지막 단계다. 배럴을 다시 만들면 CI가 실패하도록 `scripts/check-no-barrels.mjs`를 추가하고 `npm run lint:barrels`로 노출한 뒤 `static` workflow에 단계로 넣었다.
- 검사는 "`src/` 안에 `index.ts`/`index.tsx`가 없다" 하나만 본다. 배럴이 없으면 `@/services` 같은 디렉터리 지정 import는 모듈 해석 단계에서 실패하므로 나머지 절반은 기존 `npm run tsc`가 함께 잡는다. ADR이 요구한 "사람 판단이 아니라 도구로 강제된다"가 이 두 단계로 성립한다.
- eslint 규칙으로 표현하지 않은 이유는 `no-restricted-imports`가 지정자 문자열만 보기 때문이다. `@/proxy`, `@/boundary`처럼 정당한 단일 세그먼트 파일 import와 `@/services` 같은 디렉터리 import를 패턴만으로 구분할 수 없어, 파일시스템 검사가 더 정확하다.
- `src/AGENTS.md`의 금지 규칙에 강제 수단을 명시하고, ADR-0004의 「관련 이력」에 마이그레이션 PR 7건을 기록했다.

## Test plan

- `npm run lint:barrels` — "배럴 없음" 출력, exit 0
- 음성 대조: `src/db/index.ts`를 임시로 만든 뒤 재실행 — exit 1과 해당 경로 출력을 확인하고 삭제했다
- `npm run lint` — 12 problems (4 errors, 8 warnings). 변경 전 `dev`와 동일한 기존 문제
- `npm run tsc` — 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqQsi9pPxYy57h7nsUcvYF