### PR TITLE
docs: 디렉터리 감사 결과와 회색지대 결정을 문서화한다

### DIFF
--- a/_workspace/directory-audit/plan.md
+++ b/_workspace/directory-audit/plan.md
@@ -15,7 +15,7 @@
 
 ## 1. 보고서 판정에 대한 이견
 
-실행 전에 확정해야 하는 사실 층위 이견 3건. 처방이 아니라 판정 자체에 대한 반론이다.
+실행 전에 확정해야 하는 사실 층위 이견 4건. 처방이 아니라 판정 자체에 대한 반론이다.
 
 ### 이견 1 — `webhooks/portone`은 축1 위반이 아니다
 
@@ -45,6 +45,16 @@ return document ? { lat: Number(document.y), lng: Number(document.x) } : ...
 카카오맵 API가 결과 배열을 `documents`로 부르는 탓에 생긴 지역 변수명이다. 전역 `document`에는 `.y`/`.x`가 없다.
 
 판정: Q3 대상은 13개가 아니라 12개.
+
+### 이견 4 — `api/order/create`는 배치 위반이 아니라 dead code
+
+보고서: "브라우저 트리거 주문 생성 mutation을 POST Route Handler로 배치" (축1/Medium), 조치 = `src/actions/createOrder.ts`로 이동.
+
+그 Action은 **이미 존재한다.** `src/app/(main)/(checkout)/payment/_containers/CheckoutForm.tsx:7`이 `@/actions/createOrder`를 import해 쓰고 있고, Route Handler `src/app/api/order/create/route.ts`를 호출하는 곳은 저장소 전체에 없다. 유일한 문자열 매치인 `.claude/skills/feature-team-orchestrator/SKILL.md:156`은 예시 서술이지 호출자가 아니며, `src/core/domain/routes.ts`에 API 경로 상수가 없어 동적 조립 경로도 없다.
+
+즉 이전은 과거에 이미 끝났고 Route Handler만 잔재로 남았다. 보고서는 두 경로가 공존하는 상태를 "잘못 배치됨"으로 읽었지만, 실제 상태는 "이전 완료 후 정리 누락"이다.
+
+판정: 이동 대상이 아니라 삭제 대상. Step 4의 성격과 리스크 등급이 여기서 바뀐다.
 
 ---
 
@@ -85,6 +95,15 @@ Q3 대상 12건의 성격 분류:
 
 ## 3. 실행 순서
 
+| Step | 상태 | PR |
+|---|---|---|
+| 1 — 규칙 문서 반영 | 완료 | #233 |
+| 2 — 계획서 | 완료 | #233 |
+| 3 — `_components` → `_containers` | 완료 | #235 |
+| 4 — order API 정리 | 대기 (Step 3 머지 선행) | — |
+| 5 — 잔여 항목 | 미착수 | — |
+| 6 — lint 규칙 | 미착수 | — |
+
 ### Step 1 — 결정을 규칙 문서에 반영 (docs 전용 PR)
 
 **목적**: Q1·Q3·Q4·Q6의 결정을 규칙 문서에 박아 다음 감사가 같은 질문을 하지 않게 한다. Step 3·4의 판정 기준이 여기서 나오므로 실행보다 먼저다.
@@ -121,24 +140,27 @@ Q3 대상 12건의 성격 분류:
 
 **TDD gate 주의**: `.claude/settings.json`의 훅 matcher는 `Write|Edit|MultiEdit`이다. 순수 이동 리팩터에는 새로 쓸 테스트가 없으므로 `git mv` + `sed` 경로 치환(Bash)으로 진행한다. 훅 우회가 아니라 리네임에 맞는 도구 선택이다.
 
-**검증**: `pnpm typecheck` + 이동한 13개 테스트 파일 통과 + `pnpm lint`.
-**산출물**: Issue 1개 + PR 1개.
+**검증**: `npm run tsc` + `npm run lint` + `npm run lint:barrels` + `npm run test:unit` + `npm run test:component`.
+
+**부수 리네임**: `AdminReviewsTemplate` → `AdminReviewsTable`. `Template` 접미사는 `src/ui/components/templates/AGENTS.md`가 "완성된 콘텐츠를 props로 받는 순수 페이지 몸통"에만 허용하는데 이 파일은 `deleteReviewByAdmin`·`toast`·`router.refresh`를 소유한다. `_containers`로 옮기면 이름이 주장하는 순수성과 위치가 정면으로 어긋나므로 같은 PR에서 처리한다. 형제 컨테이너 27개가 모두 무접미사라 `Container`도 붙이지 않는다.
+
+**산출물**: PR 1개.
 
 ### Step 4 — order API 통합
 
 **목적**: 축1 Medium 1건 + 축2 Low 1건을 한 번에 해소. 따로 하면 같은 파일을 두 번 건드리고 소비자 import가 두 번 깨진다.
 
 **작업**
-1. `src/app/api/order/create/route.ts`의 POST 핸들러를 `src/actions/createOrder.ts`로 이동 (`data-access.md` — 브라우저 트리거 mutation은 Server Action)
+1. `src/app/api/order/create/route.ts` 삭제 (이견 4 — 호출자 0인 dead code, Action은 이미 존재)
 2. `src/app/api/order/route.ts` → `src/app/api/orders/route.ts` 리네임 (`route-naming.md` — 컬렉션 복수형, 행위 세그먼트 금지)
-3. 소비자(`CheckoutForm.tsx` 등) 호출부를 `fetch` → Action 직접 호출로 교체
+3. 소비자 1곳 수정 — `my-orders/_containers/OrderList.tsx:37`의 `/api/order?${query}`
 
