### PR TITLE
feat(tdd-gate): test 없는 src 편집을 막는 PreToolUse·Stop 훅을 추가한다

### DIFF
--- a/.claude/hooks/tdd-gate/post-tool-use.mjs
+++ b/.claude/hooks/tdd-gate/post-tool-use.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * 이번 턴에 실제로 편집된 강제 대상 경로를 기록한다. Stop hook(Lever B)이 소비한다.
+ * 훅이 파일을 쓰는 유일한 지점이다.
+ */
+
+import fs from "node:fs";
+import { ensureCacheDir, inspect, turnFile } from "./resolver.mjs";
+
+async function main() {
+  const payload = JSON.parse(await readStdin());
+  if (!["Write", "Edit", "MultiEdit"].includes(payload.tool_name)) return;
+
+  const filePath = payload.tool_input?.file_path;
+  if (!filePath) return;
+
+  const target = await inspect(filePath);
+  if (!target.enforced) return;
+
+  ensureCacheDir();
+  fs.appendFileSync(turnFile(payload.session_id), `${target.relPath}\n`);
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (c) => (data += c));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    process.stderr.write(`tdd-gate(post-tool-use) fail-open: ${err?.stack ?? err}\n`);
+    process.exit(0);
+  });

--- a/.claude/hooks/tdd-gate/pre-tool-use.mjs
+++ b/.claude/hooks/tdd-gate/pre-tool-use.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Lever A — PreToolUse(Write|Edit).
+ *
+ *   기존 파일 수정 → 형제 test 존재만 확인한다(TDD 3단계 refactor 는 green 에서 일어난다).
+ *   신규 파일 생성 → 형제 test 존재 + 그 test 가 red 인지 확인한다(TDD 1단계).
+ *
+ * 예외·파싱 실패는 전부 fail-open 이다. 게이트 버그가 작업을 막으면 안 된다.
+ */
+
+import { inspect } from "./resolver.mjs";
+import { runSiblings } from "./run-tests.mjs";
+
+const DOCS = (tier) => `docs/__test/${tier}.md`;
+
+function deny(reason) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+async function main() {
+  const payload = JSON.parse(await readStdin());
+  if (!["Write", "Edit", "MultiEdit"].includes(payload.tool_name)) return;
+
+  const filePath = payload.tool_input?.file_path;
+  if (!filePath) return;
+
+  const target = await inspect(filePath);
+  if (!target.enforced) return;
+
+  const { relPath, tier, recommended, siblings, exists } = target;
+
+  if (siblings.length === 0) {
+    // .tsx 도 config 가 허용할 때만 단서를 붙인다. adapters/browser 처럼 .ts 고정인
+    // 자리에서는 잘못된 안내가 된다.
+    const tsxAllowed = target.candidates.some((c) => c.suffix.endsWith(".tsx"));
+    const jsxHint =
+      recommended.suffix.endsWith(".ts") && tsxAllowed
+        ? " JSX 래퍼가 필요하면 확장자를 .tsx 로 바꿔라."
+        : "";
+    deny(
+      [
+        `TDD gate: ${relPath} 에 대응하는 ${tier} test 가 없다.`,
+        ``,
+        `먼저 작성할 파일: ${recommended.path}`,
+        `tier: ${tier} — 작성 규칙은 ${DOCS(tier)} 를 따른다.${jsxHint}`,
+        ``,
+        `test 를 먼저 쓰고 나서 이 편집을 다시 시도해라.`,
+        `이 파일이 정말 test 대상이 아니라면 .claude/tdd-gate.json 의 exclude 에 추가해라.`,
+      ].join("\n"),
+    );
+  }
+
+  if (exists) return; // 기존 수정: 형제 test 존재만으로 통과
+
+  const { green } = runSiblings(siblings);
+  if (green) {
+    deny(
+      [
+        `TDD gate: ${relPath} 는 신규 파일인데 형제 test 가 이미 통과한다.`,
+        ``,
+        `통과 중인 test: ${siblings.map((s) => s.path).join(", ")}`,
+        `처음부터 통과하는 test 로는 새 파일을 정당화하지 못한다.`,
+        `이 파일이 없으면 실패하는 test 를 먼저 추가해 red 를 만든 뒤 다시 시도해라.`,
+      ].join("\n"),
+    );
+  }
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (c) => (data += c));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    process.stderr.write(`tdd-gate(pre-tool-use) fail-open: ${err?.stack ?? err}\n`);
+    process.exit(0);
+  });

