### PR TITLE
refactor(vitest): unit·component project 범위를 좁혀 tier를 하나로 확정한다

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { loadEnvConfig } from "@next/env";
@@ -27,6 +27,8 @@ export default defineConfig({
             "src/adapters/server/**/*.unit.test.ts",
             "src/core/**/*.unit.test.ts",
             "src/app/api/**/*.unit.test.ts",
+            "src/ui/stores/slices/**/*.unit.test.ts",
+            "src/ui/context/**/reducer.unit.test.ts",
             "src/boundary.unit.test.ts",
             "src/proxy.unit.test.ts",
           ],
@@ -43,6 +45,12 @@ export default defineConfig({
             "src/ui/**/*.component.test.{ts,tsx}",
             "src/app/**/*.component.test.{ts,tsx}",
             "src/adapters/browser/**/*.component.test.ts",
+          ],
+          exclude: [
+            ...configDefaults.exclude,
+            "src/app/api/**",
+            "src/ui/stores/slices/**",
+            "src/ui/context/**/reducer.*",
           ],
           setupFiles: ["./test/support/setup/jsdom-polyfill.ts"],
           maxWorkers: 2,


### PR DESCRIPTION
## Summary

- `unit` project의 include에 `src/ui/stores/slices/**/*.unit.test.ts`와 `src/ui/context/**/reducer.unit.test.ts`를 추가하고, `component` project에 `configDefaults.exclude`를 스프레드한 exclude를 신설해 `src/app/api/**`, `src/ui/stores/slices/**`, `src/ui/context/**/reducer.*`를 닫았다.
- 새 규칙이 아니라 이미 문서가 규정한 내용을 config에 반영한 것이다. 근거: `docs/__test/unit.md`(reducer·Zustand store·Route Handler는 unit), `src/ui/stores/AGENTS.md`, `src/ui/context/AGENTS.md`.
- 그 결과 slice·reducer 소스가 unit·component 후보를 동시에 내던 패턴 겹침이 사라지고, 모든 소스 파일이 정확히 하나의 tier로 확정된다.
- 현재 slice·reducer 테스트 파일이 아직 없어 수집되는 테스트 파일 집합은 변하지 않는다. 앞으로 작성될 테스트의 배치 기준을 미리 확정하는 변경이다.

## Test plan

- `npx vitest list --filesOnly --project unit --project component` — 변경 전후 모두 133개(unit 28 / component 105), diff 없음
- `npm run tsc` — 통과
- `npm run lint` — `4 errors, 8 warnings`. 변경 전 `dev`에서도 동일해 이 PR과 무관한 기존 상태다
- `npm run build` — 통과
- `npm run test` — `Test Files 5 failed | 145 passed (150)`, `Tests 17 failed | 947 passed (964)`. 변경 전 `dev`에서 동일한 수치를 확인해 회귀 없음(#209 StoreProvider 계열)