-**리스크**: **높음.** 결제 흐름이 걸려 있다.
-- 착수 전 확인: `webhooks/portone`이 `merchantUid`를 역조회에만 쓰는지, 발급 타이밍이 PortOne 결제창 호출 전인지
-- 회귀 테스트 없이 진행하지 않는다
+**리스크**: 낮음. 초안에서는 "높음 — 결제 흐름 회귀 테스트 필수"로 평가했으나 이견 4로 뒤집혔다. 남는 건 소비자 1개짜리 GET 엔드포인트 리네임과 미사용 파일 삭제이고, 결제 생성 경로는 이미 Server Action이 담당하므로 `merchantUid` 발급 타이밍 확인도 불필요하다.
 
-**검증**: 주문 생성 → 결제 → 웹훅 수신 통합 시나리오.
-**산출물**: Issue 1개 + PR 1개. Step 3 머지 후 착수.
+**선행 조건**: Step 3 머지. `OrderList.tsx`가 Step 3에서 `_containers`로 이동한 파일이라, dev에서 새로 분기하면 같은 파일에서 충돌한다.
+
+**검증**: `npm run tsc` / `lint` / `test:unit` / `test:component`. 주문 목록 조회 경로만 바뀌므로 결제 통합 시나리오는 대상이 아니다.
+**산출물**: Issue 1개 + PR 1개.
 
 ### Step 5 — 잔여 항목 (낮은 우선순위)
 

