### PR TITLE
refactor: 클라이언트 로컬 식별자를 결정적 채번 방식으로 바꾼다

### DIFF
--- a/src/ui/context/guestbookDemo/reducer.ts
+++ b/src/ui/context/guestbookDemo/reducer.ts
@@ -5,32 +5,44 @@ import type { GuestbookDemoAction, GuestbookDemoEntry, GuestbookDemoState } from
 // 마지막 페이지 이후 중단을 모두 데모에서 확인할 수 있다.
 export const INITIAL_GUESTBOOK_DEMO_STATE: GuestbookDemoState = {
   entries: [
-    { id: "demo-24", author: "박서준", message: "두 분의 새로운 시작을 진심으로 축하드립니다. 늘 행복하세요!", password: "0000", createdAt: "2026-08-24T09:12:00.000Z" },
-    { id: "demo-23", author: "김하은", message: "결혼 축하해! 오늘 정말 예쁘다, 앞으로도 지금처럼 행복하길 바랄게.", password: "0000", createdAt: "2026-08-23T14:33:00.000Z" },
-    { id: "demo-22", author: "이도윤", message: "축하합니다! 두 분이서 함께 만들어갈 앞날을 응원합니다.", password: "0000", createdAt: "2026-08-22T11:05:00.000Z" },
-    { id: "demo-21", author: "최지우", message: "결혼을 진심으로 축하드려요. 사랑 가득한 가정 이루시길 바랍니다.", password: "0000", createdAt: "2026-08-21T18:47:00.000Z" },
-    { id: "demo-20", author: "정민서", message: "너무 잘 어울리는 두 사람! 결혼 축하하고 늘 웃음 가득하길.", password: "0000", createdAt: "2026-08-20T10:20:00.000Z" },
-    { id: "demo-19", author: "강수아", message: "결혼 축하합니다. 서로 아끼고 존중하며 오래오래 행복하세요.", password: "0000", createdAt: "2026-08-19T16:58:00.000Z" },
-    { id: "demo-18", author: "조은우", message: "축하해요! 두 분의 결혼식, 정말 아름다울 것 같아요.", password: "0000", createdAt: "2026-08-18T09:41:00.000Z" },
-    { id: "demo-17", author: "윤서연", message: "결혼 진심으로 축하드립니다. 건강하고 행복한 나날 되세요.", password: "0000", createdAt: "2026-08-17T13:15:00.000Z" },
-    { id: "demo-16", author: "임하준", message: "축하합니다! 두 분 앞날에 늘 좋은 일만 가득하시길 바랍니다.", password: "0000", createdAt: "2026-08-16T20:02:00.000Z" },
-    { id: "demo-15", author: "한지민", message: "결혼 축하해요. 함께라서 더 빛나는 두 사람이 되길 응원해요.", password: "0000", createdAt: "2026-08-15T08:37:00.000Z" },
-    { id: "demo-14", author: "오세훈", message: "결혼 축하드립니다! 서로에게 최고의 동반자가 되시길 바랍니다.", password: "0000", createdAt: "2026-08-14T15:26:00.000Z" },
-    { id: "demo-13", author: "신유나", message: "축하해! 오늘부터 시작될 두 사람의 이야기를 응원할게.", password: "0000", createdAt: "2026-08-13T11:49:00.000Z" },
-    { id: "demo-12", author: "장도현", message: "결혼을 축하드립니다. 늘 지금처럼 다정한 부부 되세요.", password: "0000", createdAt: "2026-08-12T17:03:00.000Z" },
-    { id: "demo-11", author: "권나윤", message: "축하합니다! 두 분의 새 출발을 마음 다해 응원합니다.", password: "0000", createdAt: "2026-08-11T09:58:00.000Z" },
-    { id: "demo-10", author: "배준혁", message: "결혼 축하해요. 웃음이 끊이지 않는 가정 이루시길 바랍니다.", password: "0000", createdAt: "2026-08-10T14:12:00.000Z" },
-    { id: "demo-9", author: "문소율", message: "축하드립니다! 서로 사랑하며 건강하게 지내시길 바랍니다.", password: "0000", createdAt: "2026-08-09T19:30:00.000Z" },
-    { id: "demo-8", author: "서준서", message: "결혼 축하해! 두 사람이 함께라서 더 행복할 앞날을 응원해.", password: "0000", createdAt: "2026-08-08T10:44:00.000Z" },
-    { id: "demo-7", author: "홍예은", message: "축하합니다. 오늘의 설렘이 오래도록 이어지길 바랍니다.", password: "0000", createdAt: "2026-08-07T16:21:00.000Z" },
-    { id: "demo-6", author: "황지호", message: "결혼 축하드려요! 두 분 앞날에 행복만 가득하시길 바랍니다.", password: "0000", createdAt: "2026-08-06T12:05:00.000Z" },
-    { id: "demo-5", author: "안유진", message: "축하해요! 서로 의지하며 평생 행복하게 사세요.", password: "0000", createdAt: "2026-08-05T08:59:00.000Z" },
-    { id: "demo-4", author: "송민준", message: "결혼 진심으로 축하드립니다. 늘 건강하고 행복하시길 바랍니다.", password: "0000", createdAt: "2026-08-04T21:14:00.000Z" },
-    { id: "demo-3", author: "전지호", message: "축하합니다! 두 사람의 새로운 챕터를 응원해요.", password: "0000", createdAt: "2026-08-03T13:38:00.000Z" },
-    { id: "demo-2", author: "노하람", message: "결혼 축하해! 오래오래 지금처럼 알콩달콩 지내길 바랄게.", password: "0000", createdAt: "2026-08-02T10:27:00.000Z" },
-    { id: "demo-1", author: "유채원", message: "축하드립니다. 두 분의 결혼을 진심으로 축복합니다.", password: "0000", createdAt: "2026-08-01T09:00:00.000Z" },
+    { id: "demo-24", author: "박서준", message: "두 분의 새로운 시작을 진심으로 축하드립니다. 늘 행복하세요!", password: "0000" },
+    { id: "demo-23", author: "김하은", message: "결혼 축하해! 오늘 정말 예쁘다, 앞으로도 지금처럼 행복하길 바랄게.", password: "0000" },
+    { id: "demo-22", author: "이도윤", message: "축하합니다! 두 분이서 함께 만들어갈 앞날을 응원합니다.", password: "0000" },
+    { id: "demo-21", author: "최지우", message: "결혼을 진심으로 축하드려요. 사랑 가득한 가정 이루시길 바랍니다.", password: "0000" },
+    { id: "demo-20", author: "정민서", message: "너무 잘 어울리는 두 사람! 결혼 축하하고 늘 웃음 가득하길.", password: "0000" },
+    { id: "demo-19", author: "강수아", message: "결혼 축하합니다. 서로 아끼고 존중하며 오래오래 행복하세요.", password: "0000" },
+    { id: "demo-18", author: "조은우", message: "축하해요! 두 분의 결혼식, 정말 아름다울 것 같아요.", password: "0000" },
+    { id: "demo-17", author: "윤서연", message: "결혼 진심으로 축하드립니다. 건강하고 행복한 나날 되세요.", password: "0000" },
+    { id: "demo-16", author: "임하준", message: "축하합니다! 두 분 앞날에 늘 좋은 일만 가득하시길 바랍니다.", password: "0000" },
+    { id: "demo-15", author: "한지민", message: "결혼 축하해요. 함께라서 더 빛나는 두 사람이 되길 응원해요.", password: "0000" },
+    { id: "demo-14", author: "오세훈", message: "결혼 축하드립니다! 서로에게 최고의 동반자가 되시길 바랍니다.", password: "0000" },
+    { id: "demo-13", author: "신유나", message: "축하해! 오늘부터 시작될 두 사람의 이야기를 응원할게.", password: "0000" },
+    { id: "demo-12", author: "장도현", message: "결혼을 축하드립니다. 늘 지금처럼 다정한 부부 되세요.", password: "0000" },
+    { id: "demo-11", author: "권나윤", message: "축하합니다! 두 분의 새 출발을 마음 다해 응원합니다.", password: "0000" },
+    { id: "demo-10", author: "배준혁", message: "결혼 축하해요. 웃음이 끊이지 않는 가정 이루시길 바랍니다.", password: "0000" },
+    { id: "demo-9", author: "문소율", message: "축하드립니다! 서로 사랑하며 건강하게 지내시길 바랍니다.", password: "0000" },
+    { id: "demo-8", author: "서준서", message: "결혼 축하해! 두 사람이 함께라서 더 행복할 앞날을 응원해.", password: "0000" },
+    { id: "demo-7", author: "홍예은", message: "축하합니다. 오늘의 설렘이 오래도록 이어지길 바랍니다.", password: "0000" },
+    { id: "demo-6", author: "황지호", message: "결혼 축하드려요! 두 분 앞날에 행복만 가득하시길 바랍니다.", password: "0000" },
+    { id: "demo-5", author: "안유진", message: "축하해요! 서로 의지하며 평생 행복하게 사세요.", password: "0000" },
+    { id: "demo-4", author: "송민준", message: "결혼 진심으로 축하드립니다. 늘 건강하고 행복하시길 바랍니다.", password: "0000" },
+    { id: "demo-3", author: "전지호", message: "축하합니다! 두 사람의 새로운 챕터를 응원해요.", password: "0000" },
+    { id: "demo-2", author: "노하람", message: "결혼 축하해! 오래오래 지금처럼 알콩달콩 지내길 바랄게.", password: "0000" },
+    { id: "demo-1", author: "유채원", message: "축하드립니다. 두 분의 결혼을 진심으로 축복합니다.", password: "0000" },
   ],
 };
