### PR TITLE
refactor(types): 도메인 타입을 재수출 대신 core에서 직접 import한다

### DIFF
--- a/src/app/(admin)/admin/premium-features/_components/PremiumFeatureCardAction.tsx
+++ b/src/app/(admin)/admin/premium-features/_components/PremiumFeatureCardAction.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import { Button } from "@/ui/components/atoms/button";
 import { Edit, Trash2 } from "lucide-react";
-import type { PremiumFeature } from "@/services/premiumFeature";
+import type { PremiumFeature } from "@/core/domain/premium-feature";
 import { useAdminModalStore } from "@/ui/stores/use-app-store";
 const PremiumFeatureCardAction = ({
   premiumFeature,

--- a/src/app/(admin)/admin/premium-features/_containers/PremiumFeatureDialog.tsx
+++ b/src/app/(admin)/admin/premium-features/_containers/PremiumFeatureDialog.tsx
@@ -3,7 +3,7 @@
 import { useActionState, useEffect } from "react";
 import { toast } from "sonner";
 
-import type { PremiumFeature } from "@/services/premiumFeature";
+import type { PremiumFeature } from "@/core/domain/premium-feature";
 import { updatePremiumFeature } from "@/actions/updatePremiumFeature";
 import type { APIResponse } from "@/core/domain/error";
 import { hasFieldErrors } from "@/core/utils/error";

--- a/src/app/(admin)/admin/products/_components/ProductTableRow.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductTableRow.tsx
@@ -2,7 +2,7 @@ import { Eye, Heart, ShoppingCart } from "lucide-react";
 import { AppImage } from "@/ui/components/atoms/app-image";
 import { Badge } from "@/ui/components/atoms/badge";
 import { TypographyMuted, TypographySmall } from "@/ui/components/atoms/typography";
-import type { Product } from "@/services/product";
+import type { Product } from "@/core/domain/product";
 import { ProductTableRowAction } from "../_containers/ProductTableRowAction";
 import { ProductTableRowSelect } from "../_containers/ProductTableRowSelect";
 import type { ProductCategory, SubCategory } from "@/core/domain/product-category";

--- a/src/app/(admin)/admin/products/_containers/ProductEditDialog.tsx
+++ b/src/app/(admin)/admin/products/_containers/ProductEditDialog.tsx
@@ -3,7 +3,7 @@
 import type React from "react";
 import { useActionState, useEffect, useState } from "react";
 import { updateProduct } from "@/actions/updateProduct";
-import type { Product } from "@/services/product";
+import type { Product } from "@/core/domain/product";
 import { Spinner } from "@/ui/components/atoms/spinner";
 import { Alert } from "@/ui/components/molecules/Alert";
 import { ImageField } from "@/ui/components/organisms/ImageField";

--- a/src/app/(admin)/admin/products/_containers/ProductTableRowSelect.tsx
+++ b/src/app/(admin)/admin/products/_containers/ProductTableRowSelect.tsx
@@ -5,7 +5,7 @@ import { isStatus, STATUS_ITEMS } from "@/app/(admin)/admin/products/_types/stat
 import { updateProductStatus } from "@/actions/updateProductStatus";
 import { toast } from "sonner";
 import { BaseSelect } from "@/ui/components/molecules/BaseSelect";
-import type { Product } from "@/services/product";
+import type { Product } from "@/core/domain/product";
 const ProductTableRowSelect = ({ product }: { product: Product }) => {
   const router = useRouter();
   const [status, setStatus] = useState<string>(product.status);

--- a/src/app/(admin)/admin/products/new/_containers/ProductRegistrationForm.tsx
+++ b/src/app/(admin)/admin/products/new/_containers/ProductRegistrationForm.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 
 import { createProduct } from "@/actions/createProduct";
 import type { APIResponse } from "@/core/domain/error";
-import type { PremiumFeature } from "@/services/premiumFeature";
+import type { PremiumFeature } from "@/core/domain/premium-feature";
 import { ProductRegistrationForm as PureProductRegistrationForm } from "../_components/ProductRegistrationForm";
 import { routes } from "@/core/domain/routes";
 export function ProductRegistrationForm({

--- a/src/app/(main)/(products)/products/[category]/[id]/_components/ProductDetailTemplate.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_components/ProductDetailTemplate.tsx
@@ -1,5 +1,5 @@
-import type { Product } from "@/services/product";
-import type { PremiumFeature } from "@/services/premiumFeature";
+import type { Product } from "@/core/domain/product";
+import type { PremiumFeature } from "@/core/domain/premium-feature";
 import type { ReviewListPage, ReviewSortType } from "@/core/domain/review";
 import { ProductSummary } from "../_containers/ProductSummary";
 import { ProductFeatures } from "./ProductFeatures";

--- a/src/app/(main)/(products)/products/[category]/[id]/_containers/ProductSummary.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_containers/ProductSummary.tsx
@@ -4,8 +4,8 @@ import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 
 import { useOrderStore } from "@/ui/stores/use-app-store";
-import type { Product } from "@/services/product";
-import type { PremiumFeature } from "@/services/premiumFeature";
+import type { Product } from "@/core/domain/product";
+import type { PremiumFeature } from "@/core/domain/premium-feature";
 
 import type { CheckoutItem } from "@/core/domain/checkout";
 import { ProductSummary as PureProductSummary } from "../_components/ProductSummary";

--- a/src/app/(main)/(products)/products/[category]/_containers/ProductCatalog.tsx
+++ b/src/app/(main)/(products)/products/[category]/_containers/ProductCatalog.tsx
@@ -3,7 +3,7 @@
 import { useProducts } from "@/ui/hooks/useProducts";
 import { usePremiumFeature } from "@/ui/hooks/usePremiumFeatures";
 import { ProductCatalog as ProductCatalogView } from "@/app/(main)/(products)/products/[category]/_components/ProductCatalog";
-import type { Product } from "@/services/product";
+import type { Product } from "@/core/domain/product";
 import type { ProductCategory, SubCategory } from "@/core/domain/product-category";
 
 export function ProductCatalog({

--- a/src/app/(main)/_components/HomeTemplate.tsx
+++ b/src/app/(main)/_components/HomeTemplate.tsx
@@ -1,4 +1,4 @@
-import type { Product } from "@/services/product";
+import type { Product } from "@/core/domain/product";
 import { EcommerceHero } from "./EcommerceHero";
 import { LiveDemoSection } from "./LiveDemoSection";
 import { SubCategoryNavSection } from "./SubCategoryNavSection";

--- a/src/app/(main)/_components/PopularProductsSection.tsx
+++ b/src/app/(main)/_components/PopularProductsSection.tsx
@@ -4,7 +4,7 @@ import { WheelGesturesPlugin } from "embla-carousel-wheel-gestures";
 import { TypographyH2 } from "@/ui/components/atoms/typography";
 import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from "@/ui/components/atoms/carousel";
 import { ProductCard } from "@/ui/components/molecules/ProductCard";
-import type { Product } from "@/services/product";
+import type { Product } from "@/core/domain/product";
 import { POPULAR_PRODUCTS_MIN_ITEMS } from "@/core/domain/product";
 
 interface PopularProductsSectionProps {

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { HomeTemplate } from "@/app/(main)/_components/HomeTemplate";
-import type { Product } from "@/services/product";
+import type { Product } from "@/core/domain/product";
 import { getAvailableSubCategoriesService, getPopularProductsService } from "@/services/product";
 import type { AvailableSubCategory } from "@/core/domain/product-category";
 import { POPULAR_PRODUCTS_LIMIT } from "@/core/domain/product";

--- a/src/models/product.model.ts
+++ b/src/models/product.model.ts
@@ -3,11 +3,10 @@ import type { Model } from "mongoose";
 import mongoose, { model, Schema } from "mongoose";
 import type { ProductCategory, SubCategory } from "@/core/domain/product-category";
 import type { InvitationTheme } from "@/core/domain/theme";
-import type { ProductJSON, ProductStatus } from "@/core/domain/product";
+import type { ProductStatus } from "@/core/domain/product";
 import { SUB_CATEGORY_MAP, PRODUCT_CATEGORIES } from "@/core/domain/product-category";
 import { INVITATION_THEMES } from "@/core/domain/theme";
 
-export type { ProductCategory, ProductJSON, SubCategory };
 export { SUB_CATEGORY_MAP };
 
 export type Status = ProductStatus;

--- a/src/services/premiumFeature.ts
+++ b/src/services/premiumFeature.ts
@@ -4,7 +4,6 @@ import { FeatureModel } from "@/models/feature.model";
 import type { PremiumFeatureDto } from "@/core/schemas/request/premiumFeature.schema";
 import type { PremiumFeature } from "@/core/domain/premium-feature";
 import { AppError } from "@/core/domain/error";
-export type { PremiumFeature } from "@/core/domain/premium-feature";
 import { dbConnect } from "@/db/connect";
 
 import mongoose from "mongoose";

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -1,5 +1,6 @@
 import "server-only";
-import type { ProductJSON, ProductDB, IProduct } from "@/models/product.model";
+import type { ProductDB, IProduct } from "@/models/product.model";
+import type { ProductJSON } from "@/core/domain/product";
 import { ProductModel, MobileInvitationProductModel } from "@/models/product.model";
 import type { ProductDto } from "@/core/schemas/request/product.schema";
 import { dbConnect } from "@/db/connect";
@@ -20,8 +21,6 @@ import { requireAdmin, requireAuth } from "./auth";
 import { deleteProductAsset } from "@/adapters/server/cloudinary/cleanup";
 import { extractPublicId } from "@/adapters/server/cloudinary/publicId";
 
-// Product 타입을 export (다른 파일에서 사용)
-export type Product = ProductJSON;
 
 type ProductUploadInput = ProductDto & {
   previewUrl?: string;


### PR DESCRIPTION
## Summary

- ADR-0004는 심볼이 정의된 파일을 직접 지정해 import하도록 요구하는데, route-local 컴포넌트 12개가 `Product`·`PremiumFeature`를 services 경유로 가져오고 있었다.
- 감사 보고서는 이를 "services가 core 도메인 타입을 소유·재노출"로 읽었으나 **소유가 아니다.** `core/domain/product.ts:44`에 `export type Product = ProductJSON`이, `core/domain/premium-feature.ts`에 `PremiumFeature`가 이미 정의돼 있다. `services/product.ts`가 그 alias를 중복 선언하고 `services/premiumFeature.ts`가 재노출했을 뿐이라, 타입을 옮길 필요 없이 경로만 바꾸면 되고 심볼 이름도 그대로다.
- 재수출 3줄을 제거했다 — services 2곳과, 아무 importer도 쓰지 않던 `models/product.model.ts`의 `export type { ProductCategory, ProductJSON, SubCategory }`. 서비스 내부에서는 `ProductJSON`을 모델 대신 core에서 받는다.
- 정리 목적이 아니다. 이 변경으로 UI 파일들이 `import "server-only"`를 품은 모듈을 더 이상 이름으로 지목하지 않는다. 지금은 `import type`이라 런타임에 지워지지만 `type` 키워드가 실수로 빠지면 서버 모듈이 클라이언트 번들로 끌려갔고, 그 경로가 구조적으로 사라졌다.

## 감사 집계에 대한 메모

축1/Low 14건과 축2/Low 9건은 상당 부분 같은 현상을 두 축에 나눠 담은 결과였다. 실행 계획 §1 이견 2는 "원인 2 / 파급 12"로 적었는데, 실제로는 원인 0(타입은 이미 core에 있음) / 재수출 3줄 + 경로 14개다.

## Test plan

- `npm run lint` — 통과
- `npm run tsc` — 통과
- `npm run lint:barrels` — 통과
- `npm run test:unit` — 29 files / 244 tests 통과
- `npm run test:component` — 105 files / 402 tests 통과
- `npm run test:integration` — 17 files / 320 tests 통과