### PR TITLE
feat: 상품·주문·리뷰 확인창을 공용 AlertDialog로 통일한다

### DIFF
--- a/src/app/(admin)/admin/products/_components/ProductPermanentDeleteDialog.component.test.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductPermanentDeleteDialog.component.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { useState } from "react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ProductPermanentDeleteDialog } from "./ProductPermanentDeleteDialog";
+
+const PRODUCT_TITLE = "봄맞이 Spring 청첩장";
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+const ProductPermanentDeleteHost = ({
+  onAction,
+}: {
+  onAction: () => Promise<boolean>;
+}) => {
+  const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        영구 삭제 열기
+      </button>
+      <ProductPermanentDeleteDialog
+        open={open}
+        onOpenChange={setOpen}
+        productTitle={PRODUCT_TITLE}
+        pending={pending}
+        onConfirm={async () => {
+          setPending(true);
+          const succeeded = await onAction();
+          setPending(false);
+          if (succeeded) {
+            setOpen(false);
+          }
+        }}
+      />
+    </>
+  );
+};
+
+const renderHost = async (onAction: () => Promise<boolean>) => {
+  const user = userEvent.setup();
+  render(<ProductPermanentDeleteHost onAction={onAction} />);
+  await user.click(screen.getByRole("button", { name: "영구 삭제 열기" }));
+  return user;
+};
+
+const confirmationInput = () =>
+  screen.getByLabelText(`확인을 위해 상품명 "${PRODUCT_TITLE}"을 입력하세요`);
+
+const purgeButton = () => screen.getByRole("button", { name: "영구 삭제" });
+
+describe("ProductPermanentDeleteDialog", () => {
+  it("상품명을 입력하기 전에는 영구 삭제 버튼이 잠겨 있다", async () => {
+    await renderHost(async () => true);
+
+    expect(purgeButton()).toBeDisabled();
+  });
+
+  it("대소문자가 다르면 영구 삭제 버튼이 열리지 않는다", async () => {
+    const user = await renderHost(async () => true);
+
+    await user.type(confirmationInput(), "봄맞이 spring 청첩장");
+
+    expect(purgeButton()).toBeDisabled();
+  });
+
+  it("앞뒤 공백이 붙으면 영구 삭제 버튼이 열리지 않는다", async () => {
+    const user = await renderHost(async () => true);
+
+    await user.type(confirmationInput(), `${PRODUCT_TITLE} `);
+
+    expect(purgeButton()).toBeDisabled();
+  });
+
+  it("상품명이 완전히 일치하면 영구 삭제를 실행할 수 있다", async () => {
+    const onAction = vi.fn(async () => true);
+    const user = await renderHost(onAction);
+
+    await user.type(confirmationInput(), PRODUCT_TITLE);
+    expect(purgeButton()).toBeEnabled();
+
+    await user.click(purgeButton());
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("영구 삭제에 실패하면 입력한 상품명을 그대로 남긴다", async () => {
+    const deferred = createDeferred<boolean>();
+    const user = await renderHost(() => deferred.promise);
+
+    await user.type(confirmationInput(), PRODUCT_TITLE);
+    await user.click(purgeButton());
+    await act(async () => {
+      deferred.resolve(false);
+    });
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(confirmationInput()).toHaveValue(PRODUCT_TITLE);
+    expect(purgeButton()).toBeEnabled();
+  });
+
+  it("취소했다가 다시 열면 입력값이 비어 있다", async () => {
+    const user = await renderHost(async () => true);
+
+    await user.type(confirmationInput(), PRODUCT_TITLE);
+    await user.click(screen.getByRole("button", { name: "취소" }));
+    await user.click(screen.getByRole("button", { name: "영구 삭제 열기" }));
+
+    expect(confirmationInput()).toHaveValue("");
+    expect(purgeButton()).toBeDisabled();
+  });
+
+  it("영구 삭제에 성공한 뒤 다시 열면 입력값이 비어 있다", async () => {
+    const user = await renderHost(async () => true);
+
+    await user.type(confirmationInput(), PRODUCT_TITLE);
+    await user.click(purgeButton());
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "영구 삭제 열기" }));
+
+    expect(confirmationInput()).toHaveValue("");
+    expect(purgeButton()).toBeDisabled();
+  });
+});

--- a/src/app/(admin)/admin/products/_components/ProductPermanentDeleteDialog.tsx
+++ b/src/app/(admin)/admin/products/_components/ProductPermanentDeleteDialog.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Input } from "@/ui/components/atoms/input";
+import { ConfirmDialog } from "@/ui/components/molecules/ConfirmDialog";
+
+interface ProductPermanentDeleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  productTitle: string;
+  pending: boolean;
+  onConfirm: () => void;
+}
+
+/**
+ * 영구 삭제는 되돌릴 수 없어 확인 한 번으로는 부족하다 — 상품명을 그대로 입력해야
+ * 실행 버튼이 열린다. 대소문자나 앞뒤 공백을 보정하지 않는 완전 일치다.
+ *
+ * 실패하면 입력값을 남겨 그대로 재시도할 수 있고, 다이얼로그가 닫힐 때 비운다.
+ */
+const ProductPermanentDeleteDialog = ({
+  open,
+  onOpenChange,
+  productTitle,
+  pending,
+  onConfirm,
+}: ProductPermanentDeleteDialogProps) => {
+  const inputId = useId();
+  const [confirmationText, setConfirmationText] = useState("");
+  // 열림 여부가 바뀌는 렌더에서 입력값을 비운다 — 취소든 성공이든 닫히는 경로가
+  // 여럿이라 특정 핸들러에 초기화를 걸 수 없다. effect로 하면 닫힌 값이 한 번
+  // 그려진 뒤에야 비워져 cascading render가 된다(React "prop 변화에 state 맞추기").
+  const [wasOpen, setWasOpen] = useState(open);
+  if (wasOpen !== open) {
+    setWasOpen(open);
+    setConfirmationText("");
+  }
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="상품 영구 삭제"
+      description={`"${productTitle}" 상품을 영구 삭제합니다. 이미지를 포함한 모든 데이터가 사라지며 복구할 수 없습니다.`}
+      confirmLabel="영구 삭제"
+      pendingLabel="영구 삭제 중..."
+      pending={pending}
+      confirmDisabled={confirmationText !== productTitle}
+      onConfirm={onConfirm}
+    >
+      <div className="space-y-2">
+        <label htmlFor={inputId} className="text-sm font-medium">
+          확인을 위해 상품명 &quot;{productTitle}&quot;을 입력하세요
+        </label>
+        <Input
+          id={inputId}
+          value={confirmationText}
+          disabled={pending}
+          autoComplete="off"
+          onChange={(event) => setConfirmationText(event.target.value)}
+        />
+      </div>
+    </ConfirmDialog>
+  );
+};
+
+export { ProductPermanentDeleteDialog };