--- a/_workspace/directory-audit/plan.md
+++ b/_workspace/directory-audit/plan.md
@@ -1,0 +1,203 @@
+# 디렉터리 감사 실행 계획
+
+> 대상 보고서: `_workspace/directory-audit/report.md` (2026-09-02)
+> 작성일: 2026-09-02
+
+## 0. 이 문서의 위치
+
+보고서는 **사실 층위**(위반 판정 + 근거 문서)를 담당한다. 이 문서는 **결정·실행 층위**를 담당한다 — 처방, 우선순위, 판정 이견.
+
+보고서는 수정하지 않는다. 보고서에 포함된 `조치:` 필드와 §3의 이동/리네임/분할/유지 열, §4의 `영향:` 수치는 실행 층위 내용이므로 이 문서의 판단으로 대체한다.
+
+**결정은 이 문서가 아니라 규칙 문서(AGENTS.md / ADR)에 반영한다.** 계획서에만 적으면 다음 감사가 같은 질문을 다시 하게 된다.
+
+---
+
+## 1. 보고서 판정에 대한 이견
+
+실행 전에 확정해야 하는 사실 층위 이견 3건. 처방이 아니라 판정 자체에 대한 반론이다.
+
+### 이견 1 — `webhooks/portone`은 축1 위반이 아니다
+
+보고서: Route Handler 5개가 "외부 API·SDK 호출 또는 Adapter 조합 유스케이스를 직접 소유" (Medium).
+
+`src/app/api/webhooks/portone/route.ts`가 하는 일은 서명 검증(`Webhook.verify`) → `storeId` 확인 → `syncPayment(paymentId)` 위임뿐이다. 도메인 로직은 이미 `services/payment`에 있다. 서명 검증은 "이 HTTP 요청이 진짜인지" 판정하는 일이므로 **진입점의 고유 책임**이며 유스케이스 소유가 아니다.
+
+판정: 위반 아님. Route Handler 위반은 5건이 아니라 4건.
+
+### 이견 2 — 축1/Low 14건은 원인 2 / 파급 12로 분리해야 한다
+
+보고서: "core 도메인 타입을 services 2개가 소유·재노출하고 route-local UI 등 12개가 그 경로를 소비" — 14건.
+
+실제 위반은 `src/services/product.ts:24`, `src/services/premiumFeature.ts:7` **2건**이다. 나머지 12개는 그 2건을 import하는 소비자로, 원인을 고치면 import 경로 한 줄씩 바뀔 뿐이다. 14건으로 계상하면 부채 규모가 7배로 부풀어 보인다.
+
+판정: 원인 2건 / 파급 12건으로 분리 계상.
+
+### 이견 3 — Q3 현황 13건 중 1건은 오탐
+
+`src/ui/hooks/useKakaomapGeocode.ts:23`의 `document`는 브라우저 전역이 아니다.
+
+```ts
+const document = data?.documents?.[0];   // 카카오맵 응답 배열 원소
+return document ? { lat: Number(document.y), lng: Number(document.x) } : ...
+```
+
+카카오맵 API가 결과 배열을 `documents`로 부르는 탓에 생긴 지역 변수명이다. 전역 `document`에는 `.y`/`.x`가 없다.
+
+판정: Q3 대상은 13개가 아니라 12개.
+
+---
+
+## 2. 회색지대 6문항 — 확정된 결정
+
+| Q | 결정 | 반영할 문서 | 문서 수정 필요 |
+|---|---|---|---|
+| Q1 route-local `_utils` 승격 기준 | 라우트 종속이면 `_utils` 잔류 | `src/app/AGENTS.md §Structure` | 필요 |
+| Q2 `ui/hooks` 승격 임계점 | 현행 유지 | — | 불필요 (기존 "2개 이상 라우트 공유 시 승격"이 이미 답) |
+| Q3 `adapters/browser` 경계 범위 | 대체·스텁이 필요한 capability만 | `src/adapters/AGENTS.md §경계` | 필요 |
+| Q4 `boundary.ts` 역할 분할 | 분할하지 않고 `src/` 루트 예외로 명문화 | `src/AGENTS.md` | 필요 |
+| Q5 `_components` view/side effect 혼재 | 파일 전체를 `_containers`로 이동 | — | 불필요 (기존 조건문이 이동을 요구, 분할 요구 아님) |
+| Q6 `kakaomap` 세그먼트 | `kakao-map`으로 리네임 | `docs/conventions/route-naming.md` | 필요 |
+
+### Q3 결정 근거 (유일하게 되돌리기 비싼 결정)
+
+선택지 A(브라우저 전역 접근을 전부 Adapter화)를 **탈락**시킨 이유는 실행 비용이 아니라 규칙 체계와의 자기모순이다.
+
+`src/adapters/AGENTS.md`는 "`server/`와 `browser/` 아래 폴더 하나는 외부 서비스 또는 런타임 경계 하나를 담당한다"를 불변식으로 둔다. A안을 실행하면 `document.body.style`, `addEventListener`, `matchMedia`, `document.cookie` 같은 서로 무관한 접근이 `adapters/browser/dom/` 형태의 자루 폴더로 모인다. 이는 경계 하나가 아니라 나머지 전부이며 ADR-0002가 세운 구조를 깬다.
+
+선택지 B의 보고서 문구("복사·위치 조회만")도 기준이 아니라 결과 열거라 새 코드 판정에 쓸 수 없다. 다음 문장으로 대체한다:
+
+> `adapters/browser/`는 **대체·스텁이 필요한 capability**를 감싼다 — 권한 게이트가 있거나(clipboard, geolocation), 비결정적이거나(`crypto.randomUUID`), 외부 SDK·앱을 호출하는(portone, daum, kakao, deeplink) 것. 렌더 부수효과로서의 DOM 조작·이벤트 리스너·미디어쿼리는 Adapter 대상이 아니며 컴포넌트나 `ui/hooks`에 남긴다.
+
+선례: `adapters/browser/deeplink/open-app.ts`는 SDK를 쓰지 않고 `window.open`/`window.location.href`만 만지지만 정당한 Adapter다. "`window`를 써서"가 아니라 **"지도 앱 열기"라는 이름 붙는 capability 하나**를 이루고, 티맵 실패 시 네이버맵 폴백이라는 정책까지 소유하기 때문이다.
+
+Q3 대상 12건의 성격 분류:
+
+| 분류 | 파일 | 처리 |
+|---|---|---|
+| 권한·비결정 capability | `ui/hooks/useCopy.ts:14`, `ui/hooks/useNavigationGeo.ts:14`, `ui/hooks/useImageList.ts:8`, `ui/context/guestbookDemo/reducer.ts:42` | Adapter화 (4건) |
+| native `window.confirm` | `my-orders/_components/OrderCard.tsx:75`, `my-orders/_components/ReviewFormDialog.tsx:70`, `admin/reviews/_components/AdminReviewsTemplate.tsx:28` | **Q3 대상 아님** — 별도 Issue |
+| DOM 부수효과 | `(preview)/_components/GuestbookModal.tsx:42`, `preview/[publicKey]/_components/ThemeSync.tsx:11`, `.../interactions/InteractionOverlay.tsx:53`, `ui/components/atoms/sidebar.tsx:82,104`, `ui/hooks/useMobile.ts:8` | 현행 유지 |
+
+`window.confirm` 3건을 Q3에서 분리하는 이유: Adapter로 감싸도 여전히 네이티브 confirm이 뜬다. 프로젝트에 `ui/components/molecules/Alert`와 Radix Dialog가 있는데 주문 취소·리뷰 삭제라는 되돌릴 수 없는 동작에 브라우저 기본 confirm을 쓰는 것은 UI 일관성 문제다. Adapter화가 아니라 컴포넌트 교체가 해법이다.
+
+---
+
+## 3. 실행 순서
+
+### Step 1 — 결정을 규칙 문서에 반영 (docs 전용 PR)
+
+**목적**: Q1·Q3·Q4·Q6의 결정을 규칙 문서에 박아 다음 감사가 같은 질문을 하지 않게 한다. Step 3·4의 판정 기준이 여기서 나오므로 실행보다 먼저다.
+
+**작업**
+- `src/app/AGENTS.md §Structure` — 라우트 종속 순수함수는 소비자 수와 무관하게 `_utils` 잔류 (Q1)
+- `src/adapters/AGENTS.md §경계` — §2의 Q3 기준 문장 추가 (Q3)
+- `src/AGENTS.md` — `boundary.ts`가 Route Handler 변환과 Action 변환을 함께 소유하는 것을 루트 예외로 명문화 (Q4)
+- `docs/conventions/route-naming.md` — 무하이픈 합성 세그먼트 금지 (Q6)
+
+**리스크**: 없음. 코드 변경 없음.
+**검증**: 없음 (docs).
+**산출물**: PR 1개. Step 3과 병렬 진행 가능.
+
+### Step 2 — 이 계획서 자체
+
+이 문서 커밋. 보고서는 원본 유지.
+
+### Step 3 — `_components` 13개 → `_containers` (최우선 착수)
+
+**목적**: 축1 Medium 부채의 최대 덩어리 해소. 로직 변경 0, 규칙 근거 최강, 리스크 최저.
+
+**근거**: `src/app/AGENTS.md §Structure` — "라우트 전용 client 컴포넌트가 다음 중 하나라도 포함하면 `_components/`가 아니라 동급의 `_containers/{Name}.tsx`에 둔다: `useSWR`/`useSWRInfinite` + `fetcher` / `useActionState` 또는 `startTransition(() => action(...))` / zustand 결과로 `toast`·`router.replace` 실행". 단정형 조건이며 13개 파일이 모두 해당한다.
+
+**대상 13개** (부록 A)
+
+**작업**
+1. 각 라우트에 `_containers/` 생성 (`admin/products`, `admin/reviews`, `my-orders`, `payment-result`, `preview/[publicKey]`는 신설 / `my-orders/[orderId]/invitation`, `products/[category]/[id]`는 기존 활용)
+2. `git mv`로 본체 + 동거 테스트(`*.component.test.tsx`) 함께 이동
+3. 상대 경로 import 수정 — 이동 파일끼리 서로 import하는 3쌍이 있어 한 커밋에 묶어야 한다 (부록 A 참조)
+4. 외부 소비자 import 경로 수정 (`page.tsx`, `MyOrdersTemplate.tsx`, `ProductDetailTemplate.tsx` 등)
+
+**리스크**: 낮음. 순수 이동. 다만 상대 경로가 얽혀 있어 부분 커밋 시 빌드가 깨진다 — 단일 커밋.
+
+**TDD gate 주의**: `.claude/settings.json`의 훅 matcher는 `Write|Edit|MultiEdit`이다. 순수 이동 리팩터에는 새로 쓸 테스트가 없으므로 `git mv` + `sed` 경로 치환(Bash)으로 진행한다. 훅 우회가 아니라 리네임에 맞는 도구 선택이다.
+
+**검증**: `pnpm typecheck` + 이동한 13개 테스트 파일 통과 + `pnpm lint`.
+**산출물**: Issue 1개 + PR 1개.
+
+### Step 4 — order API 통합
+
+**목적**: 축1 Medium 1건 + 축2 Low 1건을 한 번에 해소. 따로 하면 같은 파일을 두 번 건드리고 소비자 import가 두 번 깨진다.
+
+**작업**
+1. `src/app/api/order/create/route.ts`의 POST 핸들러를 `src/actions/createOrder.ts`로 이동 (`data-access.md` — 브라우저 트리거 mutation은 Server Action)
+2. `src/app/api/order/route.ts` → `src/app/api/orders/route.ts` 리네임 (`route-naming.md` — 컬렉션 복수형, 행위 세그먼트 금지)
+3. 소비자(`CheckoutForm.tsx` 등) 호출부를 `fetch` → Action 직접 호출로 교체
+
+**리스크**: **높음.** 결제 흐름이 걸려 있다.
+- 착수 전 확인: `webhooks/portone`이 `merchantUid`를 역조회에만 쓰는지, 발급 타이밍이 PortOne 결제창 호출 전인지
+- 회귀 테스트 없이 진행하지 않는다
+
+**검증**: 주문 생성 → 결제 → 웹훅 수신 통합 시나리오.
+**산출물**: Issue 1개 + PR 1개. Step 3 머지 후 착수.
+
+### Step 5 — 잔여 항목 (낮은 우선순위)
+
+Step 3·4가 끝나면 Low 상당수가 자동 소멸한다. 남는 것:
+
+| 항목 | 대상 | 비고 |
+|---|---|---|
+| Route Handler Adapter 분리 | `api/banks`, `api/kakaomap` | 외부 API 계약을 라우트가 소유 중 |
+| Route Handler → services 조합 이동 | `api/subway/[station]`, `api/upload/signature` | Adapter는 이미 있고 조합만 라우트에 있음 |
+| `kakao-map` 리네임 | `api/kakaomap` | 위 작업에 얹는다 |
+| runtime marker 2줄 | `adapters/browser/cloudinary/widget.tsx`, `adapters/server/cloudinary/publicId.ts` | ADR-0002 — `import "client-only"` / `import "server-only"` |
+| 도메인 타입 `core/` 이동 | `services/product.ts:24`, `services/premiumFeature.ts:7` | 소비자 12개 import 경로 일괄 수정 |
+| Q3 Adapter 신설 | `adapters/browser/clipboard/`, `adapters/browser/geolocation/` | `useCopy`, `useNavigationGeo` |
+
+`crypto.randomUUID` 2건(`useImageList.ts`, `guestbookDemo/reducer.ts`)은 Adapter화할지 생성 위치를 서버로 올릴지 별도 판단이 필요하다. 이번 범위 밖.
+
+### Step 6 — 재발 방지 lint 규칙 (선택)
+
+축 3(의존 방향)이 위반 0인 이유는 ESLint가 막아서다. 축 1이 35인 이유는 사람이 지켜야 해서다.
+
+Step 3 완료 후 `_components/*.tsx`에서 `@/actions/*` import를 금지하는 규칙을 추가하면 13건이 다시 쌓이지 않는다. 감사를 재실행하는 것보다 싸다.
+
+---
+
+## 4. 이번 범위에서 제외
+
+| 항목 | 사유 |
+|---|---|
+| `api/webhooks/portone` Adapter 분리 | 이견 1 — 위반 아님 |
+| `window.confirm` 3건 → Alert/Dialog 교체 | Q3 아닌 UI 일관성 이슈. 별도 Issue |
+| DOM 부수효과 6건 Adapter화 | Q3 결정으로 현행 유지 확정 |
+| `_utils` 11개 `core/utils` 승격 | Q1 결정으로 잔류 확정 |
+| `ui/hooks` 17개 route-local 이동 | Q2 결정으로 현행 유지 확정 |
+| `boundary.ts` 분할 | Q4 결정으로 예외 명문화 |
+| 재수출 경로 import 9건 (축2/Low) | 대부분 Step 5의 도메인 타입 이동으로 소멸. 잔여분은 소멸 후 재평가 |
+
+---
+
+## 부록 A — Step 3 대상 13개
+
+| # | 현재 경로 | 이동 대상 `_containers` | 상대 import |
+|---|---|---|---|
+| 1 | `(admin)/admin/products/_components/ProductEditDialog.tsx` | 신설 | → `./NumberField` (미이동, 경로 조정 필요) |
+| 2 | `(admin)/admin/products/_components/ProductTableRowAction.tsx` | 신설 | → `./ProductTableRow` 타입 (미이동) |
+| 3 | `(admin)/admin/products/_components/ProductTableRowSelect.tsx` | 신설 | — |
+| 4 | `(admin)/admin/reviews/_components/AdminReviewsTemplate.tsx` | 신설 | — |
+| 5 | `(main)/(my-order)/my-orders/[orderId]/invitation/_components/InvitationStatusControls.tsx` | 기존 | — |
+| 6 | `(main)/(my-order)/my-orders/_components/OrderCard.tsx` | 신설 | → `./PaymentButton`, `./PendingCoupleInfoBanner`, `./ReviewFormDialog` |
+| 7 | `(main)/(my-order)/my-orders/_components/OrderList.tsx` | 신설 | → `./OrderCard` (동반 이동) |
+| 8 | `(main)/(my-order)/my-orders/_components/PaymentButton.tsx` | 신설 | — |
+| 9 | `(main)/(my-order)/my-orders/_components/ReviewFormDialog.tsx` | 신설 | — |
+| 10 | `(main)/(products)/products/[category]/[id]/_components/ProductLikeBadge.tsx` | 기존 | — |
+| 11 | `(main)/(products)/products/[category]/[id]/_components/ProductViewTracker.tsx` | 기존 | — |
+| 12 | `(main)/payment-result/_components/PaymentResult.tsx` | 신설 | → `./PaymentResultTemplate` (미이동) |
+| 13 | `(preview)/preview/[publicKey]/_components/LiveGuestbookSection.tsx` | 신설 | → `./EyebrowSection`, `./GuestbookList`, `../_utils/...` (미이동) |
+
+13개 모두 동거 테스트 `*.component.test.tsx`가 존재하며 함께 이동한다.
+
+주의 지점:
+- #6·#7은 서로 import하며 둘 다 이동 대상 → 상대 경로 유지
+- #1·#2·#12·#13은 **이동하지 않는** 형제를 import → `../_components/{Name}`으로 조정
+- `PendingCoupleInfoBanner`는 위반 목록에 없으므로 `_components`에 남는다

