### PR TITLE
chore(adapters): 누락된 cloudinary 런타임 marker를 복구한다

### DIFF
--- a/src/adapters/browser/cloudinary/widget.tsx
+++ b/src/adapters/browser/cloudinary/widget.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import "client-only";
+
 import { useEffect, useMemo, useState } from "react";
 import { CldUploadWidget } from "next-cloudinary";
 import type { CloudinaryUploadWidgetResults } from "next-cloudinary";

--- a/src/adapters/server/cloudinary/publicId.ts
+++ b/src/adapters/server/cloudinary/publicId.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 // Cloudinary 업로드 응답의 secure_url(DB에 저장되는 형태)에서 publicId를 역산한다 —
 // 이 프로젝트 업로드 위젯은 public_id를 직접 지정하지 않아(widget.tsx) Cloudinary가
 // "v{version}/{folder}/{자동생성 파일명}.{ext}" 형태로 발급한다. deleteProductAsset은


### PR DESCRIPTION
## Summary

- ADR-0002는 adapter에 가드를 둘 겹으로 둔다 — 폴더 경로가 런타임을 나타내고, `server-only`/`client-only` import가 그것을 빌드 타임에 강제한다. cloudinary 모듈 2개는 경로만 있고 marker가 없어, 잘못된 쪽에서 import해도 배포 전까지 드러나지 않는 상태였다.
- `adapters/browser/cloudinary/widget.tsx` — `"use client"` 지시어 다음에 `import "client-only";`. 형제 `browser/daum/useDaumPopup.ts`와 같은 배치다.
- `adapters/server/cloudinary/publicId.ts` — 첫 줄에 `import "server-only";`. `services/product.ts`와 같은 배치다.
- 테스트는 둘 다 영향 없다. vitest가 node project용으로 `server-only`를 `test/support/setup/server-only.ts` 스텁으로 alias하고, widget은 소비자 3곳이 모두 `vi.mock`으로 대체해 직접 로드하는 건 자기 jsdom 테스트뿐인데 거기서 `client-only`는 빈 모듈로 해석된다.

## 참고 — 이번 범위에서 다루지 않은 것

`extractPublicId`는 I/O가 없는 순수 문자열 함수라 ADR-0001 기준으로는 `core/utils/` 후보이기도 하다. 다만 Cloudinary가 발급하는 `v{version}/{folder}/{name}.{ext}` 형태를 역산하는 adapter 고유 지식이라 판단이 갈린다. 이 PR은 marker 복구가 목적이라 위치는 건드리지 않았다.

## Test plan

- `npm run lint` — 통과
- `npm run tsc` — 통과
- `npm run test:unit` — 29 files / 244 tests 통과 (`publicId.unit.test.ts` 포함)
- `npm run test:component` — 105 files / 402 tests 통과 (`widget.component.test.ts` 포함)