### PR TITLE
refactor(api): 라우트가 들고 있던 유스케이스를 services로 옮긴다

### DIFF
--- a/src/app/api/subway/[station]/route.ts
+++ b/src/app/api/subway/[station]/route.ts
@@ -1,17 +1,8 @@
 import type { APIRouteResponse} from "@/boundary";
 import { routeSuccess, routeError } from "@/boundary";
-import { AppError } from "@/core/domain/error";
-import { fetchSeoulOpenApi } from "@/adapters/server/seoul-open-api/request";
-import { SUBWAY_LINE_COLORS, DEFAULT_SUBWAY_LINE_COLOR } from "@/core/domain/subway";
+import { getSubwayStationLines } from "@/services/subway";
 import type { SubwayStationLineInfoResponse } from "@/core/schemas/response/subway.schema";
 import type { NextRequest } from "next/server";
-
-const SERVICE_NAME = "SearchInfoBySubwayNameService";
-
-type SubwayNameSearchRow = {
-  STATION_NM: string;
-  LINE_NUM: string;
-};
 
 export const GET = async (
   _req: NextRequest,
@@ -20,20 +11,7 @@ export const GET = async (
   try {
     const { station } = await params;
 
-    const rows = await fetchSeoulOpenApi<SubwayNameSearchRow>(SERVICE_NAME, [1, 50, station]);
-
-    if (rows.length === 0) {
-      throw new AppError("NOT_FOUND", "해당 역을 찾을 수 없습니다.");
-    }
-
-    const uniqueLineNames = [...new Set(rows.map((row) => row.LINE_NUM))];
-
-    const lines = uniqueLineNames.map((name) => ({
-      name,
-      color: SUBWAY_LINE_COLORS[name] ?? DEFAULT_SUBWAY_LINE_COLOR,
-    }));
-
-    return routeSuccess({ station, lines });
+    return routeSuccess(await getSubwayStationLines(station));
   } catch (error) {
     return routeError(error);
   }

--- a/src/app/api/subway/[station]/route.unit.test.ts
+++ b/src/app/api/subway/[station]/route.unit.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/adapters/server/seoul-open-api/request", () => ({
+  fetchSeoulOpenApi: vi.fn(),
+}));
+
+import { fetchSeoulOpenApi } from "@/adapters/server/seoul-open-api/request";
+import { GET } from "./route";
+
+const buildRequest = (station: string) =>
+  new NextRequest(`http://localhost/api/subway/${encodeURIComponent(station)}`);
+
+const call = (station: string) =>
+  GET(buildRequest(station), { params: Promise.resolve({ station }) });
+
+describe("GET /api/subway/[station]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("중복 노선을 합치고 노선별 색상을 붙여 리턴한다", async () => {
+    vi.mocked(fetchSeoulOpenApi).mockResolvedValue([
+      { STATION_NM: "서울역", LINE_NUM: "01호선" },
+      { STATION_NM: "서울역", LINE_NUM: "01호선" },
+      { STATION_NM: "서울역", LINE_NUM: "04호선" },
+    ]);
+
+    const res = await call("서울역");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.station).toBe("서울역");
+    expect(body.data.lines.map((line: { name: string }) => line.name)).toEqual([
+      "01호선",
+      "04호선",
+    ]);
+    expect(
+      body.data.lines.every((line: { color: string }) => Boolean(line.color)),
+    ).toBe(true);
+  });
+
+  it("알 수 없는 노선명에는 기본 색상을 쓴다", async () => {
+    vi.mocked(fetchSeoulOpenApi).mockResolvedValue([
+      { STATION_NM: "가상역", LINE_NUM: "99호선" },
+    ]);
+
+    const res = await call("가상역");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.lines).toEqual([{ name: "99호선", color: "#6B7280" }]);
+  });
+
+  it("조회 결과가 없으면 404를 리턴한다", async () => {
+    vi.mocked(fetchSeoulOpenApi).mockResolvedValue([]);
+
+    const res = await call("없는역");
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.success).toBe(false);
+  });
+});

--- a/src/app/api/upload/signature/route.ts
+++ b/src/app/api/upload/signature/route.ts
@@ -1,25 +1,21 @@
 import type { NextRequest } from "next/server";
 import type { APIRouteResponse } from "@/boundary";
 import { routeSuccess, routeError } from "@/boundary";
