### PR TITLE
test: dev 브랜치에서 깨져 있던 테스트 17건을 복구한다

### DIFF
--- a/src/app/(admin)/admin/products/_components/ProductTableRowAction.component.test.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRowAction.component.test.tsx
@@ -23,7 +23,10 @@ import { restoreProduct } from "@/actions/restoreProduct";
 import { permanentlyDeleteProduct } from "@/actions/permanentlyDeleteProduct";
 import type { Product } from "@/core/domain/product";
 import { ProductTableRowAction } from "./ProductTableRowAction";
+import type { ProductTableRowProps } from "./ProductTableRow";
 import { MOBILE_INVITATION_CATEGORY } from "@/core/domain/product-category";
+import { createAppStore, type AppStoreApi } from "@/ui/stores/app.store";
+import { StoreProvider } from "@/ui/stores/provider";
 
 const buildProduct = (overrides?: Partial<Product>): Product => ({
   _id: "507f1f77bcf86cd799439011",
@@ -57,21 +60,33 @@ const buildProduct = (overrides?: Partial<Product>): Product => ({
   ...overrides,
 });
 
+// ProductTableRowAction은 useAdminModalStore를 구독하므로 StoreProvider 없이는
+// 마운트 시점에 throw한다 — 테스트마다 새 store 인스턴스를 만들어 주입한다.
+let testStore: AppStoreApi;
+
+const renderAction = (props: ProductTableRowProps) =>
+  render(
+    <StoreProvider store={testStore}>
+      <ProductTableRowAction {...props} />
+    </StoreProvider>,
+  );
+
 describe("ProductTableRowAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(window, "confirm").mockReturnValue(true);
+    testStore = createAppStore();
   });
 
   it("view가 active(기본값)면 복구/영구 삭제 버튼은 없다", () => {
-    render(<ProductTableRowAction product={buildProduct()} />);
+    renderAction({ product: buildProduct() });
 
     expect(screen.queryByText("복구")).not.toBeInTheDocument();
     expect(screen.queryByText("영구 삭제")).not.toBeInTheDocument();
   });
 
   it("view가 trash면 복구/영구 삭제 버튼을 렌더링한다", () => {
-    render(<ProductTableRowAction product={buildProduct()} view="trash" />);
+    renderAction({ product: buildProduct(), view: "trash" });
 
     expect(screen.getByText("복구")).toBeInTheDocument();
     expect(screen.getByText("영구 삭제")).toBeInTheDocument();
@@ -84,7 +99,7 @@ describe("ProductTableRowAction", () => {
       data: { message: "상품이 성공적으로 복구되었습니다." },
     });
 
-    render(<ProductTableRowAction product={buildProduct()} view="trash" />);
+    renderAction({ product: buildProduct(), view: "trash" });
 
     await user.click(screen.getByText("복구"));
 
@@ -99,7 +114,7 @@ describe("ProductTableRowAction", () => {
       data: { message: "상품이 성공적으로 삭제되었습니다." },
     });
 
-    render(<ProductTableRowAction product={buildProduct()} />);
+    renderAction({ product: buildProduct() });
 
     const buttons = screen.getAllByRole("button");
     await user.click(buttons[1]);
@@ -115,7 +130,7 @@ describe("ProductTableRowAction", () => {
       data: { message: "상품이 영구적으로 삭제되었습니다." },
     });
 
-    render(<ProductTableRowAction product={buildProduct()} view="trash" />);
+    renderAction({ product: buildProduct(), view: "trash" });
 
     await user.click(screen.getByText("영구 삭제"));
 

--- a/test/integration/services/invitation.integration.test.ts
+++ b/test/integration/services/invitation.integration.test.ts
@@ -18,7 +18,7 @@ import {
 // 세션 조회만 대체한다(partial mock) — 쿠키/JWT는 이 파일의 검증 대상이 아니다.
 const { authState } = vi.hoisted(() => ({ authState: { userId: "" } }));
 
-vi.mock("./auth", async (importOriginal) => {
+vi.mock("@/services/auth", async (importOriginal) => {
   const actual = await importOriginal<typeof AuthModule>();
   return {
     ...actual,

--- a/test/integration/services/order.integration.test.ts
+++ b/test/integration/services/order.integration.test.ts
@@ -31,7 +31,7 @@ import { createProductService } from "@/services/product";
 // 그대로 둔다(partial mock).
 const { authState } = vi.hoisted(() => ({ authState: { userId: "" } }));
 
-vi.mock("./auth", async (importOriginal) => {
+vi.mock("@/services/auth", async (importOriginal) => {
   const actual = await importOriginal<typeof AuthModule>();
   return {
     ...actual,
@@ -225,60 +225,6 @@ describe("order", () => {
         await expect(createOrderService(input)).rejects.toMatchObject({
           category: "NOT_FOUND",
         });
-      });
-
-      it("minQuantity/maxQuantity 필드가 없는 레거시 상품은 (1,1) 폴백 기준으로 검증한다 (수량 1만 통과)", async () => {
-        const result = await ProductModel.collection.insertOne({
-          authorId: "legacy",
-          title: "레거시 주문 상품",
-          description: "레거시 문서(필드 없음)",
-          thumbnail: "https://example.com/legacy.jpg",
-          price: 1000,
-          category: MOBILE_INVITATION_CATEGORY,
-          subCategory: "wedding",
-          isPremium: false,
-          isFeatured: false,
-          priority: 0,
-          likes: [],
-          views: 0,
-          salesCount: 0,
-          discount: { discountType: "rate", value: 0 },
-          status: "active",
-          featureIds: [],
-          deletedAt: null,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        } as never);
-        const legacyProductId = result.insertedId.toString();
-
-        const invalidInput = buildOrderInput({
-          product: {
-            productId: legacyProductId,
-            title: "레거시 주문 상품",
-            category: MOBILE_INVITATION_CATEGORY,
-            thumbnail: "https://example.com/legacy.jpg",
-            pricing: { originalPrice: 1000, discountedPrice: 1000 },
-            quantity: 2,
-            selectedFeatures: [],
-          },
-        });
-        await expect(createOrderService(invalidInput)).rejects.toMatchObject({
-          category: "VALIDATION",
-        });
-
-        const validInput = buildOrderInput({
-          product: {
-            productId: legacyProductId,
-            title: "레거시 주문 상품",
-            category: MOBILE_INVITATION_CATEGORY,
-            thumbnail: "https://example.com/legacy.jpg",
-            pricing: { originalPrice: 1000, discountedPrice: 1000 },
-            quantity: 1,
-            selectedFeatures: [],
-          },
-        });
-        const validResult = await createOrderService(validInput);
-        expect(validResult.product.quantity).toBe(1);
       });
     });
 

--- a/test/integration/services/payment.integration.test.ts
+++ b/test/integration/services/payment.integration.test.ts
@@ -42,7 +42,7 @@ vi.mock("@portone/server-sdk", () => {
 // 그대로 둔다(partial mock, order.integration.test.ts와 동일 패턴).
 const { authState } = vi.hoisted(() => ({ authState: { userId: "" } }));
 
-vi.mock("./auth", async (importOriginal) => {
+vi.mock("@/services/auth", async (importOriginal) => {
   const actual = await importOriginal<typeof AuthModule>();
   return {
     ...actual,

--- a/test/integration/services/review.integration.test.ts
+++ b/test/integration/services/review.integration.test.ts
@@ -24,7 +24,7 @@ import {
 
 // deleteReviewByAdminService가 자체적으로 requireAdmin()을 호출한다 — 세션
 // 조회만 대체하고 나머지 auth 구현(getUser 등)은 그대로 둔다(partial mock).
-vi.mock("./auth", async (importOriginal) => {
+vi.mock("@/services/auth", async (importOriginal) => {
   const actual = await importOriginal<typeof AuthModule>();
   return {
     ...actual,


### PR DESCRIPTION
## Summary

- `dev`에서 오래 실패하고 있던 테스트 17건(component 5 + integration 12)을 0으로 만든다. CI가 `lint`/`tsc`/`build`만 돌려 PR 게이트에 걸리지 않은 사이 두 개의 독립적인 회귀가 누적됐다.
- **integration 12건** — 4개 서비스 테스트가 세션 경계를 `vi.mock("./auth")`로 부분 Mock하는데, `088401c`(#204)에서 `src/services/`에서 `test/integration/services/`로 옮겨진 뒤 그 specifier가 아무것도 가리키지 않게 됐다. Mock이 무력화되면서 실제 `requireAuth` → `getAuth` → `getCookie` 체인이 돌아 `` `cookies` was called outside a request scope ``가 났다. 짝이 되는 타입 import는 `@/services/auth` 절대 경로라 `tsc`도 못 잡았다. specifier를 `@/services/auth`로 교정했다 — `test/integration/app/api/order/route.integration.test.ts`가 쓰는 방식과 동일하다.
- **component 5건** — `ProductTableRowAction`이 `useAdminModalStore`를 구독하는데 `67e022d`(#203)에서 store가 per-mount 인스턴스로 바뀐 뒤 Context 없이 마운트하면 `StoreProvider is missing!`을 던진다. `src/ui/stores/AGENTS.md`의 규약대로 테스트마다 `createAppStore()`로 만든 인스턴스를 `StoreProvider`에 주입한다.
- Mock을 되살리자 가려져 있던 stale 테스트 1건이 드러나 함께 삭제했다 — order의 레거시 `(1,1)` 수량 폴백 테스트. `1b2be25`가 `getProductQuantityBoundsService`에서 그 폴백을 의도적으로 제거하고 짝이 되는 테스트도 지웠는데, 이 테스트만 자기 Mock이 깨져 있던 덕에 살아남아 있었다.

이슈 본문의 29건 중 component 12건은 `ProductEditDialog` 테스트 2개 파일이며, `2a22540`(#221)에서 레거시 테스트로 이미 제거되어 복원하지 않았다. 이슈 작업항목 3(CI 테스트 게이트)은 `docs/validation/ci-gates.md:11`의 현행 정책 개정과 브랜치 보호 변경이 따라오므로 #229로 분리했다.

Closes #209
Related to #229

## Test plan

- `npm run test` — 150 files / 963 tests 전부 통과 (수정 전 `17 failed | 947 passed`)
- `npm run lint` — 통과
- `npm run tsc` — 통과
- `grep -rn 'vi.mock("\./' test/` — 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RT2BYsT5zDD2G8aUmGWhS
