### PR TITLE
refactor(api): PortOne 은행 목록 조회를 server adapter로 감싼다

### DIFF
--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -16,6 +16,7 @@
 | `server/cookies/` | Next.js 쿠키 API | server-only |
 | `server/jose/` | JWT 암복호화 | server-only |
 | `server/nodemailer/` | 이메일 전송 | server-only |
+| `server/portone/` | 은행 목록 조회 | server-only |
 | `server/seoul-open-api/` | 서울 열린데이터광장 API 호출·가드·에러분류 | server-only |
 | `browser/clipboard/` | 클립보드 쓰기 | client-only |
 | `browser/cloudinary/` | 브라우저 업로드 | client-only |

--- a/src/adapters/server/portone/banks.ts
+++ b/src/adapters/server/portone/banks.ts
@@ -1,0 +1,57 @@
+import "server-only";
+import { AppError } from "@/core/domain/error";
+import { banksResponseSchema } from "@/core/schemas/response/banks.schema";
+import type { BanksResponse } from "@/core/schemas/response/banks.schema";
+
+const BANKS_URL = "https://api.portone.io/banks";
+
+/**
+ * PortOne 은행 목록 조회 — 계좌 입력 폼의 은행 선택지를 채운다.
+ *
+ * 응답을 스키마로 검증한 뒤 통과시킨다. 이 엔드포인트는 인증이 없어 점검 페이지나
+ * 프록시 오류가 200 HTML로 돌아올 수 있는데, 검증 없이 `items`만 꺼내면 그때
+ * `undefined`가 성공 응답에 담겨 화면에서야 터진다.
+ */
+export async function fetchBanks(): Promise<BanksResponse> {
+  let res: Response;
+  try {
+    res = await fetch(BANKS_URL);
+  } catch (error) {
+    throw new AppError(
+      "EXTERNAL_SERVICE",
+      `PortOne 은행 목록 요청 실패: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const text = await res.text();
+
+  if (!res.ok) {
+    throw new AppError(
+      "EXTERNAL_SERVICE",
+      `PortOne 은행 목록 조회 오류 (status=${res.status}): ${text.slice(0, 300)}`,
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new AppError(
+      "EXTERNAL_SERVICE",
+      `PortOne이 JSON이 아닌 응답을 반환함 (status=${res.status}): ${text.slice(0, 300)}`,
+    );
+  }
+
+  const parsed = banksResponseSchema.safeParse(
+    (json as { items?: unknown })?.items,
+  );
+
+  if (!parsed.success) {
+    throw new AppError(
+      "EXTERNAL_SERVICE",
+      "PortOne 은행 목록 응답 형태가 예상과 다릅니다.",
+    );
+  }
+
+  return parsed.data;
+}

--- a/src/adapters/server/portone/banks.unit.test.ts
+++ b/src/adapters/server/portone/banks.unit.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchBanks } from "./banks";
+import { AppError } from "@/core/domain/error";
+
+function mockResponse(status: number, ok: boolean, body: string): Response {
+  return {
+    ok,
+    status,
+    text: async () => body,
+  } as Response;
+}
+
+describe("fetchBanks", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("items 배열을 꺼내 리턴한다", async () => {
+    const body = JSON.stringify({
+      items: [
+        { bank: "KOOKMIN", name: { ko: "국민은행" } },
+        { bank: "SHINHAN", name: { ko: "신한은행" } },
+      ],
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(200, true, body));
+
+    await expect(fetchBanks()).resolves.toEqual([
+      { bank: "KOOKMIN", name: { ko: "국민은행" } },
+      { bank: "SHINHAN", name: { ko: "신한은행" } },
+    ]);
+  });
+
+  it("네트워크 실패를 EXTERNAL_SERVICE로 분류한다", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(fetchBanks()).rejects.toBeInstanceOf(AppError);
+    await expect(fetchBanks()).rejects.toMatchObject({
+      category: "EXTERNAL_SERVICE",
+    });
+  });
+
+  it("에러 상태코드를 EXTERNAL_SERVICE로 분류한다", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(503, false, JSON.stringify({ message: "unavailable" })),
+    );
+
+    await expect(fetchBanks()).rejects.toMatchObject({
+      category: "EXTERNAL_SERVICE",
+    });
+  });
+
+  it("JSON이 아닌 응답을 EXTERNAL_SERVICE로 분류한다", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, true, "<html>maintenance</html>"),
+    );
+
+    await expect(fetchBanks()).rejects.toMatchObject({
+      category: "EXTERNAL_SERVICE",
+    });
+  });
+
+  it("응답 형태가 계약과 다르면 200이어도 EXTERNAL_SERVICE로 분류한다", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, true, JSON.stringify({ items: [{ bank: "KOOKMIN" }] })),
+    );
+
+    await expect(fetchBanks()).rejects.toMatchObject({
+      category: "EXTERNAL_SERVICE",
+    });
+  });
+});

--- a/src/app/api/banks/route.ts
+++ b/src/app/api/banks/route.ts
@@ -1,12 +1,11 @@
 import type { APIRouteResponse} from "@/boundary";
 import { routeSuccess, routeError } from "@/boundary";
+import { fetchBanks } from "@/adapters/server/portone/banks";
 import type { BanksResponse } from "@/core/schemas/response/banks.schema";
 
 export const GET = async (): Promise<APIRouteResponse<BanksResponse>> => {
   try {
-    const res = await fetch("https://api.portone.io/banks");
-    const { items }: { items: BanksResponse } = await res.json();
-    return routeSuccess(items);
+    return routeSuccess(await fetchBanks());
   } catch (error) {
     return routeError(error);
   }


### PR DESCRIPTION
## Summary

- ADR-0001은 외부 SDK·API 경계를 `adapters/`에 두는데, `api/banks/route.ts`가 `api.portone.io`를 직접 호출하고 있어 상류 계약이 `src/app/api` 아래에 살고 있었다.
- `fetchBanks`를 새 `adapters/server/portone/` 폴더에 두고, `seoul-open-api/request.ts`가 이미 쓰는 형태를 그대로 따랐다 — 네트워크 실패·에러 상태코드·비-JSON 응답을 각각 `AppError("EXTERNAL_SERVICE")`로 분류한다.
- 라우트는 위임과 응답만 남는다.
- `adapters/AGENTS.md` 디렉토리 표에 `server/portone/`을 추가했다.

## 함께 고친 결함

기존 라우트는 `res.ok` 검사 없이 `res.json()` 결과에서 `items`를 바로 꺼냈다.

```ts
const res = await fetch("https://api.portone.io/banks");
const { items }: { items: BanksResponse } = await res.json();
return routeSuccess(items);
```

이 엔드포인트는 인증이 없어 점검 페이지나 프록시 오류가 200 HTML로 돌아올 수 있다. 그 경우 `res.json()`이 던지거나 `items`가 `undefined`가 되고, 그대로 **성공 응답**에 담겨 화면 렌더 시점에야 터진다.

`core/schemas/response/banks.schema.ts`의 `banksResponseSchema`는 정의만 되어 있고 호출자가 없었다. 외부 응답 파싱은 경계의 일이므로 adapter에서 `safeParse`로 검증한다.

동작 변화 — 상류 응답이 계약과 다르면 `200 + undefined` 대신 502가 나간다. `z.object`는 기본이 비-strict라 PortOne이 필드를 추가해도 통과하고, 필드를 없애거나 이름을 바꾼 경우에만 걸린다.

## 참고

이 폴더는 `api/webhooks/portone/route.ts`가 `@portone/server-sdk`의 `Webhook.verify`를 직접 쓰는 것을 나중에 옮길 자리이기도 하다. 다만 실행 계획 §1 이견 1에서 그 라우트는 위반이 아니라고 판정했으므로(서명 검증은 진입점 고유 책임) 이번에 건드리지 않는다.

## Test plan

- `npm run lint` — 통과
- `npm run tsc` — 통과
- `npm run lint:barrels` — 통과
- `npm run test:unit` — 31 files / 252 tests 통과 (신규 `banks.unit.test.ts` 5건 포함: 정상, 네트워크 실패, 에러 상태코드, 비-JSON, 계약 불일치)
- `npm run test:component` — 107 files / 406 tests 통과
- `npm run test:integration` — 17 files / 320 tests 통과