### PR TITLE
fix: 업로드 서명 요청의 깨진 JSON/null 본문을 400으로 분류한다

### DIFF
--- a/src/app/api/upload/signature/route.ts
+++ b/src/app/api/upload/signature/route.ts
@@ -3,18 +3,44 @@ import type { APIRouteResponse } from "@/boundary";
 import { routeSuccess, routeError } from "@/boundary";
 import { createUploadSignatureForCurrentUser } from "@/services/upload";
 import type { UploadSignature } from "@/adapters/server/cloudinary/sign";
+import { AppError } from "@/core/domain/error";
+
+type UploadSignatureRequestBody = {
+  folder?: string;
+  paramsToSign?: Record<string, unknown>;
+};
 
 export const POST = async (
   request: NextRequest,
 ): Promise<APIRouteResponse<UploadSignature>> => {
   try {
-    const { folder: requestedFolder, paramsToSign } = await request.json();
+    let parsedBody: unknown;
+    try {
+      parsedBody = await request.json();
+    } catch {
+      throw new AppError(
+        "VALIDATION",
+        "요청 본문이 올바른 JSON 형식이 아닙니다.",
+      );
+    }
+
+    if (typeof parsedBody !== "object" || parsedBody === null) {
+      throw new AppError(
+        "VALIDATION",
+        "요청 본문이 올바른 JSON 형식이 아닙니다.",
+      );
+    }
+
+    const { folder: requestedFolder, paramsToSign } =
+      parsedBody as UploadSignatureRequestBody;
+    const folder =
+      requestedFolder ??
+      (typeof paramsToSign?.folder === "string"
+        ? paramsToSign.folder
+        : undefined);
 
     return routeSuccess(
-      await createUploadSignatureForCurrentUser(
-        requestedFolder ?? paramsToSign?.folder,
-        paramsToSign,
-      ),
+      await createUploadSignatureForCurrentUser(folder, paramsToSign),
     );
   } catch (error) {
     return routeError(error);

--- a/src/app/api/upload/signature/route.unit.test.ts
+++ b/src/app/api/upload/signature/route.unit.test.ts
@@ -28,12 +28,48 @@ const buildRequest = (body: unknown) =>
     body: JSON.stringify(body),
   });
 
+const buildRawRequest = (rawBody: string) =>
+  new NextRequest("http://localhost/api/upload/signature", {
+    method: "POST",
+    body: rawBody,
+  });
+
 describe("POST /api/upload/signature", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("인증되지 않으면 401을 리턴한다", async () => {
+  it("깨진 JSON이면 인증 여부와 무관하게 400을 리턴한다", async () => {
+    vi.mocked(requireAuth).mockResolvedValue({
+      role: "USER",
+      email: "a@b.com",
+      userId: "u1",
+    });
+
+    const res = await POST(buildRawRequest("{ invalid json"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(requireAuth).not.toHaveBeenCalled();
+  });
+
+  it("본문이 JSON null이면 400을 리턴한다(500 아님)", async () => {
+    vi.mocked(requireAuth).mockResolvedValue({
+      role: "USER",
+      email: "a@b.com",
+      userId: "u1",
+    });
+
+    const res = await POST(buildRawRequest("null"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(requireAuth).not.toHaveBeenCalled();
+  });
+
+  it("파싱은 성공하고 인증되지 않으면 401을 리턴한다", async () => {
     vi.mocked(requireAuth).mockRejectedValue(
       new AppError("UNAUTHENTICATED", "로그인이 필요합니다."),
     );

--- a/src/services/upload.ts
+++ b/src/services/upload.ts
@@ -8,8 +8,10 @@ import { requireAuth } from "./auth";
  * 업로드 서명 발급 — 서명은 Cloudinary에 파일을 올릴 권한 자체이므로 로그인 확인이
  * 발급의 일부다. 호출자가 인증을 먼저 부르는 것을 잊을 수 있는 자리에 두지 않는다.
  *
- * folder 검사가 인증 뒤에 오는 순서도 유스케이스의 일부다 — 미인증 호출자에게는
- * 요청 본문이 어떻든 401로 답한다.
+ * folder 검사가 인증 뒤에 오는 순서도 유스케이스의 일부다 — 파싱에 성공한 미인증
+ * 호출자에게는 folder 값과 무관하게 401로 답한다. 파싱 자체가 실패한 요청(깨진
+ * JSON, null 본문)은 route.ts 경계에서 이미 400으로 걸러지므로 이 함수에 도달하지
+ * 않는다.
  */
 export async function createUploadSignatureForCurrentUser(
   folder: string | undefined,


### PR DESCRIPTION
## Summary

- `src/app/api/upload/signature/route.ts`에서 `request.json()`이 던지는 `SyntaxError`(깨진 JSON)와 JSON `null` 본문(파싱은 성공하나 구조분해 시 TypeError)이 모두 `routeError`의 알 수 없는 예외 분기로 떨어져 500 `INTERNAL`을 반환하던 결함을 고쳤다.
- 파싱 실패와 non-object 본문을 `AppError("VALIDATION")`으로 변환해 400을 반환하도록 하고, 이 검사를 인증 체크(`requireAuth`)보다 먼저 수행해 파싱 실패는 인증 여부와 무관하게 400, 파싱에 성공한 미인증 요청은 기존대로 401을 유지하도록 분리했다.
- `src/services/upload.ts`의 "요청 본문이 어떻든 401" 주석을 실제 경계에 맞게 "파싱에 성공한 미인증 호출자"로 좁혔다.

## Test plan

- `npx vitest run src/app/api/upload/signature/route.unit.test.ts` — 6 tests passed(깨진 JSON→400, null 본문→400, 파싱 성공+미인증→401, folder 누락→400, 정상 요청→200, 위젯 파라미터 전달)
- `npm run lint` — passed
- `npm run lint:barrels` — passed
- `npm run tsc` — passed

Closes #249