### PR TITLE
refactor(adapters): 클립보드·위치 조회를 browser adapter로 감싼다

### DIFF
--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -17,9 +17,11 @@
 | `server/jose/` | JWT 암복호화 | server-only |
 | `server/nodemailer/` | 이메일 전송 | server-only |
 | `server/seoul-open-api/` | 서울 열린데이터광장 API 호출·가드·에러분류 | server-only |
+| `browser/clipboard/` | 클립보드 쓰기 | client-only |
 | `browser/cloudinary/` | 브라우저 업로드 | client-only |
 | `browser/daum/` | 주소 팝업 | client-only |
 | `browser/deeplink/` | 지도 앱 딥링크 | client-only |
+| `browser/geolocation/` | 현재 위치 조회 | client-only |
 | `browser/kakao/` | 지도 SDK 로더 | client-only |
 | `browser/portone/` | 브라우저 결제 SDK | client-only |
 

--- a/src/adapters/browser/clipboard/write-text.component.test.ts
+++ b/src/adapters/browser/clipboard/write-text.component.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { writeText } from "./write-text";
+
+describe("writeText", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("navigator.clipboard에 텍스트를 위임한다", async () => {
+    const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText: clipboardWriteText } });
+
+    await writeText("복사할 텍스트");
+
+    expect(clipboardWriteText).toHaveBeenCalledWith("복사할 텍스트");
+  });
+
+  it("권한이 거부되면 거부 사유를 그대로 전파한다", async () => {
+    const denied = new Error("NotAllowedError");
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText: vi.fn().mockRejectedValue(denied) },
+    });
+
+    await expect(writeText("복사할 텍스트")).rejects.toBe(denied);
+  });
+});

--- a/src/adapters/browser/clipboard/write-text.ts
+++ b/src/adapters/browser/clipboard/write-text.ts
@@ -1,0 +1,9 @@
+import "client-only";
+
+/**
+ * Clipboard 쓰기 경계 — 권한 게이트가 있어 호출자가 성공을 가정할 수 없고,
+ * 테스트에서는 전역 navigator를 건드리지 않고 이 모듈만 대체하면 된다.
+ * 실패 사유는 그대로 던져 호출자가 UI 문구를 결정한다.
+ */
+export const writeText = (text: string): Promise<void> =>
+  navigator.clipboard.writeText(text);

--- a/src/adapters/browser/geolocation/current-position.component.test.ts
+++ b/src/adapters/browser/geolocation/current-position.component.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { getCurrentCoordinates } from "./current-position";
+
+describe("getCurrentCoordinates", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("좌표를 lat/lng 형태로 정규화해 돌려준다", async () => {
+    const getCurrentPosition = vi.fn((success) => {
+      success({ coords: { latitude: 37.5, longitude: 127.0 } });
+    });
+    vi.stubGlobal("navigator", { geolocation: { getCurrentPosition } });
+
+    await expect(getCurrentCoordinates()).resolves.toEqual({
+      lat: 37.5,
+      lng: 127.0,
+    });
+  });
+
+  it("권한 거부 등으로 실패하면 throw하지 않고 null로 떨어뜨린다", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const getCurrentPosition = vi.fn((_success, error) => {
+      error(new Error("denied"));
+    });
+    vi.stubGlobal("navigator", { geolocation: { getCurrentPosition } });
+
+    await expect(getCurrentCoordinates()).resolves.toBeNull();
+
+    errorSpy.mockRestore();
+  });
+});

--- a/src/adapters/browser/geolocation/current-position.ts
+++ b/src/adapters/browser/geolocation/current-position.ts
@@ -1,0 +1,28 @@
+import "client-only";
+
+export interface Coordinates {
+  lat: number;
+  lng: number;
+}
+
+/**
+ * Geolocation 경계 — 권한 프롬프트가 걸려 있어 결과가 환경마다 다르고,
+ * 콜백 API라 호출자가 매번 Promise로 감싸야 했다.
+ *
+ * 거부·실패는 throw하지 않고 null로 떨어뜨린다 — 위치는 있으면 좋은 정보지
+ * 없으면 화면이 못 뜨는 값이 아니라서, 호출자가 try/catch 대신 분기만 하면 된다.
+ */
+export const getCurrentCoordinates = (): Promise<Coordinates | null> =>
+  new Promise((resolve) => {
+    navigator.geolocation.getCurrentPosition(
+      (position) =>
+        resolve({
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+        }),
+      (error) => {
+        console.error(error);
+        resolve(null);
+      },
+    );
+  });