--- a/_workspace/directory-audit/report.md
+++ b/_workspace/directory-audit/report.md
@@ -1,0 +1,97 @@
+## §1 요약
+
+| 지표 | 수치 |
+|---|---:|
+| 조사 파일 | 613 |
+| 판정 대상 `.ts`/`.tsx` | 574 (비테스트 441 + 테스트 133) |
+| 위반 파일 | 37 |
+| 준수 파일 | 537 |
+| 준수율 | 93.6% |
+
+| 축 | High | Medium | Low | 합계 |
+|---|---:|---:|---:|---:|
+| 축 1 — 역할 배치 | 0 | 19 | 16 | 35 |
+| 축 2 — 파일 위치·명명 | 0 | 0 | 11 | 11 |
+| 축 3 — 의존 방향 | 0 | 0 | 0 | 0 |
+## §2 위반 목록
+
+### 축 1 — 역할 배치
+
+- `src/app/api/banks/route.ts:7`, `src/app/api/kakaomap/route.ts:17`, `src/app/api/subway/[station]/route.ts:4`, `src/app/api/upload/signature/route.ts:6`, `src/app/api/webhooks/portone/route.ts:1` — [축1/Medium] Route Handler 5개가 외부 API·SDK 호출 또는 Adapter 조합 유스케이스를 직접 소유
+  근거: ADR-0001 §결정
+  조치: 분할
+
+- `src/app/api/order/create/route.ts:28` — [축1/Medium] 브라우저 트리거 주문 생성 mutation을 POST Route Handler로 배치
+  근거: data-access.md §데이터 접근 경로 — 무엇이 필요한가가 기준
+  조치: 이동 → `src/actions/createOrder.ts`
+
+- `src/app/(admin)/admin/products/_components/ProductEditDialog.tsx:4`, `src/app/(admin)/admin/products/_components/ProductTableRowAction.tsx:2`, `src/app/(admin)/admin/products/_components/ProductTableRowSelect.tsx:5`, `src/app/(admin)/admin/reviews/_components/AdminReviewsTemplate.tsx:3`, `src/app/(main)/(my-order)/my-orders/[orderId]/invitation/_components/InvitationStatusControls.tsx:3`, `src/app/(main)/(my-order)/my-orders/_components/OrderCard.tsx:3`, `src/app/(main)/(my-order)/my-orders/_components/OrderList.tsx:4`, `src/app/(main)/(my-order)/my-orders/_components/PaymentButton.tsx:12`, `src/app/(main)/(my-order)/my-orders/_components/ReviewFormDialog.tsx:3`, `src/app/(main)/(products)/products/[category]/[id]/_components/ProductLikeBadge.tsx:3`, `src/app/(main)/(products)/products/[category]/[id]/_components/ProductViewTracker.tsx:3`, `src/app/(main)/payment-result/_components/PaymentResult.tsx:3`, `src/app/(preview)/preview/[publicKey]/_components/LiveGuestbookSection.tsx:3` — [축1/Medium] `_components` 13개가 SWR 또는 Server Action 결합과 도메인 side effect를 소유
+  근거: src/app/AGENTS.md §Structure
+  조치: 이동 → 각 라우트의 동급 `_containers/{동일파일명}`
+
+- `src/adapters/browser/cloudinary/widget.tsx:1`, `src/adapters/server/cloudinary/publicId.ts:1` — [축1/Low] 런타임 세그먼트의 제품 모듈 2개에 각각 `client-only`·`server-only` marker가 없음
+  근거: ADR-0002 §결정
+  조치: 유지
+
+- `src/services/product.ts:24`, `src/services/premiumFeature.ts:7`, `src/app/(main)/(products)/products/[category]/[id]/_components/ProductDetailTemplate.tsx:1`, `src/app/(admin)/admin/premium-features/_components/PremiumFeatureCardAction.tsx:6`, `src/app/(admin)/admin/products/new/_containers/ProductRegistrationForm.tsx:9`, `src/app/(main)/(products)/products/[category]/[id]/_containers/ProductSummary.tsx:7`, `src/app/(admin)/admin/premium-features/_containers/PremiumFeatureDialog.tsx:6`, `src/app/(admin)/admin/products/_components/ProductTableRowSelect.tsx:8`, `src/app/(main)/(products)/products/[category]/_containers/ProductCatalog.tsx:6`, `src/app/(admin)/admin/products/_components/ProductEditDialog.tsx:6`, `src/app/(main)/page.tsx:4`, `src/app/(admin)/admin/products/_components/ProductTableRow.tsx:5`, `src/app/(main)/_components/HomeTemplate.tsx:1`, `src/app/(main)/_components/PopularProductsSection.tsx:7` — [축1/Low] core 도메인 타입을 services 2개가 소유·재노출하고 route-local UI 등 12개가 그 경로를 소비
+  근거: ADR-0001 §결정
+  조치: 이동 → `src/core/domain/product.ts`, `src/core/domain/premium-feature.ts`
+
+### 축 2 — 파일 위치·명명
+
+- `src/app/api/order/route.ts:19`, `src/app/api/order/create/route.ts:28` — [축2/Low] 주문 컬렉션 API가 단수 `order`를 쓰고 행위 세그먼트 `create`를 별도 노출
+  근거: route-naming.md §규칙 4가지
+  조치: 리네임 → `src/app/api/orders/route.ts`
+
+- `src/services/payment.ts:4`, `src/services/product.ts:2`, `src/app/(main)/(products)/products/[category]/[id]/_components/ProductDetailTemplate.tsx:2`, `src/app/(admin)/admin/premium-features/_components/PremiumFeatureCardAction.tsx:6`, `src/app/(admin)/admin/products/new/_containers/ProductRegistrationForm.tsx:9`, `src/app/(main)/(products)/products/[category]/[id]/_containers/ProductSummary.tsx:8`, `src/app/(admin)/admin/premium-features/_containers/PremiumFeatureDialog.tsx:6`, `src/app/(preview)/_components/GuestbookModal.tsx:3`, `src/app/(admin)/admin/_components/AdminModal.tsx:4` — [축2/Low] 9개 파일이 심볼 정의 파일 대신 models·services·store facade의 재수출 경로를 import
+  근거: ADR-0004 §결정
+  조치: 유지
+
+### 축 3 — 의존 방향
+
+위반 없음 (확인 파일 574개)
+
+## §3 심각도 집계
+
+| 심각도 | 건수 | 이동 | 리네임 | 분할 | 유지 |
+|---|---:|---:|---:|---:|---:|
+| High | 0 | 0 | 0 | 0 | 0 |
+| Medium | 19 | 14 | 0 | 5 | 0 |
+| Low | 27 | 14 | 2 | 0 | 11 |
+| 합계 | 46 | 28 | 2 | 5 | 11 |
+
+## §4 회색지대 질문
+
+Q1. route-local 순수 함수는 재사용 건수만으로 `_utils` 잔류 여부를 정할 것인가?
+  현황: `_utils` 제품 파일 11개는 모두 순수하며 10개는 단일 소비자, 1개는 같은 라우트 하위 소비자 3개가 사용
+  선택지: A) 라우트 종속이면 `_utils` 유지 B) 순수 계산이면 `core/utils` 승격
+  영향: A) 이동 0개 B) 이동 11개
+
+Q2. `ui/hooks` 승격 임계점은 현재 소비 범위인가, 잠재 재사용성인가?
+  현황: 훅 23개 중 14개는 직접 app 소비자가 한 라우트 하위에만 있고 3개는 그 훅들의 내부 지원용이며 6개는 복수 소비자·공용 UI가 사용
+  선택지: A) 단일 라우트 종속 17개를 route-local `_hooks`로 이동 B) 의미상 재사용 가능한 훅은 `ui/hooks` 유지
+  영향: A) 이동 17개 B) 이동 0개
+
+Q3. `adapters/browser`가 감싸야 할 브라우저 API 경계를 어디까지 볼 것인가?
+  현황: app·ui 제품 모듈 13개가 `window`·`document`·`navigator`·`sessionStorage`·`crypto`를 직접 사용
+  선택지: A) 브라우저 전역 접근을 전부 Adapter화 B) 독립 capability wrapper인 복사·위치 조회만 Adapter화
+  영향: A) 13개 분할·이동 B) 2개 분할·이동
+
+Q4. Route Handler와 Server Action이 함께 쓰는 오류 변환 경계는 어느 역할이 소유해야 하는가?
+  현황: `src/boundary.ts` 1개가 `NextResponse` 변환과 Action 반환 오류 변환을 함께 소유
+  선택지: A) 프레임워크 Adapter와 Action 경계로 분할 B) `src/` 루트 예외로 명문화
+  영향: A) 1개 분할 B) 이동 0개
+
+Q5. `_components`의 view와 도메인 side effect가 한 파일에 섞였을 때 파일 전체를 옮길 것인가?
+  현황: 위반 13개 모두 렌더링과 SWR·Server Action 흐름을 한 파일에서 함께 수행
+  선택지: A) 파일 전체를 `_containers`로 이동 B) 순수 view를 `_components`에 남기고 container를 신설
+  영향: A) 13개 이동 B) 최대 13개 container 신설·기존 파일 분할
+
+Q6. `kakaomap`은 어휘화된 단일어인가, `kakao-map`으로 분리할 합성어인가?
+  현황: `src/app/api/kakaomap/route.ts` 1개만 무하이픈 합성 세그먼트를 사용
+  선택지: A) `kakaomap` 유지 B) `kakao-map`으로 리네임
+  영향: A) 이동 0개 B) 라우트 1개와 소비 경로 변경
+
+## §5 문서 갭
+
+- 없음