-import { AppError } from "@/core/domain/error";
-import { requireAuth } from "@/services/auth";
-import { signUploadRequest } from "@/adapters/server/cloudinary/sign";
+import { createUploadSignatureForCurrentUser } from "@/services/upload";
 import type { UploadSignature } from "@/adapters/server/cloudinary/sign";
 
 export const POST = async (
   request: NextRequest,
 ): Promise<APIRouteResponse<UploadSignature>> => {
   try {
-    await requireAuth();
-
     const { folder: requestedFolder, paramsToSign } = await request.json();
-    const folder = requestedFolder ?? paramsToSign?.folder;
 
-    if (!folder) {
-      throw new AppError("VALIDATION", "folder 파라미터가 필요합니다.");
-    }
-
-    return routeSuccess(signUploadRequest(folder, paramsToSign));
+    return routeSuccess(
+      await createUploadSignatureForCurrentUser(
+        requestedFolder ?? paramsToSign?.folder,
+        paramsToSign,
+      ),
+    );
   } catch (error) {
     return routeError(error);
   }

--- a/src/services/subway.ts
+++ b/src/services/subway.ts
@@ -1,8 +1,15 @@
 import "server-only";
 import { unstable_cache } from "next/cache";
 import { fetchSeoulOpenApi } from "@/adapters/server/seoul-open-api/request";
+import { AppError } from "@/core/domain/error";
+import {
+  SUBWAY_LINE_COLORS,
+  DEFAULT_SUBWAY_LINE_COLOR,
+} from "@/core/domain/subway";
+import type { SubwayStationLineInfoResponse } from "@/core/schemas/response/subway.schema";
 
-const SERVICE_NAME = "SearchSTNBySubwayLineInfo";
+const STATION_LIST_SERVICE_NAME = "SearchSTNBySubwayLineInfo";
+const STATION_LINE_SERVICE_NAME = "SearchInfoBySubwayNameService";
 const CACHE_REVALIDATE_SECONDS = 60 * 60 * 24;
 
 type SubwayLineInfoRow = {
@@ -16,7 +23,7 @@ type SubwayLineInfoRow = {
 // throw하면 캐시 쓰기 자체를 건너뛰므로, 실패가 캐시에 갇히는 문제가 없다.
 const getCachedSubwayStationNames = unstable_cache(
   async (): Promise<string[]> => {
-    const rows = await fetchSeoulOpenApi<SubwayLineInfoRow>(SERVICE_NAME, [1, 1000]);
+    const rows = await fetchSeoulOpenApi<SubwayLineInfoRow>(STATION_LIST_SERVICE_NAME, [1, 1000]);
     return [...new Set(rows.map((row) => row.STATION_NM))];
   },
   ["subway-station-names"],
@@ -30,4 +37,35 @@ export async function getAllSubwayStationNames(): Promise<string[]> {
 export async function isValidSubwayStationName(name: string): Promise<boolean> {
   const names = await getAllSubwayStationNames();
   return names.includes(name);
+}
+
+type SubwayNameSearchRow = {
+  STATION_NM: string;
+  LINE_NUM: string;
+};
+
+// 한 역이 환승역이면 노선 수만큼 행이 내려온다 — 노선명으로 합친 뒤 표시용 색상을 붙인다.
+// 역 목록(위)과 달리 캐시하지 않는다: 입력 역명마다 키가 갈려 캐시 적중률이 낮고,
+// 청첩장 저장 시점에 한 번 부르는 경로라 매 요청 비용이 문제되지 않는다.
+export async function getSubwayStationLines(
+  station: string,
+): Promise<SubwayStationLineInfoResponse> {
+  const rows = await fetchSeoulOpenApi<SubwayNameSearchRow>(
+    STATION_LINE_SERVICE_NAME,
+    [1, 50, station],
+  );
+
+  if (rows.length === 0) {
+    throw new AppError("NOT_FOUND", "해당 역을 찾을 수 없습니다.");
+  }
+
+  const uniqueLineNames = [...new Set(rows.map((row) => row.LINE_NUM))];
+
+  return {
+    station,
+    lines: uniqueLineNames.map((name) => ({
+      name,
+      color: SUBWAY_LINE_COLORS[name] ?? DEFAULT_SUBWAY_LINE_COLOR,
+    })),
+  };
 }

--- a/src/services/upload.ts
+++ b/src/services/upload.ts
@@ -1,0 +1,25 @@
+import "server-only";
+import { signUploadRequest } from "@/adapters/server/cloudinary/sign";
+import type { UploadSignature } from "@/adapters/server/cloudinary/sign";
+import { AppError } from "@/core/domain/error";
+import { requireAuth } from "./auth";
+
+/**
+ * 업로드 서명 발급 — 서명은 Cloudinary에 파일을 올릴 권한 자체이므로 로그인 확인이
+ * 발급의 일부다. 호출자가 인증을 먼저 부르는 것을 잊을 수 있는 자리에 두지 않는다.
+ *
+ * folder 검사가 인증 뒤에 오는 순서도 유스케이스의 일부다 — 미인증 호출자에게는
+ * 요청 본문이 어떻든 401로 답한다.
+ */
+export async function createUploadSignatureForCurrentUser(
+  folder: string | undefined,
+  paramsToSign?: Record<string, unknown>,
+): Promise<UploadSignature> {
+  await requireAuth();
+
+  if (!folder) {
+    throw new AppError("VALIDATION", "folder 파라미터가 필요합니다.");
+  }
+
+  return signUploadRequest(folder, paramsToSign);
+}


### PR DESCRIPTION
## Summary

- ADR-0001은 adapter와 비즈니스 규칙의 조합을 services에 두고, Route Handler에는 파싱·위임·응답만 남긴다. 두 라우트가 그 선을 넘어 있었다 — `subway/[station]`은 환승 노선 병합과 표시용 색상 매핑을 직접 했고, `upload/signature`는 "서명 발급에 로그인이 필요하다"는 규칙을 알고 있었다.
- `getSubwayStationLines`를 `services/subway.ts`의 기존 역 목록 조회 옆에 추가했다. 파일이 서울 열린데이터광장 API 두 개를 부르게 되어 `SERVICE_NAME` → `STATION_LIST_SERVICE_NAME`으로 구체화했다.
- 역 목록과 달리 `unstable_cache`를 쓰지 않는다 — 입력 역명마다 캐시 키가 갈려 적중률이 낮고, 청첩장 저장 시 한 번 부르는 경로라 매 요청 비용이 문제되지 않는다. 이유는 코드 주석에 남겼다.
- `createUploadSignatureForCurrentUser`는 `folder` 검사를 인증 뒤에 둔다. 검사를 라우트에 남기면 미인증 + folder 누락 요청이 401에서 400으로 바뀌는데, "미인증에게는 본문이 어떻든 401"이 이 유스케이스의 일부라고 봤다.

## 남은 동작 차이 1건

원래 라우트는 `requireAuth()`를 `request.json()`보다 먼저 호출했다. 지금은 파싱이 먼저라, **깨진 JSON을 보낸 미인증 호출자**만 401 대신 파싱 에러로 응답한다. 이걸 보존하려면 인증을 라우트에 남겨야 해서 이번 변경의 목적과 충돌한다. 유출되는 정보가 없고 기존 테스트가 고정하는 경로(정상 본문 미인증 = 401, folder 누락 = 400)는 그대로다.

## 테스트 설계

`src/services/**`는 vitest `unit` project include에 없다(`src/app/api/**`, `src/actions/**`, `src/core/**` 등만 수집). 따라서 라우트 테스트가 서비스를 mock하면 "`requireAuth`가 실제로 호출되는가"라는 인증 커버리지가 통째로 사라진다.

그래서 라우트 테스트는 **adapter만 mock하고 서비스는 실제로 실행**시킨다. 기존 `upload/signature/route.unit.test.ts` 4건이 한 줄도 바뀌지 않고 통과하는 것이 그 증거이고, 신규 `subway/[station]/route.unit.test.ts` 3건도 같은 형태로 맞췄다(중복 노선 병합, 미등록 노선 기본 색상, 결과 없음 404).

## Test plan

- `npm run lint` — 통과
- `npm run tsc` — 통과
- `npm run lint:barrels` — 통과
- `npm run test:unit` — 30 files / 247 tests 통과 (신규 subway 3건 포함, upload 4건 무수정 통과)
- `npm run test:component` — 107 files / 406 tests 통과
- `npm run test:integration` — 17 files / 320 tests 통과