### PR TITLE
refactor: 미사용 DISABLED 에러 분류를 제거한다

### DIFF
--- a/.claude/agents/api-designer.md
+++ b/.claude/agents/api-designer.md
@@ -11,7 +11,7 @@ color: blue
 
 ## 핵심 역할
 1. 기능에 필요한 엔드포인트(또는 Server Action) 목록과 각각의 요청/응답 shape 확정
-2. 인증 요구사항(어떤 라우트가 로그인 필요한지), 에러 카테고리(`VALIDATION`/`UNAUTHENTICATED`/`FORBIDDEN`/`NOT_FOUND`/`INTERNAL`/`DISABLED`/`EXTERNAL_SERVICE`) 매핑
+2. 인증 요구사항(어떤 라우트가 로그인 필요한지), 에러 카테고리(`VALIDATION`/`UNAUTHENTICATED`/`FORBIDDEN`/`NOT_FOUND`/`INTERNAL`/`EXTERNAL_SERVICE`) 매핑
 3. `src/shared/schemas/request/`, `src/shared/schemas/response/`에 들어갈 zod 스키마 초안 작성
 4. 즉시 응답 vs 비동기 결과(있다면) 구분을 명시적으로 문서화 — 프론트가 헷갈리는 1순위 원인
 

--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -47,7 +47,6 @@ ErrorPayload = { 분류, message, fieldErrors? }
 | FORBIDDEN | 403 | 인가 실패 |
 | NOT_FOUND | 404 | 리소스 없음 |
 | INTERNAL | 500 | 서버/DB 처리 실패 |
-| DISABLED | 503 | 기능 일시 비활성 |
 | EXTERNAL_SERVICE | 502 | 외부 연동 실패 |
 
 ## 채널 A — Server Action (`src/actions/`)

--- a/src/boundary.ts
+++ b/src/boundary.ts
@@ -15,7 +15,6 @@ export const ERROR_STATUS_MAP: Record<ErrorCategory, number> = {
   FORBIDDEN: 403,
   NOT_FOUND: 404,
   INTERNAL: 500,
-  DISABLED: 503,
   EXTERNAL_SERVICE: 502,
 };
 

--- a/src/core/domain/error.ts
+++ b/src/core/domain/error.ts
@@ -25,7 +25,6 @@ export const ERROR_CATEGORIES = [
   "FORBIDDEN",
   "NOT_FOUND",
   "INTERNAL",
-  "DISABLED",
   "EXTERNAL_SERVICE",
 ] as const;
 


### PR DESCRIPTION
## Summary

- `/api/order/create` 라우트가 PR #236에서 삭제된 뒤 `DISABLED` 에러 분류를 던지는 곳이 없어졌다 — taxonomy(`src/core/domain/error.ts`)와 HTTP status 매핑(`src/boundary.ts`), 관련 문서(`docs/architecture/error-handling.md`, `.claude/agents/api-designer.md`)에서 `DISABLED` 언급을 제거했다.
- `ERROR_SAFE_MESSAGES`에는 원래 `DISABLED`가 없어 수정 대상이 아니었다.
- 테스트 코드에는 `DISABLED`를 assert하는 곳이 없어 별도 정리가 필요 없었다.

## Test plan

- `grep -rn "DISABLED" src/ docs/ .claude/agents/` — 잔존 참조 없음 확인
- `npm run lint` — 통과
- `npm run lint:barrels` — 통과
- `npm run tsc` — 통과
- `npx vitest run --project unit src/boundary.unit.test.ts src/core/utils/error.unit.test.ts` — 18개 테스트 통과

Closes #83