--- a/docs/conventions/route-naming.md
+++ b/docs/conventions/route-naming.md
@@ -1,15 +1,16 @@
 # 라우트 명명 규칙
 
-> Last updated: 2026-08-08
+> Last updated: 2026-09-02
 
 새 라우트 세그먼트(폴더명)를 지을 때만 참고한다 — 기존 세그먼트를 일괄 소급 변경하지는 않는다.
 
-## 규칙 4가지
+## 규칙 5가지
 
 - **소문자 + kebab-case 고정** — camelCase/snake_case 안 씀. 하이픈만 검색엔진이 단어 구분자로 인식한다.
 - **명사 위주, 동사는 관용적으로 굳은 것만 예외 허용** — REST 자원 경로는 명사가 기본(`products`, `my-orders`). "행위 자체가 화면"인 경우만 동사/동사구 예외 허용(`login`, `signup`, `search`, `products/new`).
 - **약어는 "어휘화(lexicalized)"된 것만 허용** — 기준: 비개발자가 줄임말인 줄 모를 만큼 이미 굳어졌는가. `id`/`api`/`url`/`info`/`faq`는 허용, `pw`/`addr`/`qty`류는 풀스펠링으로 짓는다.
-- **복수=컬렉션, 단수=단일 리소스** — 목록/여러 건 다루는 경로(`products`, `users`, `my-orders`)는 복수형, 설정·액션·단일 인스턴스 화면(`my-profile`, `payment`, `dashboard`, `settings`)은 단수형.
+- **합성어는 하이픈으로 분리** — 두 단어가 붙은 세그먼트를 무하이픈으로 짓지 않는다(`kakaomap` 대신 `kakao-map`). 1번 규칙이 하이픈을 단어 구분자로 정한 이상, 붙여쓰면 검색엔진도 사람도 단어 경계를 못 읽는다. 예외는 3번 규칙의 어휘화 기준을 통과한 단일어뿐이다 — 비개발자가 한 단어로 인식하면 그대로 둔다(`signup`, `checkout`).
+- **복수=컬렉션, 단수=단일 리소스** — 목록/여러 건 다루는 경로(`products`, `users`, `my-orders`)는 복수형, 설정·액션·단일 인스턴스 화면(`my-profile`, `payment`, `dashboard`, `settings`)은 단수형. API 경로에서 행위는 HTTP 메서드로 표현하고 별도 세그먼트로 노출하지 않는다(`POST /api/orders`이지 `POST /api/order/create`가 아니다).
 
 ## 실제 적용 사례
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,6 +1,6 @@
 # src/
 