--- a/src/app/(admin)/admin/products/_containers/ProductTableRowAction.component.test.tsx
+++ b/src/app/(admin)/admin/products/_containers/ProductTableRowAction.component.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const refreshMock = vi.fn();
@@ -71,10 +71,20 @@ const renderAction = (props: ProductTableRowProps) =>
     </StoreProvider>,
   );
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+const dialogButton = (name: string) =>
+  within(screen.getByRole("alertdialog")).getByRole("button", { name });
+
 describe("ProductTableRowAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(window, "confirm").mockReturnValue(true);
     testStore = createAppStore();
   });
 
@@ -92,7 +102,7 @@ describe("ProductTableRowAction", () => {
     expect(screen.getByText("영구 삭제")).toBeInTheDocument();
   });
 
-  it("복구 확인 후 restoreProduct를 호출하고 성공하면 라우터를 refresh한다", async () => {
+  it("복구 확인창은 되돌릴 수 있는 동작임을 알리고, 확인하면 restoreProduct를 호출한다", async () => {
     const user = userEvent.setup();
     vi.mocked(restoreProduct).mockResolvedValue({
       success: true,
@@ -101,13 +111,20 @@ describe("ProductTableRowAction", () => {
 
     renderAction({ product: buildProduct(), view: "trash" });
 
-    await user.click(screen.getByText("복구"));
+    await user.click(screen.getByRole("button", { name: "복구" }));
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent("봄맞이 청첩장");
+    expect(dialog).toHaveTextContent("다시 삭제할 수 있습니다");
+
+    await user.click(dialogButton("복구"));
 
     expect(restoreProduct).toHaveBeenCalledWith("507f1f77bcf86cd799439011");
     expect(refreshMock).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("alertdialog")).toBeNull();
   });
 
-  it("삭제 확인 후 deleteProduct를 호출하고 성공하면 라우터를 refresh한다", async () => {
+  it("삭제 확인창은 휴지통 복구 가능을 알리고, 확인하면 deleteProduct를 호출한다", async () => {
     const user = userEvent.setup();
     vi.mocked(deleteProduct).mockResolvedValue({
       success: true,
@@ -116,14 +133,67 @@ describe("ProductTableRowAction", () => {
 
     renderAction({ product: buildProduct() });
 
-    const buttons = screen.getAllByRole("button");
-    await user.click(buttons[1]);
+    await user.click(screen.getByRole("button", { name: "상품 삭제" }));
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent("봄맞이 청첩장");
+    expect(dialog).toHaveTextContent("휴지통에서 복구할 수 있습니다");
+
+    await user.click(dialogButton("삭제"));
 
     expect(deleteProduct).toHaveBeenCalledWith("507f1f77bcf86cd799439011");
     expect(refreshMock).toHaveBeenCalledOnce();
   });
 
-  it("영구 삭제 확인 후 permanentlyDeleteProduct를 호출하고 성공하면 라우터를 refresh한다", async () => {
+  it("삭제를 취소하면 deleteProduct를 호출하지 않는다", async () => {
+    const user = userEvent.setup();
+    renderAction({ product: buildProduct() });
+
+    await user.click(screen.getByRole("button", { name: "상품 삭제" }));
+    await user.click(dialogButton("취소"));
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(deleteProduct).not.toHaveBeenCalled();
+  });
+
+  it("삭제에 실패하면 확인창을 열어둔 채 다시 시도할 수 있다", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteProduct).mockResolvedValue({
+      success: false,
+      error: { category: "INTERNAL", message: "삭제에 실패했습니다." },
+    });
+
+    renderAction({ product: buildProduct() });
+
+    await user.click(screen.getByRole("button", { name: "상품 삭제" }));
+    await user.click(dialogButton("삭제"));
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(refreshMock).not.toHaveBeenCalled();
+
+    await user.click(dialogButton("삭제"));
+    expect(deleteProduct).toHaveBeenCalledTimes(2);
+  });
+
+  it("삭제가 진행되는 동안 확인 버튼을 다시 눌러도 deleteProduct를 중복 호출하지 않는다", async () => {
+    const deferred = createDeferred<{ success: true; data: { message: string } }>();
+    vi.mocked(deleteProduct).mockReturnValue(deferred.promise);
+    const user = userEvent.setup();
+
+    renderAction({ product: buildProduct() });
+
+    await user.click(screen.getByRole("button", { name: "상품 삭제" }));
+    await user.click(dialogButton("삭제"));
+    await user.click(dialogButton("삭제 중..."));
+
+    expect(deleteProduct).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve({ success: true, data: { message: "삭제되었습니다." } });
+    });
+  });
+
+  it("영구 삭제는 상품명을 정확히 입력해야 permanentlyDeleteProduct를 호출한다", async () => {
     const user = userEvent.setup();
     vi.mocked(permanentlyDeleteProduct).mockResolvedValue({
       success: true,
@@ -132,9 +202,23 @@ describe("ProductTableRowAction", () => {
 
     renderAction({ product: buildProduct(), view: "trash" });
 
-    await user.click(screen.getByText("영구 삭제"));
+    await user.click(screen.getByRole("button", { name: "영구 삭제" }));
 
-    expect(permanentlyDeleteProduct).toHaveBeenCalledWith("507f1f77bcf86cd799439011");
+    expect(screen.getByRole("alertdialog")).toHaveTextContent(
+      "복구할 수 없습니다",
+    );
+    expect(dialogButton("영구 삭제")).toBeDisabled();
+
+    await user.type(
+      screen.getByLabelText('확인을 위해 상품명 "봄맞이 청첩장"을 입력하세요'),
+      "봄맞이 청첩장",
+    );
+    await user.click(dialogButton("영구 삭제"));
+
+    expect(permanentlyDeleteProduct).toHaveBeenCalledWith(
+      "507f1f77bcf86cd799439011",
+    );
     expect(refreshMock).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("alertdialog")).toBeNull();
   });
 });

--- a/src/app/(admin)/admin/products/_containers/ProductTableRowAction.tsx
+++ b/src/app/(admin)/admin/products/_containers/ProductTableRowAction.tsx
@@ -4,6 +4,8 @@ import { permanentlyDeleteProduct } from "@/actions/permanentlyDeleteProduct";
 import { restoreProduct } from "@/actions/restoreProduct";
 import type { ProductTableRowProps } from "../_components/ProductTableRow";
 import { Button } from "@/ui/components/atoms/button";
+import { ConfirmDialog } from "@/ui/components/molecules/ConfirmDialog";
+import { ProductPermanentDeleteDialog } from "../_components/ProductPermanentDeleteDialog";
 import { useAdminModalStore } from "@/ui/stores/use-app-store";
 import { Edit, RotateCcw, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -16,12 +18,12 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRestoring, setIsRestoring] = useState(false);
   const [isPurging, setIsPurging] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isRestoreOpen, setIsRestoreOpen] = useState(false);
+  const [isPurgeOpen, setIsPurgeOpen] = useState(false);
 
+  // 실패하면 다이얼로그를 닫지 않는다 — 사용자가 오류 toast를 보고 그대로 재시도한다.
   const handleDelete = async () => {
-    if (!confirm(`"${product.title}" 상품을 삭제하시겠습니까?`)) {
-      return;
-    }
-
     setIsDeleting(true);
 
     try {
@@ -33,6 +35,7 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
       }
 
       toast.success(result.data.message);
+      setIsDeleteOpen(false);
       router.refresh();
     } catch {
       toast.error("삭제 중 오류가 발생했습니다.");
@@ -42,10 +45,6 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
   };
 
   const handleRestore = async () => {
-    if (!confirm(`"${product.title}" 상품을 복구하시겠습니까?`)) {
-      return;
-    }
-
     setIsRestoring(true);
 
     try {
@@ -57,6 +56,7 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
       }
 
       toast.success(result.data.message);
+      setIsRestoreOpen(false);
       router.refresh();
     } catch {
       toast.error("복구 중 오류가 발생했습니다.");
@@ -66,14 +66,6 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
   };
 
   const handlePurge = async () => {
-    if (
-      !confirm(
-        `"${product.title}" 상품을 영구 삭제하시겠습니까? 이미지 포함 모든 데이터가 사라지며 되돌릴 수 없습니다.`,
-      )
-    ) {
-      return;
-    }
-
     setIsPurging(true);
 
     try {
@@ -85,6 +77,7 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
       }
 
       toast.success(result.data.message);
+      setIsPurgeOpen(false);
       router.refresh();
     } catch {
       toast.error("영구 삭제 중 오류가 발생했습니다.");
@@ -99,7 +92,7 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
         <Button
           size="sm"
           variant="outline"
-          onClick={handleRestore}
+          onClick={() => setIsRestoreOpen(true)}
           disabled={isRestoring || isPurging}
         >
           <RotateCcw className="h-4 w-4" />
@@ -108,12 +101,31 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
         <Button
           size="sm"
           variant="outline"
-          onClick={handlePurge}
+          onClick={() => setIsPurgeOpen(true)}
           disabled={isRestoring || isPurging}
         >
           <Trash2 className="h-4 w-4" />
           영구 삭제
         </Button>
+
+        <ConfirmDialog
+          open={isRestoreOpen}
+          onOpenChange={setIsRestoreOpen}
+          title="상품 복구"
+          description={`"${product.title}" 상품을 복구합니다. 복구하면 판매 목록에 다시 표시되며, 언제든 다시 삭제할 수 있습니다.`}
+          confirmLabel="복구"
+          pendingLabel="복구 중..."
+          confirmVariant="default"
+          pending={isRestoring}
+          onConfirm={handleRestore}
+        />
+        <ProductPermanentDeleteDialog
+          open={isPurgeOpen}
+          onOpenChange={setIsPurgeOpen}
+          productTitle={product.title}
+          pending={isPurging}
+          onConfirm={handlePurge}
+        />
       </div>
     );
   }
@@ -132,11 +144,22 @@ const ProductTableRowAction = ({ product, view = "active" }: ProductTableRowProp
         size="sm"
         variant="outline"
         aria-label="상품 삭제"
-        onClick={handleDelete}
+        onClick={() => setIsDeleteOpen(true)}
         disabled={isDeleting}
       >
         <Trash2 className="h-4 w-4" />
       </Button>
+
+      <ConfirmDialog
+        open={isDeleteOpen}
+        onOpenChange={setIsDeleteOpen}
+        title="상품 삭제"
+        description={`"${product.title}" 상품을 삭제합니다. 삭제한 상품은 휴지통에서 복구할 수 있습니다.`}
+        confirmLabel="삭제"
+        pendingLabel="삭제 중..."
+        pending={isDeleting}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 };

--- a/src/app/(admin)/admin/reviews/_containers/AdminReviewsTable.component.test.tsx
+++ b/src/app/(admin)/admin/reviews/_containers/AdminReviewsTable.component.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { AdminReviewListPage } from "@/core/domain/review";
 
@@ -33,6 +33,14 @@ const buildPage = (
   ...overrides,
 });
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
 describe("AdminReviewsTable", () => {
   beforeEach(() => {
     refreshMock.mockClear();
@@ -56,8 +64,7 @@ describe("AdminReviewsTable", () => {
     expect(screen.getByText("등록된 리뷰가 없습니다")).toBeInTheDocument();
   });
 
-  it("삭제 확인 후 deleteReviewByAdmin을 호출하고 성공하면 새로고침한다", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+  it("삭제 확인창은 대상 리뷰와 복구 불가를 알리고, 확인하면 삭제 후 새로고침한다", async () => {
     deleteReviewByAdmin.mockResolvedValue({
       success: true,
       data: { message: "리뷰가 삭제되었습니다." },
@@ -67,18 +74,68 @@ describe("AdminReviewsTable", () => {
 
     await user.click(screen.getByRole("button", { name: "삭제" }));
 
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent("김민준");
+    expect(dialog).toHaveTextContent("봄빛 청첩장 세트");
+    expect(dialog).toHaveTextContent("복구할 수 없습니다");
+
+    await user.click(within(dialog).getByRole("button", { name: "삭제" }));
+
     expect(deleteReviewByAdmin).toHaveBeenCalledWith("review-1");
     expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("alertdialog")).toBeNull();
   });
 
   it("삭제를 취소하면 deleteReviewByAdmin을 호출하지 않는다", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(false);
     const user = userEvent.setup();
     render(<AdminReviewsTable page={buildPage()} />);
 
     await user.click(screen.getByRole("button", { name: "삭제" }));
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "취소",
+      }),
+    );
 
+    expect(screen.queryByRole("alertdialog")).toBeNull();
     expect(deleteReviewByAdmin).not.toHaveBeenCalled();
+  });
+
+  it("삭제에 실패하면 확인창을 열어둔 채 재시도할 수 있다", async () => {
+    deleteReviewByAdmin.mockResolvedValue({
+      success: false,
+      error: { category: "INTERNAL", message: "삭제에 실패했습니다." },
+    });
+    const user = userEvent.setup();
+    render(<AdminReviewsTable page={buildPage()} />);
+
+    await user.click(screen.getByRole("button", { name: "삭제" }));
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "삭제",
+      }),
+    );
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it("삭제가 진행되는 동안 확인 버튼을 다시 눌러도 중복 호출하지 않는다", async () => {
+    const deferred = createDeferred<{ success: true; data: { message: string } }>();
+    deleteReviewByAdmin.mockReturnValue(deferred.promise);
+    const user = userEvent.setup();
+    render(<AdminReviewsTable page={buildPage()} />);
+
+    await user.click(screen.getByRole("button", { name: "삭제" }));
+    const dialog = screen.getByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: "삭제" }));
+    await user.click(within(dialog).getByRole("button", { name: "삭제 중..." }));
+
+    expect(deleteReviewByAdmin).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve({ success: true, data: { message: "삭제되었습니다." } });
+    });
   });
 
   it("nextCursor가 없으면 다음 페이지 버튼이 비활성화된다", () => {

--- a/src/app/(admin)/admin/reviews/_containers/AdminReviewsTable.tsx
+++ b/src/app/(admin)/admin/reviews/_containers/AdminReviewsTable.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/ui/components/atoms/button";
 import { TypographyH1, TypographyMuted } from "@/ui/components/atoms/typography";
+import { ConfirmDialog } from "@/ui/components/molecules/ConfirmDialog";
 import { CursorPagination } from "@/ui/components/molecules/CursorPagination";
 import { RatingStars } from "@/ui/components/organisms/RatingStars";
 import type { AdminReviewListPage } from "@/core/domain/review";
@@ -18,32 +19,55 @@ interface AdminReviewsTableProps {
 
 interface ReviewDeleteButtonProps {
   reviewId: string;
+  authorName: string;
+  productTitle: string;
   onDeleted: () => void;
 }
 
-const ReviewDeleteButton = ({ reviewId, onDeleted }: ReviewDeleteButtonProps) => {
+const ReviewDeleteButton = ({
+  reviewId,
+  authorName,
+  productTitle,
+  onDeleted,
+}: ReviewDeleteButtonProps) => {
   const [isDeleting, startDeleting] = useTransition();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
   const handleDelete = () => {
-    if (!window.confirm("이 리뷰를 삭제할까요? 삭제하면 되돌릴 수 없습니다.")) {
-      return;
-    }
-
     startDeleting(async () => {
       const result = await deleteReviewByAdmin(reviewId);
       if (result.success === false) {
+        // 실패하면 다이얼로그를 열어둔 채 재시도할 수 있게 남긴다.
         toast.error(result.error.message);
         return;
       }
       toast.success(result.data.message);
+      setIsConfirmOpen(false);
       onDeleted();
     });
   };
 
   return (
-    <Button size="sm" variant="outline" disabled={isDeleting} onClick={handleDelete}>
-      {isDeleting ? "삭제 중..." : "삭제"}
-    </Button>
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={isDeleting}
+        onClick={() => setIsConfirmOpen(true)}
+      >
+        {isDeleting ? "삭제 중..." : "삭제"}
+      </Button>
+      <ConfirmDialog
+        open={isConfirmOpen}
+        onOpenChange={setIsConfirmOpen}
+        title="리뷰 삭제"
+        description={`${authorName}님이 "${productTitle}"에 남긴 리뷰를 삭제합니다. 삭제한 리뷰는 복구할 수 없습니다.`}
+        confirmLabel="삭제"
+        pendingLabel="삭제 중..."
+        pending={isDeleting}
+        onConfirm={handleDelete}
+      />
+    </>
   );
 };
 
@@ -87,6 +111,8 @@ const AdminReviewsTable = ({ page, cursor }: AdminReviewsTableProps) => {
                   <td className="px-4 py-3 text-right">
                     <ReviewDeleteButton
                       reviewId={review.id}
+                      authorName={review.authorName}
+                      productTitle={review.productTitle}
                       onDeleted={() => router.refresh()}
                     />
                   </td>

--- a/src/app/(main)/(my-order)/my-orders/_containers/OrderCard.component.test.tsx
+++ b/src/app/(main)/(my-order)/my-orders/_containers/OrderCard.component.test.tsx
@@ -1,9 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { OrderListItem } from "@/core/domain/order";
 
+const refresh = vi.hoisted(() => vi.fn());
+
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useRouter: () => ({ push: vi.fn(), refresh }),
 }));
 
 vi.mock("@/ui/stores/use-app-store", () => ({
@@ -16,6 +19,7 @@ vi.mock("@/actions/cancelOrder", () => ({
   cancelOrder: vi.fn(),
 }));
 
+import { cancelOrder } from "@/actions/cancelOrder";
 import { OrderCard } from "./OrderCard";
 import { MOBILE_INVITATION_CATEGORY } from "@/core/domain/product-category";
 
@@ -46,7 +50,30 @@ const buildOrder = (overrides?: Partial<OrderListItem>): OrderListItem =>
     ...overrides,
   }) as unknown as OrderListItem;
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+// 주문 메뉴를 열고 "주문 취소"를 골라 확인창까지 진행한다.
+const openCancelConfirm = async (onOrderChanged?: () => void) => {
+  const user = userEvent.setup();
+  render(<OrderCard order={buildOrder()} onOrderChanged={onOrderChanged} />);
+
+  await user.click(screen.getByRole("button", { name: "주문 메뉴" }));
+  await user.click(screen.getByRole("menuitem", { name: "주문 취소" }));
+
+  return user;
+};
+
 describe("OrderCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("결제창을 벗어난 PENDING 주문은 결제하기 버튼을 보여준다", () => {
     render(<OrderCard order={buildOrder()} />);
 
@@ -117,5 +144,83 @@ describe("OrderCard", () => {
       screen.getByRole("button", { name: /공개 링크 복사/ }),
     ).toBeInTheDocument();
     expect(screen.getByText("발행완료")).toBeInTheDocument();
+  });
+
+  it("주문 취소를 고르면 메뉴가 닫히고 되돌릴 수 없음을 알리는 확인창이 열린다", async () => {
+    await openCancelConfirm();
+
+    expect(screen.queryByRole("menu")).toBeNull();
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent("봄맞이 청첩장");
+    expect(dialog).toHaveTextContent("복구할 수 없습니다");
+    expect(cancelOrder).not.toHaveBeenCalled();
+  });
+
+  it("확인창을 취소하면 주문을 취소하지 않고 주문 메뉴 버튼으로 포커스가 돌아온다", async () => {
+    const user = await openCancelConfirm();
+
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "취소",
+      }),
+    );
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(cancelOrder).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "주문 메뉴" })).toHaveFocus();
+  });
+
+  it("주문 취소를 확인하면 cancelOrder 후 목록 캐시와 라우터를 갱신하고 포커스를 되돌린다", async () => {
+    vi.mocked(cancelOrder).mockResolvedValue({
+      success: true,
+      data: { orderId: "order-1" },
+    });
+    const onOrderChanged = vi.fn();
+    const user = await openCancelConfirm(onOrderChanged);
+
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "주문 취소",
+      }),
+    );
+
+    expect(cancelOrder).toHaveBeenCalledWith("order-1");
+    expect(onOrderChanged).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(screen.getByRole("button", { name: "주문 메뉴" })).toHaveFocus();
+  });
+
+  it("주문 취소에 실패하면 확인창을 열어둔 채 재시도할 수 있다", async () => {
+    vi.mocked(cancelOrder).mockResolvedValue({
+      success: false,
+      error: { category: "INTERNAL", message: "취소에 실패했습니다." },
+    });
+    const user = await openCancelConfirm();
+
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "주문 취소",
+      }),
+    );
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("취소가 진행되는 동안 확인 버튼을 다시 눌러도 cancelOrder를 중복 호출하지 않는다", async () => {
+    const deferred = createDeferred<{ success: true; data: { orderId: string } }>();
+    vi.mocked(cancelOrder).mockReturnValue(deferred.promise);
+    const user = await openCancelConfirm();
+
+    const dialog = screen.getByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: "주문 취소" }));
+    await user.click(within(dialog).getByRole("button", { name: "취소 중..." }));
+
+    expect(cancelOrder).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve({ success: true, data: { orderId: "order-1" } });
+    });
   });
 });

