### PR TITLE
refactor: 공유 좌표 타입을 core로 이동한다

### DIFF
--- a/src/adapters/browser/deeplink/open-app.ts
+++ b/src/adapters/browser/deeplink/open-app.ts
@@ -1,9 +1,5 @@
 import "client-only";
-
-export interface GeoState {
-  lng: number | null;
-  lat: number | null;
-}
+import type { NullableCoordinates } from "@/core/domain/geo";
 
 const openTmap = (address: string) => {
   const timeout = setTimeout(() => {
@@ -21,8 +17,8 @@ const openNaverMap = ({
   target,
   address,
 }: {
-  current: GeoState;
-  target: GeoState;
+  current: NullableCoordinates;
+  target: NullableCoordinates;
   address: string;
 }): void => {
   const timeout = setTimeout(() => {
@@ -38,8 +34,8 @@ const openKakaoMap = ({
   target,
   address,
 }: {
-  current: GeoState;
-  target: GeoState;
+  current: NullableCoordinates;
+  target: NullableCoordinates;
   address: string;
 }): void => {
   const timeout = setTimeout(() => {

--- a/src/app/(preview)/preview/[publicKey]/_constants/navigation.ts
+++ b/src/app/(preview)/preview/[publicKey]/_constants/navigation.ts
@@ -1,4 +1,5 @@
 import { openApp } from "@/adapters/browser/deeplink/open-app";
+import type { NullableCoordinates } from "@/core/domain/geo";
 
 export const navigationButtons = [
   {
@@ -9,8 +10,8 @@ export const navigationButtons = [
       target,
       address,
     }: {
-      current: { lng: number | null; lat: number | null };
-      target: { lng: number | null; lat: number | null };
+      current: NullableCoordinates;
+      target: NullableCoordinates;
       address: string;
     }) =>
       current &&
@@ -32,8 +33,8 @@ export const navigationButtons = [
       target,
       address,
     }: {
-      current: { lng: number | null; lat: number | null };
-      target: { lng: number | null; lat: number | null };
+      current: NullableCoordinates;
+      target: NullableCoordinates;
       address: string;
     }) =>
       current &&

--- a/src/core/domain/geo.ts
+++ b/src/core/domain/geo.ts
@@ -1,0 +1,4 @@
+export interface NullableCoordinates {
+  lat: number | null;
+  lng: number | null;
+}

--- a/src/ui/hooks/useKakaomapGeocode.ts
+++ b/src/ui/hooks/useKakaomapGeocode.ts
@@ -3,10 +3,10 @@
 import { useEffect } from "react";
 import useSWR from "swr";
 import { fetcher } from "@/ui/fetcher";
-import type { GeoState } from "@/adapters/browser/deeplink/open-app";
+import type { NullableCoordinates } from "@/core/domain/geo";
 import type { KakaomapResponse } from "@/core/schemas/response/kakaomap.schema";
 
-export function useKakaomapGeocode(address: string): GeoState {
+export function useKakaomapGeocode(address: string): NullableCoordinates {
   const trimmedAddress = address.trim();
   const swrKey = trimmedAddress
     ? `/api/kakao-map?address=${encodeURIComponent(trimmedAddress)}`

--- a/src/ui/hooks/useNavigationGeo.ts
+++ b/src/ui/hooks/useNavigationGeo.ts
@@ -1,17 +1,20 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { GeoState } from "@/adapters/browser/deeplink/open-app";
+import type { NullableCoordinates } from "@/core/domain/geo";
 import { getCurrentCoordinates } from "@/adapters/browser/geolocation/current-position";
 import { useKakaomapGeocode } from "./useKakaomapGeocode";
 
 export interface NavigationGeo {
-  current: GeoState;
-  target: GeoState;
+  current: NullableCoordinates;
+  target: NullableCoordinates;
 }
 
 export function useNavigationGeo(address: string): NavigationGeo {
-  const [current, setCurrent] = useState<GeoState>({ lng: null, lat: null });
+  const [current, setCurrent] = useState<NullableCoordinates>({
+    lng: null,
+    lat: null,
+  });
 
   useEffect(() => {
     const fetchCurrentCoordinates = async () => {


### PR DESCRIPTION
## Summary

- `GeoState`가 deeplink Adapter(`open-app.ts`)에 정의돼 있었지만 UI 훅 2곳(`useKakaomapGeocode`, `useNavigationGeo`)이 함께 소비했고, `navigation.ts`에는 같은 shape이 두 번 인라인으로 중복돼 있었다.
- `src/core/domain/geo.ts`에 `NullableCoordinates` 타입을 신설하고, 4개 소비처(deeplink Adapter, UI 훅 2곳, route-local navigation 상수) 전부가 자체 정의/인라인 중복을 제거하고 core에서 직접 import하도록 교체했다.
- geolocation Adapter의 `Coordinates`(조회 성공 시 값이 항상 존재하는 별도 의미)는 이슈 결정대로 통합하지 않고 그대로 뒀다.

Closes #250

## Test plan

- `npm run tsc` — 통과
- `npm run lint` — 통과
- `npm run lint:barrels` — 통과 (배럴 없음)
- 이슈에서 신규 테스트가 불필요하다고 명시해 별도 테스트는 추가하지 않았다.