-> Last updated: 2026-08-19
+> Last updated: 2026-09-02
 
 ## Overview
 
@@ -22,6 +22,7 @@
 - **`src/` 안에 배럴(`index.ts`/`index.tsx`)을 만들지 않고, 디렉터리를 가리키는 import도 쓰지 않는다 — 심볼이 실제로 정의된 파일을 지정한다**(`@/services/auth`, `@/models/user.model`). 모듈 그래프가 심볼이 아니라 모듈 단위로 계산되므로, 배럴은 쓰지 않는 형제 모듈까지 그래프에 끌어들여 `vitest related`·`--changed`·watch·mutation 도구를 무력화한다. 근거와 측정값은 `docs/decisions/0004-explicit-module-paths-over-barrels.md` 참고. `npm run lint:barrels`가 CI에서 이를 강제한다 — 배럴이 없으면 디렉터리 지정 import는 모듈 해석 단계에서 실패하므로 `npm run tsc`가 함께 잡는다.
 - **`src/` 안 파일은 `export default`를 쓰지 않는다 — 전부 named export로 짓는다.** 단 `src/app/`의 Next.js 라우트 파일은 프레임워크가 `export default`를 강제하므로 예외이며, 대상 파일 목록은 `src/app/AGENTS.md`를 따른다.
 - 폴더의 공개 API를 재수출 목록으로 선언하지 않는다 — 무엇을 외부에서 써도 되는지는 각 계층 `AGENTS.md`의 역할 경계가 규정한다.