--- a/.claude/hooks/tdd-gate/resolver.mjs
+++ b/.claude/hooks/tdd-gate/resolver.mjs
@@ -1,0 +1,239 @@
+/**
+ * TDD gate resolver.
+ *
+ * 게이트는 판단하지 않는다. 이미 선언된 사실만 읽는다.
+ *   - vitest.config.ts 의 project include/exclude → 어떤 test 경로가 어느 tier에 속하는가
+ *   - .claude/tdd-gate.json 의 exclude          → 어떤 소스가 강제 대상 밖인가
+ *   - 파일 존재 여부                              → 형제 test 가 이미 있는가
+ *
+ * 새 규칙을 여기에 발명하지 마라. 예외가 필요하면 .claude/tdd-gate.json 에 적는다.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import picomatch from "picomatch";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const ROOT = path.resolve(HERE, "..", "..", "..");
+
+const VITEST_CONFIG = path.join(ROOT, "vitest.config.ts");
+const TSCONFIG = path.join(ROOT, "tsconfig.json");
+const POLICY_FILE = path.join(ROOT, ".claude", "tdd-gate.json");
+
+export const CACHE_DIR = path.join(ROOT, "node_modules", ".cache", "tdd-gate");
+const CONFIG_CACHE = path.join(CACHE_DIR, "projects.json");
+
+/** 게이트가 다루는 tier. integration 은 test/ 아래 별도 트리라 형제 매핑 밖이다. */
+const GATE_TIERS = ["unit", "component"];
+
+const TEST_FILE_RE = /\.(unit|component|integration)\.test\.tsx?$/;
+
+/** 이번 턴에 편집된 강제 대상 경로 기록. PostToolUse 가 쓰고 Stop 이 소비한다. */
+export function turnFile(sessionId) {
+  const safe = String(sessionId ?? "unknown").replace(/[^a-zA-Z0-9_-]/g, "");
+  return path.join(CACHE_DIR, `turn-${safe}.txt`);
+}
+
+export function ensureCacheDir() {
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+}
+
+export function toPosix(p) {
+  return p.split(path.sep).join("/");
+}
+
+/** 절대경로·상대경로·`@/`·`@test/` 를 전부 repo 루트 기준 posix 상대경로로 정규화한다. */
+export function toRelative(filePath) {
+  if (!filePath) return null;
+  const aliased = expandAlias(filePath);
+  const abs = path.isAbsolute(aliased) ? aliased : path.resolve(ROOT, aliased);
+  const rel = path.relative(ROOT, abs);
+  if (!rel || rel.startsWith("..")) return null;
+  return toPosix(rel);
+}
+
+let aliasCache = null;
+
+/** tsconfig.json 의 paths 가 alias 의 원본이다. */
+function loadAliases() {
+  if (aliasCache) return aliasCache;
+  const entries = [];
+  try {
+    const raw = fs.readFileSync(TSCONFIG, "utf8");
+    const paths = JSON.parse(stripJsonComments(raw))?.compilerOptions?.paths ?? {};
+    for (const [pattern, targets] of Object.entries(paths)) {
+      if (!pattern.endsWith("/*") || !targets?.[0]?.endsWith("/*")) continue;
+      entries.push({
+        prefix: pattern.slice(0, -1),
+        target: targets[0].slice(0, -1).replace(/^\.\//, ""),
+      });
+    }
+  } catch {
+    // fail-open: alias 를 못 읽어도 절대·상대 경로는 그대로 처리된다.
+  }
+  aliasCache = entries;
+  return entries;
+}
+
+function expandAlias(p) {
+  for (const { prefix, target } of loadAliases()) {
+    if (p.startsWith(prefix)) return target + p.slice(prefix.length);
+  }
+  return p;
+}
+
+function stripJsonComments(raw) {
+  return raw.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+export function isTestFile(relPath) {
+  return TEST_FILE_RE.test(relPath);
+}
+
+/** .claude/tdd-gate.json — 강제 대상에서 뺄 소스 glob. 없으면 빈 목록(fail-open). */
+export function loadExcludes() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(POLICY_FILE, "utf8"));
+    return Array.isArray(parsed?.exclude) ? parsed.exclude : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * vitest.config.ts 의 unit·component project 에서 include/exclude 만 뽑는다.
+ * 로드가 196ms 라 mtime 으로 캐시한다.
+ */
+export async function loadProjects() {
+  const mtimeMs = fs.statSync(VITEST_CONFIG).mtimeMs;
+
+  try {
+    const cached = JSON.parse(fs.readFileSync(CONFIG_CACHE, "utf8"));
+    if (cached.mtimeMs === mtimeMs) return cached.projects;
+  } catch {
+    // 캐시 부재·손상은 정상 경로다. 다시 읽는다.
+  }
+
+  const { loadConfigFromFile } = await import("vite");
+  const loaded = await loadConfigFromFile(
+    { command: "serve", mode: "test" },
+    VITEST_CONFIG,
+    ROOT,
+    "silent",
+  );
+
+  const projects = (loaded?.config?.test?.projects ?? [])
+    .map((entry) => entry?.test)
+    .filter((t) => t && GATE_TIERS.includes(t.name))
+    .map((t) => ({
+      name: t.name,
+      include: t.include ?? [],
+      // exclude 를 선언한 project 는 vitest 기본값을 대체한다. 여기서 기본값이
+      // 하는 일은 node_modules 류 배제뿐이라 src 후보 판정에는 영향이 없다.
+      exclude: t.exclude ?? [],
+    }));
+
+  try {
+    ensureCacheDir();
+    fs.writeFileSync(CONFIG_CACHE, JSON.stringify({ mtimeMs, projects }));
+  } catch {
+    // 캐시 저장 실패는 판정에 영향이 없다.
+  }
+
+  return projects;
+}
+
+function matchesAny(globs, relPath) {
+  return globs.some((g) => picomatch.isMatch(relPath, g, { dot: true }));
+}
+
+/**
+ * 소스 경로 하나에 대해 config 가 허용하는 형제 test 후보를 뽑는다.
+ * 후보를 만들어 picomatch 에 물을 뿐, tier 규칙을 발명하지 않는다.
+ */
+export async function resolveCandidates(relPath) {
+  const projects = await loadProjects();
+  const base = relPath.replace(/\.[^./]+$/, "");
+  const suffixes = ["unit.test.ts", "component.test.ts", "component.test.tsx"];
+
+  const candidates = [];
+  for (const suffix of suffixes) {
+    const testPath = `${base}.${suffix}`;
+    for (const project of projects) {
+      if (!matchesAny(project.include, testPath)) continue;
+      if (matchesAny(project.exclude, testPath)) continue;
+      candidates.push({ path: testPath, tier: project.name, suffix });
+    }
+  }
+  return candidates;
+}
+
+/**
+ * 권장 test 경로: 소스 확장자를 승계한다(.ts→.ts, .tsx→.tsx).
+ * 승계한 확장자가 config 에서 허용되지 않으면 허용되는 유일값으로 떨어진다
+ * (예: adapters/browser 는 .ts 고정).
+ */
+export function recommend(relPath, candidates) {
+  if (candidates.length === 0) return null;
+  const ext = path.extname(relPath).replace(".", "");
+  return candidates.find((c) => c.suffix.endsWith(`.${ext}`)) ?? candidates[0];
+}
+
+/** `<base>.<suffix>` 와 `<base>.<관점>.<suffix>` 를 둘 다 형제로 인정한다. */
+export function findSiblings(relPath, candidates) {
+  const base = relPath.replace(/\.[^./]+$/, "");
+  const dir = path.posix.dirname(base);
+  const stem = path.posix.basename(base);
+
+  let entries;
+  try {
+    entries = fs.readdirSync(path.join(ROOT, dir));
+  } catch {
+    return [];
+  }
+
+  const allowed = new Set(candidates.map((c) => c.suffix));
+  const tierOf = new Map(candidates.map((c) => [c.suffix, c.tier]));
+  const escaped = stem.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escaped}(?:\\.[^.]+)?\\.((?:unit|component)\\.test\\.tsx?)$`);
+
+  const found = [];
+  for (const entry of entries) {
+    const m = re.exec(entry);
+    if (!m || !allowed.has(m[1])) continue;
+    found.push({ path: path.posix.join(dir, entry), tier: tierOf.get(m[1]) });
+  }
+  return found;
+}
+
+/**
+ * 강제 대상 판정. 아래 4조건을 전부 만족해야 게이트가 개입한다.
+ *   src/ 안 · test 파일 아님 · policy exclude 아님 · config 가 형제 test 를 허용함
+ */
+export async function inspect(filePath) {
+  const relPath = toRelative(filePath);
+  if (!relPath) return { relPath: null, enforced: false, reason: "outside-repo" };
+  if (!relPath.startsWith("src/")) return { relPath, enforced: false, reason: "outside-src" };
+  if (isTestFile(relPath)) return { relPath, enforced: false, reason: "test-file" };
+  if (matchesAny(loadExcludes(), relPath)) {
+    return { relPath, enforced: false, reason: "policy-excluded" };
+  }
+
+  const candidates = await resolveCandidates(relPath);
+  if (candidates.length === 0) {
+    return { relPath, enforced: false, reason: "no-tier", candidates };
+  }
+
+  const tiers = [...new Set(candidates.map((c) => c.tier))];
+  return {
+    relPath,
+    enforced: true,
+    candidates,
+    tiers,
+    tier: tiers[0],
+    recommended: recommend(relPath, candidates),
+    siblings: findSiblings(relPath, candidates),
+    exists: fs.existsSync(path.join(ROOT, relPath)),
+  };
+}

--- a/.claude/hooks/tdd-gate/run-tests.mjs
+++ b/.claude/hooks/tdd-gate/run-tests.mjs
@@ -1,0 +1,36 @@
+/** 형제 test 를 tier 별로 좁혀 실행한다. --project 로 좁히지 않으면 integration 의
+ *  mongo globalSetup 이 같이 기동해 비용이 폭증한다. */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { ROOT } from "./resolver.mjs";
+
+const VITEST_BIN = path.join(ROOT, "node_modules", ".bin", "vitest");
+
+/** @param {{path: string, tier: string}[]} siblings */
+export function runSiblings(siblings, timeout = 180_000) {
+  const byTier = new Map();
+  for (const s of siblings) {
+    if (!byTier.has(s.tier)) byTier.set(s.tier, []);
+    byTier.get(s.tier).push(s.path);
+  }
+
+  const failures = [];
+  for (const [tier, paths] of byTier) {
+    const result = spawnSync(
+      VITEST_BIN,
+      ["run", "--project", tier, "--reporter=dot", ...paths],
+      { cwd: ROOT, encoding: "utf8", timeout, env: { ...process.env, CI: "1" } },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      failures.push({ tier, paths, output: tail(result.stdout, result.stderr) });
+    }
+  }
+  return { green: failures.length === 0, failures };
+}
+
+function tail(stdout, stderr) {
+  const lines = `${stdout ?? ""}${stderr ?? ""}`.trimEnd().split("\n");
+  return lines.slice(-25).join("\n");
+}

--- a/.claude/hooks/tdd-gate/stop.mjs
+++ b/.claude/hooks/tdd-gate/stop.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Lever B — Stop hook.
+ *
+ * 이번 턴에 편집된 강제 대상의 형제 test 를 실행하고, red 면 종료를 막는다(TDD 2단계).
+ * stop_hook_active 가 켜져 있으면 무한 루프 방지를 위해 기록만 비우고 통과시킨다.
+ */
+
+import fs from "node:fs";
+import { inspect, turnFile } from "./resolver.mjs";
+import { runSiblings } from "./run-tests.mjs";
+
+function block(reason) {
+  process.stdout.write(JSON.stringify({ decision: "block", reason }));
+  process.exit(0);
+}
+
+async function main() {
+  const payload = JSON.parse(await readStdin());
+  const file = turnFile(payload.session_id);
+
+  let edited;
+  try {
+    edited = [...new Set(fs.readFileSync(file, "utf8").split("\n").filter(Boolean))];
+  } catch {
+    return; // 기록 없음 = 강제 대상 편집 없음
+  }
+
+  if (payload.stop_hook_active) {
+    fs.rmSync(file, { force: true });
+    return;
+  }
+
+  const siblings = [];
+  for (const relPath of edited) {
+    const target = await inspect(relPath);
+    if (target.enforced) siblings.push(...target.siblings);
+  }
+
+  if (siblings.length === 0) {
+    fs.rmSync(file, { force: true });
+    return;
+  }
+
+  const { green, failures } = runSiblings(dedupe(siblings));
+  if (green) {
+    fs.rmSync(file, { force: true });
+    return;
+  }
+
+  block(
+    [
+      `TDD gate: 이번 턴에 편집한 파일의 test 가 실패한다. green 을 만들고 끝내라.`,
+      ``,
+      ...failures.map((f) => `[${f.tier}] ${f.paths.join(", ")}\n${f.output}`),
+    ].join("\n"),
+  );
+}
+
+function dedupe(siblings) {
+  const seen = new Map();
+  for (const s of siblings) seen.set(s.path, s);
+  return [...seen.values()];
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (c) => (data += c));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    process.stderr.write(`tdd-gate(stop) fail-open: ${err?.stack ?? err}\n`);
+    process.exit(0);
+  });

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/tdd-gate/pre-tool-use.mjs\"",
+            "timeout": 180
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/tdd-gate/post-tool-use.mjs\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/tdd-gate/stop.mjs\"",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/tdd-gate.json
+++ b/.claude/tdd-gate.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "TDD gate 강제 대상에서 제외할 소스 glob. 원본은 각 AGENTS.md 이며 이 파일은 사본이다.",
+  "exclude": [
+    "**/*.d.ts",
+    "**/type.ts",
+    "**/types.ts",
+    "**/_types/**",
+    "**/_constants/**",
+    "src/core/domain/**",
+    "src/ui/stores/app.store.ts",
+    "src/ui/stores/provider.tsx",
+    "src/ui/stores/use-app-store.ts",
+    "src/ui/context/*/provider.tsx"
+  ]
+}


### PR DESCRIPTION
## Summary

- TDD gate 훅 2레버를 추가한다. `.claude/settings.json`에 등록하므로 이 repo에서 작업하는 모두에게 적용된다.
  - **Lever A** (`PreToolUse`, `Write|Edit|MultiEdit`) — 강제 대상 소스에 형제 test가 없으면 `permissionDecision: "deny"`. 신규 파일 생성이면 형제 test가 실제로 red인지까지 확인하고, green이면 "처음부터 통과하는 test로는 새 파일을 정당화하지 못한다"로 거부한다.
  - **Lever B** (`Stop`) — `PostToolUse`가 기록한 이번 턴 편집 경로의 형제 test를 `--project {tier}`로 좁혀 실행하고, red면 `decision: "block"`.
- **게이트는 판단하지 않는다.** 이미 선언된 사실만 읽는다 — `vitest.config.ts`의 project include/exclude, `.claude/tdd-gate.json`의 exclude, 파일 존재, 실행 결과. tier 판정 규칙을 훅 코드에 발명하지 않고, 후보 3개(`.unit.test.ts` / `.component.test.ts` / `.component.test.tsx`)를 만들어 picomatch에 물어본다.
- 예외가 필요하면 훅 코드가 아니라 `.claude/tdd-gate.json`의 exclude에 적는다. 이 목록은 각 `AGENTS.md`가 원본이고 이 파일은 사본이다.
- 예외·파싱 실패·캐시 손상은 전부 fail-open(통과 + stderr 경고)이다. 게이트 버그가 작업을 막으면 안 된다.
- 훅은 파일을 쓰지 않는다. `PostToolUse`의 턴 기록(`node_modules/.cache/tdd-gate/`)만 예외다.

### 파일

| 파일 | 역할 |
| --- | --- |
| `.claude/hooks/tdd-gate/resolver.mjs` | 후보 생성·tier 확정·형제 탐색, config 로드와 mtime 캐시 |
| `.claude/hooks/tdd-gate/run-tests.mjs` | 형제 test를 tier별로 좁혀 실행 |
| `.claude/hooks/tdd-gate/pre-tool-use.mjs` | Lever A |
| `.claude/hooks/tdd-gate/post-tool-use.mjs` | 턴 기록 append |
| `.claude/hooks/tdd-gate/stop.mjs` | Lever B |
| `.claude/tdd-gate.json` | exclude 배열 |
| `.claude/settings.json` | 훅 3개 등록 |

### 알려진 범위

- Lever A는 `Write|Edit|MultiEdit`만 잡는다. `Bash`의 `sed -i`나 스크립트를 통한 파일 쓰기는 우회된다 — 의도된 범위이며 최종 방어선은 CI(`npm run test`)다.
- Stop hook은 `stop_hook_active`가 켜져 있으면 무한 루프 방지를 위해 기록만 비우고 통과시킨다.
- `integration` tier는 `test/` 아래 별도 트리라 형제 매핑 밖이고 게이트가 다루지 않는다.

## Test plan

- 리졸버 단위 검증 8건 — 전부 기대값 일치
  - `src/actions/refundOrder.ts` → `[unit] refundOrder.unit.test.ts`
  - `src/app/api/banks/route.ts` → `[unit] route.unit.test.ts`
  - `src/ui/hooks/useFoo.ts` → `[component] useFoo.component.test.ts`
  - `src/ui/components/atoms/Btn.tsx` → `[component] Btn.component.test.tsx`
  - `src/adapters/browser/x/w.tsx` → `[component] w.component.test.ts` (`.tsx` 아님)
  - `src/ui/stores/slices/order.slice.ts` → `[unit] order.slice.unit.test.ts`
  - `src/services/auth.ts` → 범위 밖(통과)
  - `src/core/domain/order.ts` → exclude(통과)
- 전 `src` 파일 스윕(573개) — 강제 대상 374 / exclude 46 / 범위 밖 20 / test 133. **tier가 2개 이상으로 갈리는 파일 0건**
- Lever A 실증 — 실제로 `src/ui/stores/slices/admin-modal.slice.ts`에 `Edit`을 시도해 deny 확인, 파일은 변경되지 않았다
- Lever A 신규 파일 분기 — 형제 test가 green이면 deny, red면 통과를 각각 확인
- Lever B — 형제 test가 red인 턴 기록에 대해 `{"decision":"block"}` 반환, green이면 무출력 + 기록 정리 확인. `stop_hook_active: true`면 통과 확인
- mtime 캐시 — cold 109ms / cached 8ms, `vitest.config.ts` touch 후 재로드, 캐시 파일 손상 시 재계산 확인
- `npm run tsc` — 통과
- `npm run lint` — `4 errors, 8 warnings`. `dev`에서도 동일한 기존 상태다(`.claude/hooks/**`는 eslint ignore 대상)
- `npm run build` — `Compiled successfully`
- `npm run test` — `Test Files 5 failed | 145 passed (150)`, `Tests 17 failed | 947 passed (964)`. `dev`와 동일해 회귀 없음(#209 StoreProvider 계열)

> Stop hook은 이번 턴 밖에서 발화하므로 세션 내 동작 증명이 안 된다. 위 Lever B 검증은 훅 스크립트에 실제 `Stop` payload를 직접 주입해 수행했다.

Supersedes #226 — #225를 `--delete-branch`로 squash merge하면서 base 브랜치가 사라져 원래 PR이 닫혔다. 브랜치를 `dev`에 리베이스해 다시 연 것이며 내용은 동일하다.

Related to #209