--- a/src/app/(main)/(my-order)/my-orders/_containers/OrderCard.tsx
+++ b/src/app/(main)/(my-order)/my-orders/_containers/OrderCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { format } from "date-fns";
@@ -12,6 +12,7 @@ import { Card, CardContent, CardHeader } from "@/ui/components/atoms/card";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/components/atoms/dropdown-menu";
 import { TypographyH3, TypographyMuted } from "@/ui/components/atoms/typography";
 import { Alert } from "@/ui/components/molecules/Alert";
+import { ConfirmDialog } from "@/ui/components/molecules/ConfirmDialog";
 import { useCopy } from "@/ui/hooks/useCopy";
 import { CreditCard, Edit, EllipsisVertical, Link2 } from "lucide-react";
 import type { OrderListItem, OrderStatus } from "@/core/domain/order";
@@ -44,6 +45,10 @@ interface OrderCardProps {
 const OrderCard = ({ order, onOrderChanged }: OrderCardProps) => {
   const router = useRouter();
   const [isCancelling, startCancelling] = useTransition();
+  const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+  // 확인창을 연 DropdownMenuItem은 메뉴가 닫히며 사라진다 — 닫힐 때 포커스를
+  // 되돌릴 대상은 그 메뉴를 여는 버튼이다.
+  const orderMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const { copyToClipboard } = useCopy();
 
   const product = order.product;
@@ -72,17 +77,15 @@ const OrderCard = ({ order, onOrderChanged }: OrderCardProps) => {
     : resolveOrderStatusLabel(order.orderStatus, product.category);
 
   const handleCancel = () => {
-    if (!window.confirm("이 주문을 취소할까요? 취소하면 되돌릴 수 없습니다.")) {
-      return;
-    }
-
     startCancelling(async () => {
       const result = await cancelOrder(order._id);
       if (result.success === false) {
+        // 실패하면 확인창을 열어둔 채 재시도할 수 있게 남긴다.
         toast.error(result.error.message);
         return;
       }
       toast.success("주문이 취소되었습니다.");
+      setIsCancelDialogOpen(false);
       // 화면에 그려지는 건 SWR 캐시라 RSC만 새로 그려서는 반영되지 않는다.
       onOrderChanged?.();
       router.refresh();
@@ -106,7 +109,12 @@ const OrderCard = ({ order, onOrderChanged }: OrderCardProps) => {
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button size="sm" variant="ghost" aria-label="주문 메뉴">
+            <Button
+              ref={orderMenuTriggerRef}
+              size="sm"
+              variant="ghost"
+              aria-label="주문 메뉴"
+            >
               <EllipsisVertical className="h-4 w-4" />
             </Button>
           </DropdownMenuTrigger>
@@ -120,12 +128,27 @@ const OrderCard = ({ order, onOrderChanged }: OrderCardProps) => {
               <Link href={routes.myOrders.detail(order._id)}>상세보기</Link>
             </DropdownMenuItem>
             {isAbandonedPending && (
-              <DropdownMenuItem disabled={isCancelling} onSelect={handleCancel}>
+              <DropdownMenuItem
+                disabled={isCancelling}
+                onSelect={() => setIsCancelDialogOpen(true)}
+              >
                 주문 취소
               </DropdownMenuItem>
             )}
           </DropdownMenuContent>
         </DropdownMenu>
+
+        <ConfirmDialog
+          open={isCancelDialogOpen}
+          onOpenChange={setIsCancelDialogOpen}
+          title="주문 취소"
+          description={`"${product.title}" 주문을 취소합니다. 취소한 주문은 복구할 수 없습니다.`}
+          confirmLabel="주문 취소"
+          pendingLabel="취소 중..."
+          pending={isCancelling}
+          onConfirm={handleCancel}
+          restoreFocusRef={orderMenuTriggerRef}
+        />
       </CardHeader>
 
       <CardContent className="space-y-4">

--- a/src/app/(main)/(my-order)/my-orders/_containers/ReviewFormDialog.component.test.tsx
+++ b/src/app/(main)/(my-order)/my-orders/_containers/ReviewFormDialog.component.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const actions = vi.hoisted(() => ({
@@ -31,6 +31,32 @@ import type { OrderReviewSummary } from "@/core/domain/order";
 import { ReviewFormDialog } from "./ReviewFormDialog";
 
 const successResponse = { success: true as const, data: { message: "완료되었습니다." } };
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+const existingReview: OrderReviewSummary = {
+  id: "review-1",
+  rating: 4,
+  content: "만족스러운 상품이었습니다.",
+  images: [],
+};
+
+// 리뷰 Dialog 안에서 삭제 확인 AlertDialog를 여는 지점까지 진행한다.
+const openDeleteConfirm = async () => {
+  const user = userEvent.setup();
+  render(<ReviewFormDialog orderId="order-1" review={existingReview} />);
+
+  await user.click(screen.getByRole("button", { name: "리뷰 보기·수정" }));
+  await user.click(screen.getByRole("button", { name: "리뷰 삭제" }));
+
+  return user;
+};
 
 describe("ReviewFormDialog", () => {
   beforeEach(() => {
@@ -86,21 +112,71 @@ describe("ReviewFormDialog", () => {
     expect(screen.getByRole("button", { name: "리뷰 삭제" })).toBeInTheDocument();
   });
 
-  it("삭제 확인 후 deleteReview에 reviewId를 위임한다", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(true);
-    actions.deleteReview.mockResolvedValue(successResponse);
-    const review: OrderReviewSummary = {
-      id: "review-1",
-      rating: 4,
-      content: "만족스러운 상품이었습니다.",
-      images: [],
-    };
-    const user = userEvent.setup();
-    render(<ReviewFormDialog orderId="order-1" review={review} />);
+  it("삭제 확인을 취소하면 확인창만 닫히고 리뷰 다이얼로그와 포커스가 남는다", async () => {
+    const user = await openDeleteConfirm();
 
-    await user.click(screen.getByRole("button", { name: "리뷰 보기·수정" }));
-    await user.click(screen.getByRole("button", { name: "리뷰 삭제" }));
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "취소",
+      }),
+    );
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(screen.getByRole("heading", { name: "리뷰 수정" })).toBeInTheDocument();
+    expect(actions.deleteReview).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "리뷰 삭제" })).toHaveFocus();
+  });
+
+  it("삭제를 확인해 성공하면 확인창과 리뷰 다이얼로그가 함께 닫힌다", async () => {
+    actions.deleteReview.mockResolvedValue(successResponse);
+    const user = await openDeleteConfirm();
+
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "삭제",
+      }),
+    );
 
     expect(actions.deleteReview).toHaveBeenCalledWith("review-1");
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(screen.queryByRole("heading", { name: "리뷰 수정" })).toBeNull();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("삭제에 실패하면 확인창과 리뷰 다이얼로그가 모두 남는다", async () => {
+    actions.deleteReview.mockResolvedValue({
+      success: false,
+      error: { category: "INTERNAL", message: "삭제에 실패했습니다." },
+    });
+    const user = await openDeleteConfirm();
+
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "삭제",
+      }),
+    );
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    // 확인창이 떠 있는 동안 바깥 Dialog는 aria-hidden으로 가려지지만 그대로 남는다.
+    expect(
+      screen.getByRole("heading", { name: "리뷰 수정", hidden: true }),
+    ).toBeInTheDocument();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("삭제가 진행되는 동안 확인 버튼을 다시 눌러도 deleteReview를 중복 호출하지 않는다", async () => {
+    const deferred = createDeferred<typeof successResponse>();
+    actions.deleteReview.mockReturnValue(deferred.promise);
+    const user = await openDeleteConfirm();
+
+    const dialog = screen.getByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: "삭제" }));
+    await user.click(within(dialog).getByRole("button", { name: "삭제 중..." }));
+
+    expect(actions.deleteReview).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve(successResponse);
+    });
   });
 });

--- a/src/app/(main)/(my-order)/my-orders/_containers/ReviewFormDialog.tsx
+++ b/src/app/(main)/(my-order)/my-orders/_containers/ReviewFormDialog.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import type { FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/ui/components/atoms/button";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/ui/components/atoms/dialog";
 import { Textarea } from "@/ui/components/atoms/textarea";
+import { ConfirmDialog } from "@/ui/components/molecules/ConfirmDialog";
 import { ImageField } from "@/ui/components/organisms/ImageField";
 import { RatingStars } from "@/ui/components/organisms/RatingStars";
 import { useImageList } from "@/ui/hooks/useImageList";
@@ -36,6 +37,10 @@ const ReviewFormDialog = ({ orderId, review }: ReviewFormDialogProps) => {
   const [open, setOpen] = useState(false);
   const [rating, setRating] = useState(review?.rating ?? 0);
   const [result, setResult] = useState<ReviewActionResult | null>(null);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  // 확인창이 닫히면 바깥 Dialog의 FocusScope가 자기 컨테이너로 포커스를 되가져간다 —
+  // 삭제를 시작한 버튼으로 되돌려 키보드 사용자의 위치를 잃지 않게 한다.
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
   const images = useImageList(review?.images);
   const router = useRouter();
   const [isSubmitting, startSubmitting] = useTransition();
@@ -67,17 +72,16 @@ const ReviewFormDialog = ({ orderId, review }: ReviewFormDialogProps) => {
 
   const handleDelete = () => {
     if (!review) return;
-    if (!window.confirm("리뷰를 삭제할까요? 삭제하면 되돌릴 수 없습니다.")) {
-      return;
-    }
 
     startDeleting(async () => {
       const response = await deleteReview(review.id);
 
       if (response.success === false) {
+        // 실패하면 확인창과 리뷰 다이얼로그를 모두 열어둔 채 재시도할 수 있게 남긴다.
         toast.error(response.error.message);
         return;
       }
+      setIsDeleteConfirmOpen(false);
       handleSuccess(response.data.message);
     });
   };
@@ -152,10 +156,11 @@ const ReviewFormDialog = ({ orderId, review }: ReviewFormDialogProps) => {
           <DialogFooter className="gap-2 sm:justify-between">
             {isEdit && (
               <Button
+                ref={deleteButtonRef}
                 type="button"
                 variant="destructive"
                 disabled={isDeleting}
-                onClick={handleDelete}
+                onClick={() => setIsDeleteConfirmOpen(true)}
               >
                 {isDeleting ? "삭제 중..." : "리뷰 삭제"}
               </Button>
@@ -172,6 +177,20 @@ const ReviewFormDialog = ({ orderId, review }: ReviewFormDialogProps) => {
             </div>
           </DialogFooter>
         </form>
+
+        {isEdit && (
+          <ConfirmDialog
+            open={isDeleteConfirmOpen}
+            onOpenChange={setIsDeleteConfirmOpen}
+            title="리뷰 삭제"
+            description="작성한 리뷰를 삭제합니다. 삭제한 리뷰는 복구할 수 없습니다."
+            confirmLabel="삭제"
+            pendingLabel="삭제 중..."
+            pending={isDeleting}
+            onConfirm={handleDelete}
+            restoreFocusRef={deleteButtonRef}
+          />
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/ui/components/atoms/alert-dialog.tsx
+++ b/src/ui/components/atoms/alert-dialog.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+
+import { cn } from "@/core/utils/cn";
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel data-slot="alert-dialog-cancel" {...props} />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+};
+

--- a/src/ui/components/molecules/ConfirmDialog.component.test.tsx
+++ b/src/ui/components/molecules/ConfirmDialog.component.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from "vitest";
+import { useState } from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+// 열림·진행 상태와 닫는 시점은 ConfirmDialog가 아니라 소비자가 소유한다 —
+// 그 계약을 그대로 재현한 최소 소비자를 두고 사용자 관점에서 관찰한다.
+const ConfirmDialogHost = ({
+  onAction,
+}: {
+  onAction: () => Promise<boolean>;
+}) => {
+  const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        상품 삭제
+      </button>
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="상품 삭제"
+        description="봄맞이 청첩장 상품을 삭제합니다. 삭제한 상품은 휴지통에서 복구할 수 있습니다."
+        confirmLabel="삭제"
+        pendingLabel="삭제 중..."
+        pending={pending}
+        onConfirm={async () => {
+          setPending(true);
+          const succeeded = await onAction();
+          setPending(false);
+          if (succeeded) {
+            setOpen(false);
+          }
+        }}
+      />
+    </>
+  );
+};
+
+const openDialog = async (onAction: () => Promise<boolean>) => {
+  const user = userEvent.setup();
+  render(<ConfirmDialogHost onAction={onAction} />);
+  await user.click(screen.getByRole("button", { name: "상품 삭제" }));
+  return user;
+};
+
+describe("ConfirmDialog", () => {
+  it("제목·설명·동작 이름을 그대로 보여준다", async () => {
+    await openDialog(async () => true);
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent("상품 삭제");
+    expect(dialog).toHaveTextContent("휴지통에서 복구할 수 있습니다");
+    expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "취소" })).toBeInTheDocument();
+  });
+
+  it("취소하면 확인 동작을 실행하지 않고 닫는다", async () => {
+    const onAction = vi.fn(async () => true);
+    const user = await openDialog(onAction);
+
+    await user.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("Esc를 누르면 확인 동작 없이 닫는다", async () => {
+    const onAction = vi.fn(async () => true);
+    const user = await openDialog(onAction);
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("바깥을 클릭해도 닫히지 않는다", async () => {
+    await openDialog(async () => true);
+
+    // 바깥 클릭 해제는 Radix가 document의 pointerdown으로 판정한다 —
+    // userEvent로는 modal overlay의 pointer-events 차단을 넘길 수 없어
+    // 저수준 이벤트로 직접 만든다.
+    fireEvent.pointerDown(document.body);
+    fireEvent.mouseDown(document.body);
+    fireEvent.click(document.body);
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+  });
+
+  it("진행 중에는 확인·취소·Esc를 모두 잠근다", async () => {
+    const deferred = createDeferred<boolean>();
+    const user = await openDialog(() => deferred.promise);
+
+    await user.click(screen.getByRole("button", { name: "삭제" }));
+
+    expect(screen.getByRole("button", { name: "삭제 중..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "취소" })).toBeDisabled();
+
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+    await act(async () => {
+      deferred.resolve(true);
+    });
+  });
+
+  it("진행 중 확인을 다시 눌러도 동작을 중복 실행하지 않는다", async () => {
+    const deferred = createDeferred<boolean>();
+    const onAction = vi.fn(() => deferred.promise);
+    const user = await openDialog(onAction);
+
+    await user.click(screen.getByRole("button", { name: "삭제" }));
+    await user.click(screen.getByRole("button", { name: "삭제 중..." }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve(true);
+    });
+  });
+
+  it("동작이 성공하면 닫는다", async () => {
+    const deferred = createDeferred<boolean>();
+    const user = await openDialog(() => deferred.promise);
+
+    await user.click(screen.getByRole("button", { name: "삭제" }));
+    await act(async () => {
+      deferred.resolve(true);
+    });
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("동작이 실패하면 열린 채로 남아 다시 시도할 수 있다", async () => {
+    const deferred = createDeferred<boolean>();
+    const onAction = vi.fn(() => deferred.promise);
+    const user = await openDialog(onAction);
+
+    await user.click(screen.getByRole("button", { name: "삭제" }));
+    await act(async () => {
+      deferred.resolve(false);
+    });
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    const retryButton = screen.getByRole("button", { name: "삭제" });
+    expect(retryButton).toBeEnabled();
+
+    await user.click(retryButton);
+    expect(onAction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/ui/components/molecules/ConfirmDialog.tsx
+++ b/src/ui/components/molecules/ConfirmDialog.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import type { ReactNode, RefObject } from "react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/ui/components/atoms/alert-dialog";
+import { Button } from "@/ui/components/atoms/button";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: ReactNode;
+  confirmLabel: string;
+  pendingLabel: string;
+  confirmVariant?: "default" | "destructive";
+  cancelLabel?: string;
+  /** 진행 중에는 확인·취소·Esc를 모두 잠근다 — 소비자가 소유하는 상태다. */
+  pending: boolean;
+  /** 확인 버튼 자체를 잠그는 추가 조건(예: 상품명 확인 입력 미완료). */
+  confirmDisabled?: boolean;
+  onConfirm: () => void;
+  /** 설명과 버튼 사이에 놓이는 추가 확인 UI. */
+  children?: ReactNode;
+  /**
+   * 닫힐 때 포커스를 되돌릴 요소. 다이얼로그를 연 요소(DropdownMenuItem 등)가
+   * 열리는 순간 사라지면 Radix의 기본 포커스 복귀 대상이 없어지므로 명시한다.
+   */
+  restoreFocusRef?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * 확인이 필요한 동작 하나를 사용자에게 되묻는다.
+ *
+ * 열림·진행 상태와 닫는 시점은 전부 소비자가 소유한다 — 액션이 성공했을 때만
+ * 닫고, 실패하면 열어둔 채 재시도할 수 있게 하기 위해서다. 그래서 확인 버튼은
+ * Radix의 `AlertDialogAction`(누르면 무조건 닫힘) 대신 일반 `Button`을 쓴다.
+ */
+const ConfirmDialog = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  pendingLabel,
+  confirmVariant = "destructive",
+  cancelLabel = "취소",
+  pending,
+  confirmDisabled = false,
+  onConfirm,
+  children,
+  restoreFocusRef,
+}: ConfirmDialogProps) => (
+  <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialogContent
+      // 바깥 클릭으로는 진행 여부와 무관하게 닫히지 않는다 — Radix AlertDialog가
+      // `onInteractOutside`/`onPointerDownOutside`를 아예 노출하지 않고 항상
+      // 막아둔다(타입에서 Omit). 되돌릴 수 없는 동작을 실수로 흘려보내지 않기 위함이다.
+      onEscapeKeyDown={(event) => {
+        if (pending) {
+          event.preventDefault();
+        }
+      }}
+      onCloseAutoFocus={(event) => {
+        if (!restoreFocusRef?.current) {
+          return;
+        }
+        event.preventDefault();
+        restoreFocusRef.current.focus();
+      }}
+    >
+      <AlertDialogHeader>
+        <AlertDialogTitle>{title}</AlertDialogTitle>
+        <AlertDialogDescription>{description}</AlertDialogDescription>
+      </AlertDialogHeader>
+
+      {children}
+
+      <AlertDialogFooter>
+        <AlertDialogCancel asChild>
+          <Button type="button" variant="outline" disabled={pending}>
+            {cancelLabel}
+          </Button>
+        </AlertDialogCancel>
+        <Button
+          type="button"
+          variant={confirmVariant}
+          disabled={pending || confirmDisabled}
+          onClick={onConfirm}
+        >
+          {pending ? pendingLabel : confirmLabel}
+        </Button>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+
+export { ConfirmDialog };


### PR DESCRIPTION
## Summary

- 4파일 6개 동작(상품 삭제·복구·영구 삭제, 관리자 리뷰 삭제, 주문 취소, 내 리뷰 삭제)이 브라우저 기본 `confirm`에 의존하고 있었다. 되돌릴 수 없는 동작인데도 스타일·문구가 제각각이고, 진행 중 잠금이나 실패 후 재시도 같은 상태를 표현할 수 없었다.
- 이미 설치된 `radix-ui` 패키지의 AlertDialog를 atom `src/ui/components/atoms/alert-dialog.tsx`로 래핑하고, 프로젝트 `Button`과 조립한 molecule `src/ui/components/molecules/ConfirmDialog.tsx`를 추가했다. 신규 패키지는 추가하지 않았다.
- `open`·`pending`·닫는 시점은 전부 소비자가 소유한다. 액션이 성공해야만 닫히고, 실패하면 열린 채로 남아 기존 toast로 에러를 알린 뒤 재시도할 수 있다. 진행 중에는 확인·취소·Esc를 잠그고, 바깥 클릭은 진행 여부와 무관하게 항상 닫기를 막는다.
- 전역 Provider나 Promise 기반 `useConfirm` 훅은 도입하지 않았다. 숨은 전역 상태를 새로 요구하는 대신 각 소비처가 직접 상태를 든다.
- 영구 삭제는 되돌릴 수 없어 확인 한 번으로 부족하다고 보고, 상품명을 완전 일치(대소문자·공백 보정 없음)로 입력해야 실행 버튼이 열리는 `ProductPermanentDeleteDialog`를 소비처 옆 `_components/`에 뒀다. 실패하면 입력값을 남기고, 닫히면 비운다.
- 복구만 default variant이고 나머지 다섯 동작은 destructive다. 버튼 라벨은 "확인" 대신 동작명(삭제·복구·주문 취소·영구 삭제)을 그대로 쓰며, 설명에는 대상 이름과 복구 가능 여부를 적었다.
- 포커스는 두 곳에서 명시적으로 되돌린다. 주문 취소는 확인창을 연 DropdownMenuItem이 메뉴와 함께 사라지고, 리뷰 삭제는 바깥 Dialog의 FocusScope가 자기 컨테이너로 포커스를 되가져가기 때문에, 각각 주문 메뉴 버튼과 리뷰 삭제 버튼으로 복귀시킨다.
- 테스트는 전부 component 티어로 뒀다. DB·스키마 변경이 없고 실제 브라우저에서만 재현되는 동작도 없어 신규 integration·E2E는 만들지 않았다. 기존 `window.confirm` spy 4곳은 실제 다이얼로그 상호작용으로 바꿨고, 테스트가 없던 주문 취소는 새로 덮었다.

## Test plan

- `npm run lint` — 통과
- `npm run lint:barrels` — 통과
- `npm run tsc` — 통과
- `npm run test:component` — 109 파일 434 테스트 통과 (신규 `ConfirmDialog` 8건, `ProductPermanentDeleteDialog` 7건 포함)
- `npm run test:unit` — 31 파일 252 테스트 통과 (회귀 확인용)

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XScHkMFahqwKkXTTytc6mf