+- **`boundary.ts`가 Route Handler용 `NextResponse` 변환과 Server Action용 반환 오류 변환을 함께 소유하는 것은 `src/` 루트의 명시적 예외다** — 역할로는 둘이지만 "AppError를 바깥 세계 표현으로 번역"이라는 개념 하나이고 `ERROR_STATUS_MAP`·마스킹 정책을 공유한다. 프레임워크 Adapter와 Action 경계로 쪼개면 그 공유 상태를 어디 둘지가 새 문제로 남으므로 분할하지 않는다.
 - 로컬 상태로 충분한 걸 곧바로 Context나 Zustand로 확장하지 않는다 — 클라이언트 상태 범위는 로컬 → Context API(`src/ui/context/`) → Zustand(`src/ui/stores/`) 순으로만 넓힌다.
 - 서버에서 온 데이터를 Context/Zustand로 직접 옮기지 않는다 — 캐싱·중복 호출 방지는 `useSWR`(주로 `src/ui/hooks/`의 훅 안에서 Zustand 구독과 함께 조합)이 전담한다.
 - **구현체 하나가 2곳 이상의 구체적 소비처에서 쓰이면, 이름에 그 소비처 중 하나를 특정하지 않는다** — 특정하면 그 이름이 다른 소비처 입장에선 의미가 맞지 않게 된다.

--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — src/adapters/
 
 > 외부 SDK와 브라우저·프레임워크 API 경계를 감싸는 계층.
-> Last updated: 2026-08-20
+> Last updated: 2026-09-02
 
 ## 공통 디렉토리 컨벤션
 
@@ -26,5 +26,11 @@
 ## 경계
 
 비즈니스 규칙과 DB 접근을 두지 않는다. 공용 타입과 순수 계산은 `src/core/`를 사용한다.
