### PR TITLE
fix: 카카오맵 주소 입력 경계값과 SWR key 인코딩을 보완한다

### DIFF
--- a/src/app/api/kakao-map/route.ts
+++ b/src/app/api/kakao-map/route.ts
@@ -1,6 +1,7 @@
 import type { APIRouteResponse} from "@/boundary";
 import { routeSuccess, routeError } from "@/boundary";
 import { geocodeAddress } from "@/adapters/server/kakao/geocode";
+import { AppError } from "@/core/domain/error";
 import type { KakaomapResponse } from "@/core/schemas/response/kakaomap.schema";
 import type { NextRequest } from "next/server";
 
@@ -9,8 +10,13 @@ export const GET = async (
 ): Promise<APIRouteResponse<KakaomapResponse>> => {
   try {
     const { searchParams } = new URL(req.url);
+    const address = searchParams.get("address")?.trim();
 
-    return routeSuccess(await geocodeAddress(searchParams.get("address") ?? ""));
+    if (!address) {
+      throw new AppError("VALIDATION", "주소를 입력해주세요.");
+    }
+
+    return routeSuccess(await geocodeAddress(address));
   } catch (error) {
     return routeError(error);
   }

--- a/src/app/api/kakao-map/route.unit.test.ts
+++ b/src/app/api/kakao-map/route.unit.test.ts
@@ -41,12 +41,55 @@ describe("GET /api/kakao-map", () => {
     const body = JSON.stringify({ errorType: "InvalidArgumentError", message: "query is required" });
     vi.mocked(fetch).mockResolvedValueOnce(mockResponse(400, false, body));
 
-    const res = await GET(buildRequest(""));
+    const res = await GET(buildRequest("강남구"));
     const json = await res.json();
 
     expect(res.status).toBe(502);
     expect(json.success).toBe(false);
     expect(json.error.category).toBe("EXTERNAL_SERVICE");
+  });
+
+  it("address 쿼리 파라미터가 없으면 400 VALIDATION을 리턴하고 fetch를 호출하지 않는다", async () => {
+    const res = await GET(new NextRequest("http://localhost/api/kakao-map"));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.category).toBe("VALIDATION");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("address가 빈 문자열이면 400 VALIDATION을 리턴하고 fetch를 호출하지 않는다", async () => {
+    const res = await GET(buildRequest(""));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.category).toBe("VALIDATION");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("address가 공백만 있으면 400 VALIDATION을 리턴하고 fetch를 호출하지 않는다", async () => {
+    const res = await GET(buildRequest("   "));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.category).toBe("VALIDATION");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("address 앞뒤 공백은 trim해 Adapter에 전달한다", async () => {
+    const body = JSON.stringify({ documents: [{ address_name: "서울시 강남구" }] });
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(200, true, body));
+
+    const res = await GET(buildRequest("  강남구  "));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(vi.mocked(fetch).mock.calls[0][0]).toContain(encodeURIComponent("강남구"));
+    expect(vi.mocked(fetch).mock.calls[0][0]).not.toContain(encodeURIComponent("  강남구  "));
   });
 
   it("ok:true이지만 비-JSON(HTML 에러 페이지) 본문이면 502 EXTERNAL_SERVICE로 분류한다", async () => {

--- a/src/ui/hooks/useKakaomapGeocode.component.test.ts
+++ b/src/ui/hooks/useKakaomapGeocode.component.test.ts
@@ -22,6 +22,15 @@ describe("useKakaomapGeocode", () => {
     expect(result.current).toEqual({ lat: null, lng: null });
   });
 
+  it("address가 공백만 있으면 swr key를 null로 전달하고 좌표를 null로 리턴한다", () => {
+    useSWRMock.mockReturnValue({ data: undefined, error: undefined });
+
+    const { result } = renderHook(() => useKakaomapGeocode("   "));
+
+    expect(useSWRMock).toHaveBeenCalledWith(null, expect.any(Function));
+    expect(result.current).toEqual({ lat: null, lng: null });
+  });
+
   it("응답이 있으면 첫 번째 document 좌표를 숫자로 변환해 리턴한다", () => {
     useSWRMock.mockReturnValue({
       data: { documents: [{ x: "127.0", y: "37.5" }] },
@@ -31,10 +40,32 @@ describe("useKakaomapGeocode", () => {
     const { result } = renderHook(() => useKakaomapGeocode("서울"));
 
     expect(useSWRMock).toHaveBeenCalledWith(
-      "/api/kakao-map?address=서울",
+      "/api/kakao-map?address=%EC%84%9C%EC%9A%B8",
       expect.any(Function),
     );
     expect(result.current).toEqual({ lat: 37.5, lng: 127 });
+  });
+
+  it("address 앞뒤 공백은 trim해 swr key를 만든다", () => {
+    useSWRMock.mockReturnValue({ data: undefined, error: undefined });
+
+    renderHook(() => useKakaomapGeocode("  서울  "));
+
+    expect(useSWRMock).toHaveBeenCalledWith(
+      "/api/kakao-map?address=%EC%84%9C%EC%9A%B8",
+      expect.any(Function),
+    );
+  });
+
+  it("&와 #가 포함된 address는 encodeURIComponent로 인코딩해 swr key를 만든다", () => {
+    useSWRMock.mockReturnValue({ data: undefined, error: undefined });
+
+    renderHook(() => useKakaomapGeocode("서울 A&B #101호"));
+
+    expect(useSWRMock).toHaveBeenCalledWith(
+      `/api/kakao-map?address=${encodeURIComponent("서울 A&B #101호")}`,
+      expect.any(Function),
+    );
   });
 
   it("에러가 있으면 콘솔에 로그를 남기고 좌표는 null을 유지한다", () => {

--- a/src/ui/hooks/useKakaomapGeocode.ts
+++ b/src/ui/hooks/useKakaomapGeocode.ts
@@ -7,7 +7,10 @@ import type { GeoState } from "@/adapters/browser/deeplink/open-app";
 import type { KakaomapResponse } from "@/core/schemas/response/kakaomap.schema";
 
 export function useKakaomapGeocode(address: string): GeoState {
-  const swrKey = address ? `/api/kakao-map?address=${address}` : null;
+  const trimmedAddress = address.trim();
+  const swrKey = trimmedAddress
+    ? `/api/kakao-map?address=${encodeURIComponent(trimmedAddress)}`
+    : null;
   const { data, error } = useSWR(swrKey, (url: string) =>
     fetcher<KakaomapResponse>(url),
   );


### PR DESCRIPTION
## Summary

- `src/app/api/kakao-map/route.ts`가 주소 누락·빈 문자열·공백을 검증하지 않아, 입력 오류가 400 VALIDATION이 아니라 502 EXTERNAL_SERVICE로 분류되고 불필요한 외부 API 호출이 발생했다. trim한 값이 없으면 `AppError("VALIDATION")`으로 short-circuit해 외부 fetch를 아예 호출하지 않도록 고쳤다.
- `src/ui/hooks/useKakaomapGeocode.ts`가 SWR key를 raw 문자열로 만들어 `&`/`#`가 든 주소가 Route Handler에 도착하기 전에 잘렸다. trim 후 `encodeURIComponent`로 인코딩해 SWR key를 만들도록 고쳤다.
- 기존 "상류 ok:false → 502" 테스트가 빈 주소를 입력값으로 썼는데, 이제 그 입력은 route에서 400으로 먼저 막히므로 비어 있지 않은 주소로 바꿔 원래 검증 의도(카카오 응답 자체의 502 분류)를 유지했다.

## Test plan

- `npx vitest run src/app/api/kakao-map/route.unit.test.ts src/ui/hooks/useKakaomapGeocode.component.test.ts` — 15개 통과 (누락/빈 문자열/공백 400, trim, `&`/`#` 인코딩 케이스 포함)
- `npm run test:unit` — 256개 통과
- `npm run test:component` — 409개 통과
- `npm run lint` — 통과
- `npm run lint:barrels` — 통과
- `npm run tsc` — 통과

Closes #246