+
+const DEMO_ID_PATTERN = /^demo-(\d+)$/;
+
+// 삭제 뒤 재추가되는 항목이 id 충돌 없이 이어지도록, entries.length가 아니라
+// 현재 존재하는 demo-N의 최댓값에서 다음 id를 결정한다.
+function nextDemoId(entries: GuestbookDemoEntry[]): string {
+  const maxN = entries.reduce((max, entry) => {
+    const matched = DEMO_ID_PATTERN.exec(entry.id);
+    return matched ? Math.max(max, Number(matched[1])) : max;
+  }, 0);
+  return `demo-${maxN + 1}`;
+}
 
 export function guestbookDemoReducer(
   state: GuestbookDemoState,
@@ -39,11 +51,10 @@ export function guestbookDemoReducer(
   switch (action.type) {
     case "ADD_ENTRY": {
       const newEntry: GuestbookDemoEntry = {
-        id: crypto.randomUUID(),
+        id: nextDemoId(state.entries),
         author: action.payload.author,
         message: action.payload.message,
         password: action.payload.password,
-        createdAt: new Date().toISOString(),
       };
       return { ...state, entries: [newEntry, ...state.entries] };
     }

--- a/src/ui/context/guestbookDemo/reducer.unit.test.ts
+++ b/src/ui/context/guestbookDemo/reducer.unit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { guestbookDemoReducer } from "./reducer";
+import type { GuestbookDemoEntry, GuestbookDemoState } from "./type";
+
+const buildEntry = (id: string): GuestbookDemoEntry => ({
+  id,
+  author: "홍길동",
+  message: "축하합니다",
+  password: "0000",
+});
+
+const buildState = (entries: GuestbookDemoEntry[]): GuestbookDemoState => ({
+  entries,
+});
+
+const addEntryAction = {
+  type: "ADD_ENTRY" as const,
+  payload: { author: "새 손님", message: "축하해요", password: "1234" },
+};
+
+describe("guestbookDemoReducer", () => {
+  it("기존 demo-N 최댓값보다 1 큰 id를 다음 항목에 부여한다", () => {
+    const state = buildState([buildEntry("demo-3"), buildEntry("demo-1")]);
+
+    const result = guestbookDemoReducer(state, addEntryAction);
+
+    expect(result.entries[0]?.id).toBe("demo-4");
+  });
+
+  it("중간 항목을 삭제한 뒤 추가해도 남아있는 최댓값 기준으로 id가 충돌하지 않는다", () => {
+    const state = buildState([buildEntry("demo-5"), buildEntry("demo-3")]);
+    const afterRemove = guestbookDemoReducer(state, {
+      type: "REMOVE_ENTRY",
+      payload: { id: "demo-5" },
+    });
+
+    const result = guestbookDemoReducer(afterRemove, addEntryAction);
+
+    expect(afterRemove.entries.map((entry) => entry.id)).toEqual(["demo-3"]);
+    expect(result.entries[0]?.id).toBe("demo-4");
+    expect(
+      result.entries.filter((entry) => entry.id === "demo-4"),
+    ).toHaveLength(1);
+  });
+
+  it("추가한 항목을 목록 맨 앞에 삽입하고 payload 필드를 그대로 반영한다", () => {
+    const state = buildState([buildEntry("demo-1")]);
+
+    const result = guestbookDemoReducer(state, addEntryAction);
+
+    expect(result.entries[0]).toEqual({
+      id: "demo-2",
+      author: "새 손님",
+      message: "축하해요",
+      password: "1234",
+    });
+    expect(result.entries).toHaveLength(2);
+  });
+
+  it("id로 지정한 항목을 제거한다", () => {
+    const state = buildState([buildEntry("demo-2"), buildEntry("demo-1")]);
+
+    const result = guestbookDemoReducer(state, {
+      type: "REMOVE_ENTRY",
+      payload: { id: "demo-2" },
+    });
+
+    expect(result.entries.map((entry) => entry.id)).toEqual(["demo-1"]);
+  });
+});

--- a/src/ui/context/guestbookDemo/type.ts
+++ b/src/ui/context/guestbookDemo/type.ts
@@ -3,7 +3,6 @@ export interface GuestbookDemoEntry {
   author: string;
   message: string;
   password: string;
-  createdAt: string;
 }
 
 export interface GuestbookDemoState {

--- a/src/ui/hooks/useImageList.component.test.ts
+++ b/src/ui/hooks/useImageList.component.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useImageList } from "./useImageList";
+
+describe("useImageList", () => {
+  it("같은 인스턴스에서 추가할수록 id가 단조 증가하고 서로 겹치지 않는다", () => {
+    const { result } = renderHook(() => useImageList());
+
+    act(() => result.current.add(["url-a"]));
+    act(() => result.current.add(["url-b", "url-c"]));
+
+    const ids = result.current.items.map((item) => Number(item.id));
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("서로 다른 훅 인스턴스는 독립된 카운터를 사용해 id가 섞이지 않는다", () => {
+    const first = renderHook(() => useImageList());
+    const second = renderHook(() => useImageList());
+
+    act(() => first.result.current.add(["a1", "a2"]));
+    act(() => second.result.current.add(["b1"]));
+    act(() => first.result.current.add(["a3"]));
+
+    expect(first.result.current.items.map((item) => item.id)).toEqual([
+      "0",
+      "1",
+      "2",
+    ]);
+    expect(second.result.current.items.map((item) => item.id)).toEqual(["0"]);
+  });
+
+  it("defaultUrls로 초기화한 항목과 이후 추가 항목의 id가 충돌하지 않는다", () => {
+    const { result, rerender } = renderHook(
+      ({ defaultUrls }: { defaultUrls?: string[] }) =>
+        useImageList(defaultUrls),
+      { initialProps: { defaultUrls: undefined as string[] | undefined } },
+    );
+
+    // useSWR 비동기 로드를 흉내내 defaultUrls가 뒤늦게 채워지는 상황을 재현한다.
+    act(() => rerender({ defaultUrls: ["init-1", "init-2"] }));
+    act(() => result.current.add(["added-1"]));
+
+    const ids = result.current.items.map((item) => item.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(result.current.getUrls()).toEqual([
+      "init-1",
+      "init-2",
+      "added-1",
+    ]);
+  });
+
+  it("remove(id)는 해당 항목만 제거한다", () => {
+    const { result } = renderHook(() => useImageList());
+
+    act(() => result.current.add(["url-a", "url-b"]));
+    const [first, second] = result.current.items;
+
+    act(() => result.current.remove(first!.id));
+
+    expect(result.current.items).toEqual([second]);
+    expect(result.current.getUrls()).toEqual(["url-b"]);
+  });
+});

--- a/src/ui/hooks/useImageList.ts
+++ b/src/ui/hooks/useImageList.ts
@@ -1,27 +1,41 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 export type ImageItem = { id: string; preview: string; url: string };
 
-const toImageItem = (url: string): ImageItem => ({
-  id: crypto.randomUUID(),
-  preview: url,
-  url,
-});
-
 export function useImageList(defaultUrls?: string[]) {
+  // 훅 인스턴스별로 격리된 단조 증가 카운터. render 중이 아니라 add()가
+  // 실제로 호출되는 시점(이벤트 핸들러)에만 읽고 증가시킨다 — render 중 ref
+  // 접근은 react-hooks/refs 위반이라 아래 초기화 분기에서는 쓰지 않는다.
+  const nextId = useRef(0);
+
   const [items, setItems] = useState<ImageItem[]>([]);
   const [initialized, setInitialized] = useState(false);
 
-  // defaultUrls가 준비되면 한 번만 초기화 (SWR 비동기 로드 대응)
+  // defaultUrls가 준비되면 한 번만 초기화 (SWR 비동기 로드 대응).
+  // 초기 항목은 배열 index로 결정적 id를 부여해 이후 add()의 카운터 id와
+  // 겹치지 않는다("init-" 접두사로 네임스페이스 분리).
   if (!initialized && defaultUrls?.length) {
     setInitialized(true);
-    setItems(defaultUrls.map(toImageItem));
+    setItems(
+      defaultUrls.map((url, index) => ({
+        id: `init-${index}`,
+        preview: url,
+        url,
+      })),
+    );
   }
 
   const add = (urls: string[]) =>
-    setItems((prev) => [...prev, ...urls.map(toImageItem)]);
+    setItems((prev) => [
+      ...prev,
+      ...urls.map((url) => ({
+        id: String(nextId.current++),
+        preview: url,
+        url,
+      })),
+    ]);
 
   const remove = (id: string) =>
     setItems((prev) => prev.filter((item) => item.id !== id));


### PR DESCRIPTION
## Summary
- `useImageList`가 `crypto.randomUUID()`로, `guestbookDemoReducer`가 `crypto.randomUUID()`/`new Date().toISOString()`으로 만들던 id는 서버로 나가지 않는 로컬 전용 식별자(렌더 key, 로컬 항목 삭제, 영속화되지 않는 데모 상태)라 비결정성이 불필요했다.
- `useImageList`는 훅 인스턴스별 `useRef` 단조 증가 카운터로, guestbook demo는 기존 `demo-N`의 최댓값+1로 다음 id를 계산하는 방식으로 바꿔 같은 입력에 같은 결과가 나오게 했다.
- 렌더 중 ref를 읽지 않는 `react-hooks/refs` 규칙 때문에 `useImageList`의 초기 `defaultUrls` 항목은 index 기반 `init-N` id를, 이후 `add()` 항목은 카운터 id를 쓰도록 네임스페이스를 분리했다(둘 다 결정적이며 서로 충돌하지 않는다).
- 렌더·정렬·영속화 어디에도 쓰이지 않던 demo `createdAt` 필드를 타입과 fixture에서 제거했다.

## Test plan
- `npx vitest run src/ui/hooks/useImageList.component.test.ts src/ui/context/guestbookDemo/reducer.unit.test.ts` — 8 passed (단조 증가, 인스턴스 분리, 초기/추가 id 충돌 없음, remove(id), demo-N 최댓값+1 채번, 삭제 후 재추가 시 id 충돌 없음)
- `npm run test:unit` — 256 passed
- `npm run test:component` — 410 passed
- `npm run lint` — pass
- `npm run lint:barrels` — pass
- `npm run tsc` — pass

Closes #239