--- a/src/ui/hooks/useCopy.ts
+++ b/src/ui/hooks/useCopy.ts
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
+import { writeText } from "@/adapters/browser/clipboard/write-text";
 
 /**
  * 텍스트 복사 로직을 관리하는 커스텀 훅
@@ -11,7 +12,7 @@ export function useCopy() {
 
   const copyToClipboard = async (text: string, onCopySuccess?: () => void) => {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeText(text);
       setIsCopied(true);
       toast.success("복사되었습니다.");
       onCopySuccess?.();

--- a/src/ui/hooks/useNavigationGeo.component.test.ts
+++ b/src/ui/hooks/useNavigationGeo.component.test.ts
@@ -1,28 +1,27 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 
 vi.mock("./useKakaomapGeocode", () => ({
   useKakaomapGeocode: vi.fn(),
 }));
 
+vi.mock("@/adapters/browser/geolocation/current-position", () => ({
+  getCurrentCoordinates: vi.fn(),
+}));
+
 import { useKakaomapGeocode } from "./useKakaomapGeocode";
+import { getCurrentCoordinates } from "@/adapters/browser/geolocation/current-position";
 import { useNavigationGeo } from "./useNavigationGeo";
 
 describe("useNavigationGeo", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useKakaomapGeocode).mockReturnValue({ lat: 37.5, lng: 127.0 });
+    vi.mocked(getCurrentCoordinates).mockResolvedValue(null);
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("navigator.geolocation으로 현재 위치를 가져와 current에 반영한다", async () => {
-    const getCurrentPosition = vi.fn((success) => {
-      success({ coords: { latitude: 37.5, longitude: 127.0 } });
-    });
-    vi.stubGlobal("navigator", { geolocation: { getCurrentPosition } });
+  it("현재 위치를 가져와 current에 반영한다", async () => {
+    vi.mocked(getCurrentCoordinates).mockResolvedValue({ lat: 37.5, lng: 127.0 });
 
     const { result } = renderHook(() => useNavigationGeo("서울"));
 
@@ -31,28 +30,16 @@ describe("useNavigationGeo", () => {
     });
   });
 
-  it("geolocation 실패 시 current를 null로 유지한다", async () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const getCurrentPosition = vi.fn((_success, error) => {
-      error(new Error("denied"));
-    });
-    vi.stubGlobal("navigator", { geolocation: { getCurrentPosition } });
-
+  it("위치 조회가 null이면 current를 초기값으로 유지한다", async () => {
     const { result } = renderHook(() => useNavigationGeo("서울"));
 
     await waitFor(() => {
-      expect(getCurrentPosition).toHaveBeenCalled();
+      expect(getCurrentCoordinates).toHaveBeenCalled();
     });
     expect(result.current.current).toEqual({ lat: null, lng: null });
-
-    errorSpy.mockRestore();
   });
 
   it("target은 useKakaomapGeocode 결과를 그대로 전달한다", () => {
-    vi.stubGlobal("navigator", {
-      geolocation: { getCurrentPosition: vi.fn() },
-    });
-
     const { result } = renderHook(() => useNavigationGeo("서울"));
 
     expect(useKakaomapGeocode).toHaveBeenCalledWith("서울");

--- a/src/ui/hooks/useNavigationGeo.ts
+++ b/src/ui/hooks/useNavigationGeo.ts
@@ -2,29 +2,13 @@
 
 import { useEffect, useState } from "react";
 import type { GeoState } from "@/adapters/browser/deeplink/open-app";
+import { getCurrentCoordinates } from "@/adapters/browser/geolocation/current-position";
 import { useKakaomapGeocode } from "./useKakaomapGeocode";
 
 export interface NavigationGeo {
   current: GeoState;
   target: GeoState;
 }
-
-const getCurrentCoordinates = (): Promise<GeoState | null> => {
-  return new Promise((resolve) => {
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        resolve({
-          lng: position.coords.longitude,
-          lat: position.coords.latitude,
-        });
-      },
-      (err) => {
-        console.error(err);
-        resolve(null);
-      },
-    );
-  });
-};
 
 export function useNavigationGeo(address: string): NavigationGeo {
   const [current, setCurrent] = useState<GeoState>({ lng: null, lat: null });


### PR DESCRIPTION
## Summary

- #233에서 `adapters/AGENTS.md §경계`에 "`browser/`는 대체·스텁이 필요한 capability를 감싼다 — 권한 게이트가 있거나, 비결정적이거나, 외부 SDK·앱을 호출하는 것"이라는 기준을 박았다. 이 PR이 그 기준의 첫 적용 사례다.
- 감사가 찾은 브라우저 전역 직접 접근 중 권한 게이트 항목에 해당하는 둘을 감쌌다 — `navigator.clipboard.writeText`(`useCopy`)와 `navigator.geolocation.getCurrentPosition`(`useNavigationGeo`). DOM 조작·이벤트 리스너·미디어쿼리는 같은 기준에 따라 현행 유지다.
- 효과는 테스트에서 드러난다. `useNavigationGeo.component.test.ts`는 geolocation 반환값을 정하려고 `vi.stubGlobal("navigator", …)`로 전역을 통째로 갈아끼우고 있었는데, 이제 모듈 하나만 mock한다.
- adapter가 불편한 부분을 가져간다. `getCurrentCoordinates`는 콜백 API를 Promise로 바꾸고, 권한 거부 시 throw 대신 `null`로 떨어뜨린다 — 위치 없음은 실패가 아니라 분기이므로 호출자가 try/catch 없이 처리한다.

## 타입 판단

`getCurrentCoordinates`는 `deeplink/open-app.ts`의 `GeoState`를 빌려 쓰지 않고 자체 `Coordinates`를 정의한다.

- adapter가 다른 adapter 폴더의 타입을 가져오면 ADR-0002의 "폴더 하나 = 경계 하나"가 흐려진다.
- 두 타입은 의미가 다르다. `GeoState`는 `{lat: number | null; lng: number | null}`로 필드별 "아직 모름"을 표현하는 훅 상태 타입이고, 위치 조회 결과는 좌표가 있거나 통째로 없거나다. `Coordinates | null`이 그것을 정확히 말한다.

`GeoState`가 adapter에 정의돼 있고 `ui/hooks` 2개가 그것을 import하는 구조는 ADR-0001상 `core/` 후보로 보이지만, 이 PR 목적 밖이라 다루지 않았다.

## Test plan

- `npm run lint` — 통과
- `npm run tsc` — 통과
- `npm run test:unit` — 29 files / 244 tests 통과
- `npm run test:component` — 107 files / 406 tests 통과 (신규 adapter 테스트 2 files / 4 tests 포함)