+
+`browser/`는 **대체·스텁이 필요한 capability**를 감싼다 — 권한 게이트가 있거나(`navigator.clipboard`, `navigator.geolocation`), 비결정적이거나(`crypto.randomUUID`), 외부 SDK·앱을 호출하는(portone, daum, kakao, deeplink) 것이다. 렌더 부수효과로서의 DOM 조작·이벤트 리스너·미디어쿼리(`document.body.style`, `addEventListener`, `matchMedia`, `document.cookie`)는 Adapter 대상이 아니며 컴포넌트나 `src/ui/hooks/`에 남긴다.
+
+판정 기준은 "브라우저 전역을 쓰는가"가 아니라 "이름 붙는 capability 하나를 이루고 통째로 바꿔치기할 수 있는가"다. `browser/deeplink/`가 SDK 없이 `window.open`·`window.location`만 쓰고도 Adapter인 이유는 "지도 앱 열기"라는 capability와 티맵 실패 시 폴백 정책을 소유하기 때문이다. `document.body.style.overflow = "hidden"` 한 줄은 그런 단위가 아니다.
+
+전역 접근을 전부 Adapter로 감싸면 서로 무관한 API가 `browser/dom/` 같은 자루 폴더에 모여 "폴더 하나 = 경계 하나" 불변식이 깨진다.
 
 소비자는 구현 파일을 직접 지정해 import한다(`@/adapters/browser/portone/request-payment`).

--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — src/app/
 
-> Last updated: 2026-07-28
+> Last updated: 2026-09-02
 
 Next.js App Router 진입점 — 공유 `layout.tsx`/독립 `error.tsx` 근거가 있는 라우트를 그룹(`(folder)`)으로 묶어 섹션을 나눈다(그룹 목록·존재 근거는 아래 "라우트 그룹 구성" 참고). 괄호 폴더는 URL에 영향 없는 조직화 단위다. Route Handler(API) 세부 규칙은 `src/app/api/AGENTS.md`에서 관리한다.
 
@@ -44,6 +44,7 @@ root layout을 통째로 대체하기 때문에 생기는 제약:
 - self-fetching Server Component 컨테이너는 `page.tsx`와 동일하게 얇게 유지한다 — organism을 배치(grid/flex/spacing, 목록 매핑 등)하는 코드가 하나라도 있으면 그 부분을 별도 순수 컴포넌트(`_components/` 또는 공용 티어)로 추출한다. 위임 하나(`return <XGrid data={data} />` 형태)만 남기면 렌더 없이 직접 호출 + 반환 타입·props 확인만으로 검증 가능해진다 — 안에서 직접 조립하면 page.tsx가 겪던 Unit/Component/Integration 3갈래 애매함이 그대로 재발한다. client 훅 기반 컨테이너(`useSWR` 등)는 이 규칙 대상이 아니다 — Rules of Hooks상 애초에 렌더 없이 호출할 수 없어 조립 코드 유무와 무관하게 항상 Component다.
 - 로컬 UI 상태(`useState` open/close, controlled input), 서버와 무관한 client 계산/타이머(`useMemo`, `setInterval` 기반 훅), mutation 없는 단순 페이지 이동(`<Link>`, `Button asChild`)만 다루면 컨테이너가 아니므로 `_components/`에 둔다.
 - 2개 이상 라우트가 공유하는 순수함수/UI/훅/타입/상수를 라우트 폴더 안에 남겨두지 않는다 — 순수함수는 `src/core/utils/`, UI는 `src/ui/components/`, 훅은 `src/ui/hooks/`, 타입은 `src/core/types/`, 상수는 `src/core/constants/`로 승격한다(각 폴더 AGENTS.md 참고).
+- 반대로 소비자가 한 라우트 하위에만 있으면 `_utils`/`_hooks`/`_types`/`_constants`에 그대로 둔다 — 그 라우트 안에서 소비자가 여럿이어도 마찬가지다. 승격 기준은 재사용 **가능성**이 아니라 **2개 이상 라우트가 실제로 공유하는가**다. 순수하다는 이유만으로 `core/`에 올리면 공용 표면만 넓어지고, 그 함수가 원래 어느 라우트 것이었는지 추적할 단서도 사라진다.
 
 ## Critical Conventions
 


### PR DESCRIPTION
## Summary

- 디렉터리 전수 조사 보고서를 `_workspace/directory-audit/report.md`로 기록하고, 처방·우선순위·판정 이견을 담은 실행 계획을 `plan.md`로 분리했다. 보고서에 처방을 섞으면 같은 코드·같은 규칙 문서로 재실행했을 때 같은 판정이 나온다는 성질이 깨져서, 두 번째 감사와의 비교가 불가능해진다.
- 감사가 규칙 문서로 판정하지 못한 회색지대 6건 중 4건을 규칙 문서 자체에 반영했다. 나머지 2건(`ui/hooks` 승격 임계점, `_components`→`_containers` 처리 방식)은 기존 문장이 이미 답을 갖고 있어 수정하지 않았다. 결정을 계획서에만 적으면 다음 감사가 같은 질문을 반복하게 된다.
- `src/app/AGENTS.md` — 소비자가 한 라우트 안에만 있으면 `_utils`/`_hooks`/`_types`/`_constants`에 잔류한다. 승격 기준은 재사용 가능성이 아니라 2개 이상 라우트의 실제 공유다.
- `src/adapters/AGENTS.md` — `browser/`는 대체·스텁이 필요한 capability(권한 게이트, 비결정적 값, 외부 SDK 호출)만 감싼다. DOM 조작·이벤트 리스너·미디어쿼리는 제외한다 — 전부 감싸면 `browser/dom/` 자루 폴더가 생겨 ADR-0002의 "폴더 하나 = 경계 하나" 불변식이 깨진다.
- `src/AGENTS.md` — `boundary.ts`가 `NextResponse` 변환과 Server Action 오류 변환을 함께 소유하는 것을 루트의 명시적 예외로 명문화했다.
- `docs/conventions/route-naming.md` — 합성어 세그먼트는 하이픈으로 분리하고(`kakaomap` → `kakao-map`), API 경로에서 행위는 HTTP 메서드로 표현한다(`POST /api/orders`).

## Test plan

- Not run: 문서 전용 변경으로 코드 변경이 없다.