### PR TITLE
feat: 모바일초대장 테마별 미리보기 오버레이 추가

### DIFF
--- a/src/app/(main)/(products)/products/[category]/[id]/_components/ProductSummary.tsx
+++ b/src/app/(main)/(products)/products/[category]/[id]/_components/ProductSummary.tsx
@@ -1,16 +1,32 @@
 "use client";
 
-import { Share2 } from "lucide-react";
+import { Eye, Share2 } from "lucide-react";
+import Link from "next/link";
 import { useMemo } from "react";
 import { AppImage } from "@/ui/components/atoms/app-image";
 import { Badge } from "@/ui/components/atoms/badge";
-import { TypographyH1, TypographyMuted } from "@/ui/components/atoms/typography";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+} from "@/ui/components/atoms/card";
+import { HoverDarkenOverlay } from "@/ui/components/atoms/hover-darken-overlay";
+import {
+  TypographyH1,
+  TypographyMuted,
+} from "@/ui/components/atoms/typography";
 import type { Product } from "@/core/domain/product";
 import type { PremiumFeature } from "@/core/domain/premium-feature";
 import { isProductCategory } from "@/core/utils/category";
 import { calculatePrice } from "@/core/utils/price";
 import type { SubCategory } from "@/core/domain/product-category";
-import { productCategoryLabels, subCategoryLabels } from "@/core/domain/product-category";
+import {
+  MOBILE_INVITATION_CATEGORY,
+  productCategoryLabels,
+  subCategoryLabels,
+} from "@/core/domain/product-category";
+import { routes } from "@/core/domain/routes";
 
 import type { CheckoutItem } from "@/core/domain/checkout";
 import { ProductLikeBadge } from "../_containers/ProductLikeBadge";
@@ -33,23 +49,52 @@ export function ProductSummary({
     <div className="mb-16">
       <div className="grid items-start gap-8 lg:grid-cols-2 lg:gap-12">
         {/* Left side - Thumbnail */}
-        <div className="group bg-muted border-border relative aspect-square overflow-hidden rounded-2xl border shadow-lg">
-          <AppImage
-            src={product.thumbnail}
-            alt={`${product.title} 상품 썸네일`}
-            loading="eager"
-          />
-          <div className="absolute top-4 right-4 flex gap-2">
-            {product.isFeatured && (
-              <Badge className="bg-accent text-accent-foreground">추천</Badge>
+        <Card className="group bg-muted border-border relative aspect-square overflow-hidden rounded-2xl p-0 shadow-lg">
+          <CardContent className="absolute inset-0 p-0">
+            <AppImage
+              src={product.thumbnail}
+              alt={`${product.title} 상품 썸네일`}
+              loading="eager"
+              zoomOnHover
+            />
+
+            <HoverDarkenOverlay />
+
+            {product.category === MOBILE_INVITATION_CATEGORY && (
+              <Link
+                href={routes.preview.sampleTheme(product.theme ?? "default")}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="absolute inset-0 cursor-pointer"
+              />
             )}
-            {product.isPremium && (
-              <Badge className="bg-accent text-accent-foreground">
-                프리미엄
-              </Badge>
+          </CardContent>
+
+          <CardHeader className="absolute top-4 right-4 left-4 gap-0 px-0">
+            <div>
+              {product.category === MOBILE_INVITATION_CATEGORY && (
+                <Badge variant="secondary">
+                  <Eye className="h-3 w-3" />
+                  미리보기
+                </Badge>
+              )}
+            </div>
+            {(product.isFeatured || product.isPremium) && (
+              <CardAction className="flex gap-2">
+                {product.isFeatured && (
+                  <Badge className="bg-accent text-accent-foreground">
+                    추천
+                  </Badge>
+                )}
+                {product.isPremium && (
+                  <Badge className="bg-accent text-accent-foreground">
+                    프리미엄
+                  </Badge>
+                )}
+              </CardAction>
             )}
-          </div>
-        </div>
+          </CardHeader>
+        </Card>
 
         {/* Right side - Product Info */}
         <div className="space-y-6">
@@ -81,9 +126,13 @@ export function ProductSummary({
             </TypographyH1>
             {product.ratingCount > 0 && (
               <div className="mb-3 flex items-center gap-2">
-                <RatingStars value={Math.round(product.ratingAverage)} size="sm" />
+                <RatingStars
+                  value={Math.round(product.ratingAverage)}
+                  size="sm"
+                />
                 <TypographyMuted>
-                  {product.ratingAverage.toFixed(1)} ({product.ratingCount.toLocaleString()}개 리뷰)
+                  {product.ratingAverage.toFixed(1)} (
+                  {product.ratingCount.toLocaleString()}개 리뷰)
                 </TypographyMuted>
               </div>
             )}
@@ -124,7 +173,11 @@ export function ProductSummary({
           </div>
 
           {/* Options */}
-          <ProductOptions product={product} options={options} onPurchase={onPurchase} />
+          <ProductOptions
+            product={product}
+            options={options}
+            onPurchase={onPurchase}
+          />
 
           {/* Additional Info */}
           <div className="bg-muted space-y-3 rounded-xl p-6">

--- a/src/app/(preview)/preview/[publicKey]/_components/GuestbookList.tsx
+++ b/src/app/(preview)/preview/[publicKey]/_components/GuestbookList.tsx
@@ -23,7 +23,7 @@ export function GuestbookList({
   onDeleteClick,
 }: GuestbookListProps) {
   return (
-    <div ref={scrollContainerRef} className="max-h-[480px] overflow-y-auto">
+    <div ref={scrollContainerRef} className="scrollbar-hide max-h-[480px] overflow-y-auto">
       <ul className="space-y-4 py-2">
         {status === "ready" && items.length === 0 && (
           <li className="text-muted-foreground py-6 text-center">

--- a/src/app/(preview)/preview/sample/[theme]/_utils/isInvitationTheme.ts
+++ b/src/app/(preview)/preview/sample/[theme]/_utils/isInvitationTheme.ts
@@ -1,0 +1,5 @@
+import { INVITATION_THEMES, type InvitationTheme } from "@/core/domain/theme";
+
+export function isInvitationTheme(theme: string): theme is InvitationTheme {
+  return (INVITATION_THEMES as readonly string[]).includes(theme);
+}

--- a/src/app/(preview)/preview/sample/[theme]/page.tsx
+++ b/src/app/(preview)/preview/sample/[theme]/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation";
+import { routes } from "@/core/domain/routes";
+import { INVITATION_THEMES } from "@/core/domain/theme";
+import { InvitationTemplate } from "@/app/(preview)/preview/[publicKey]/_components/InvitationTemplate";
+import { SAMPLE_FEATURES, sampleInvitation } from "@/app/(preview)/preview/sample/_constants/sampleInvitation";
+import { isInvitationTheme } from "./_utils/isInvitationTheme";
+
+export function generateStaticParams() {
+  return INVITATION_THEMES.map((theme) => ({ theme }));
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ theme: string }>;
+}) {
+  const { theme } = await params;
+  if (!isInvitationTheme(theme)) notFound();
+
+  return (
+    <InvitationTemplate
+      content={sampleInvitation}
+      publicKey={routes.preview.samplePublicKey}
+      features={[...SAMPLE_FEATURES]}
+      theme={theme}
+    />
+  );
+}

--- a/src/core/domain/routes.ts
+++ b/src/core/domain/routes.ts
@@ -1,4 +1,5 @@
 import type { SubCategory } from "./product-category";
+import type { InvitationTheme } from "./theme";
 
 export const routes = {
   home: "/",
@@ -37,6 +38,7 @@ export const routes = {
   preview: {
     detail: (publicKey: string) => `/preview/${publicKey}`,
     sample: "/preview/sample",
+    sampleTheme: (theme: InvitationTheme) => `/preview/sample/${theme}`,
     samplePublicKey: "sample",
   },
   admin: {

--- a/src/ui/components/atoms/app-image.tsx
+++ b/src/ui/components/atoms/app-image.tsx
@@ -13,6 +13,7 @@ interface AppImageProps {
   className?: string;
   preload?: boolean;
   loading?: "eager" | "lazy";
+  zoomOnHover?: boolean;
 }
 
 const AppImage = ({
@@ -22,6 +23,7 @@ const AppImage = ({
   className,
   preload = false,
   loading,
+  zoomOnHover = false,
 }: AppImageProps) => {
   const [failedSrc, setFailedSrc] = useState<AppImageProps["src"] | null>(null);
 
@@ -49,7 +51,12 @@ const AppImage = ({
       sizes={sizes}
       fill
       alt={alt}
-      className={cn("object-cover", className)}
+      className={cn(
+        "object-cover",
+        zoomOnHover &&
+          "transition-transform duration-700 ease-[cubic-bezier(0.25,0.46,0.45,0.94)] group-hover:scale-[1.06]",
+        className,
+      )}
       preload={preload}
       loading={loading}
       onError={() => setFailedSrc(src)}

--- a/src/ui/components/atoms/hover-darken-overlay.tsx
+++ b/src/ui/components/atoms/hover-darken-overlay.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/core/utils/cn";
+
+interface HoverDarkenOverlayProps {
+  className?: string;
+}
+
+// 부모(형제 요소들을 감싸는 카드)가 group 클래스를 가져야 반응한다 —
+// 이미지 자체의 애니메이션이 아니라 이미지 위에 얹는 별도 tint 레이어다.
+function HoverDarkenOverlay({ className }: HoverDarkenOverlayProps) {
+  return (
+    <div
+      className={cn(
+        "absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-500 group-hover:opacity-100",
+        className,
+      )}
+    />
+  );
+}
+
+export { HoverDarkenOverlay };

--- a/src/ui/components/molecules/ProductCard.tsx
+++ b/src/ui/components/molecules/ProductCard.tsx
@@ -7,9 +7,23 @@ import { subCategoryLabels } from "@/core/domain/product-category";
 import { calculatePrice } from "@/core/utils/price";
 import { AppImage } from "@/ui/components/atoms/app-image";
 import { Badge } from "@/ui/components/atoms/badge";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from "@/ui/components/atoms/card";
+import { HoverDarkenOverlay } from "@/ui/components/atoms/hover-darken-overlay";
 import { TypographyMuted } from "@/ui/components/atoms/typography";
 
-export function ProductCard({ product, rank }: { product: Product; rank?: number }) {
+export function ProductCard({
+  product,
+  rank,
+}: {
+  product: Product;
+  rank?: number;
+}) {
   const finalPrice =
     product.discount?.value > 0
       ? calculatePrice(product.price, product.discount)
@@ -24,87 +38,90 @@ export function ProductCard({ product, rank }: { product: Product; rank?: number
 
   return (
     <Link href={routes.products.detail(product.category, product._id)}>
-      <article className="group relative cursor-pointer">
-      {/* Image — the card itself. aspect-ratio는 황금비(1:1.618) 세로 카드 */}
-      <div className="bg-muted relative aspect-[1/1.618] overflow-hidden rounded-2xl">
-        {/* Thumbnail with zoom on hover */}
-        <div className="absolute inset-0 transition-transform duration-700 ease-[cubic-bezier(0.25,0.46,0.45,0.94)] group-hover:scale-[1.06]">
-          <AppImage
-            src={product.thumbnail}
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
-            alt={`${product.title} 썸네일`}
-            preload={true}
-          />
-        </div>
+      <article className="cursor-pointer">
+        {/* aspect-ratio는 황금비(1:1.618) 세로 카드 */}
+        <Card className="group bg-muted relative aspect-[1/1.618] overflow-hidden rounded-2xl border-0 p-0 shadow-none">
+          <CardContent className="absolute inset-0 p-0">
+            <AppImage
+              src={product.thumbnail}
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
+              alt={`${product.title} 썸네일`}
+              preload={true}
+              zoomOnHover
+            />
 
-        {/* Persistent bottom gradient */}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+            {/* Persistent bottom gradient */}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
 
-        {/* Hover overlay deepens */}
-        <div className="absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+            <HoverDarkenOverlay />
+          </CardContent>
 
-        {/* Top badges */}
-        <div className="absolute top-2 right-2 left-2 flex items-start justify-between sm:top-3 sm:right-3 sm:left-3">
-          <div className="flex flex-col gap-1 sm:gap-1.5">
-            {typeof rank === "number" && (
-              <Badge className="bg-foreground/85 border-transparent shadow-sm backdrop-blur-sm">
-                <TypographyMuted className="text-background text-[9px] font-bold sm:text-[10px]">
-                  {rank}
-                  <span className="sr-only">인기 {rank}위</span>
-                </TypographyMuted>
-              </Badge>
-            )}
-            {product.isPremium && (
-              <Badge className="bg-primary border-transparent tracking-widest uppercase shadow-sm backdrop-blur-sm">
-                <Sparkles className="text-primary-foreground h-2.5 w-2.5" />
-                <TypographyMuted className="text-primary-foreground text-[9px] font-bold sm:text-[10px]">
-                  Premium
-                </TypographyMuted>
-              </Badge>
-            )}
-            {product.isFeatured && (
-              <Badge className="bg-accent border-transparent tracking-widest uppercase backdrop-blur-sm">
-                <TypographyMuted className="text-accent-foreground text-[9px] font-bold sm:text-[10px]">
-                  추천
-                </TypographyMuted>
-              </Badge>
-            )}
-          </div>
-          {discountLabel && (
-            <Badge className="bg-destructive border-transparent tracking-wide shadow-sm backdrop-blur-sm">
-              <TypographyMuted className="text-destructive-foreground text-[9px] font-bold sm:text-[10px]">
-                {discountLabel}
-              </TypographyMuted>
-            </Badge>
-          )}
-        </div>
-
-        {/* Bottom info — always visible. 카드가 작아지는 브레이크포인트에 맞춰 텍스트/여백도 같이 줄어든다 */}
-        <div className="absolute inset-x-0 bottom-0 p-2.5 transition-transform duration-500 ease-[cubic-bezier(0.25,0.46,0.45,0.94)] sm:p-4">
-          <p className="mb-0.5 text-[8px] font-semibold tracking-[0.2em] text-white/50 uppercase sm:mb-1 sm:text-[9px] sm:tracking-[0.25em]">
-            {subCategoryLabels[product.subCategory as SubCategory] ??
-              product.subCategory}
-          </p>
-          <h3 className="line-clamp-2 text-xs leading-snug font-semibold text-white sm:text-sm">
-            {product.title}
-          </h3>
-          <div className="mt-1 flex items-center justify-between sm:mt-2">
-            <div className="flex items-baseline gap-1 sm:gap-1.5">
-              {hasDiscount && (
-                <span className="text-[10px] text-white/35 line-through sm:text-[11px]">
-                  {product.price.toLocaleString()}원
-                </span>
+          {/* Top badges */}
+          <CardHeader className="absolute top-2 right-2 left-2 gap-0 px-0 sm:top-3 sm:right-3 sm:left-3">
+            <div className="flex flex-col gap-1 sm:gap-1.5">
+              {typeof rank === "number" && (
+                <Badge className="bg-foreground/85 border-transparent shadow-sm backdrop-blur-sm">
+                  <TypographyMuted className="text-background text-[9px] font-bold sm:text-[10px]">
+                    {rank}
+                    <span className="sr-only">인기 {rank}위</span>
+                  </TypographyMuted>
+                </Badge>
               )}
-              <span className="text-sm font-bold text-white sm:text-base">
-                {finalPrice === 0 ? "무료" : `${finalPrice.toLocaleString()}원`}
+              {product.isPremium && (
+                <Badge className="bg-primary border-transparent tracking-widest uppercase shadow-sm backdrop-blur-sm">
+                  <Sparkles className="text-primary-foreground h-2.5 w-2.5" />
+                  <TypographyMuted className="text-primary-foreground text-[9px] font-bold sm:text-[10px]">
+                    Premium
+                  </TypographyMuted>
+                </Badge>
+              )}
+              {product.isFeatured && (
+                <Badge className="bg-accent border-transparent tracking-widest uppercase backdrop-blur-sm">
+                  <TypographyMuted className="text-accent-foreground text-[9px] font-bold sm:text-[10px]">
+                    추천
+                  </TypographyMuted>
+                </Badge>
+              )}
+            </div>
+            {discountLabel && (
+              <CardAction>
+                <Badge className="bg-destructive border-transparent tracking-wide shadow-sm backdrop-blur-sm">
+                  <TypographyMuted className="text-destructive-foreground text-[9px] font-bold sm:text-[10px]">
+                    {discountLabel}
+                  </TypographyMuted>
+                </Badge>
+              </CardAction>
+            )}
+          </CardHeader>
+
+          {/* Bottom info — always visible. 카드가 작아지는 브레이크포인트에 맞춰 텍스트/여백도 같이 줄어든다 */}
+          <CardFooter className="absolute inset-x-0 bottom-0 flex-col items-stretch px-2.5 py-2.5 transition-transform duration-500 ease-[cubic-bezier(0.25,0.46,0.45,0.94)] sm:px-4 sm:py-4">
+            <p className="mb-0.5 text-[8px] font-semibold tracking-[0.2em] text-white/50 uppercase sm:mb-1 sm:text-[9px] sm:tracking-[0.25em]">
+              {subCategoryLabels[product.subCategory as SubCategory] ??
+                product.subCategory}
+            </p>
+            <h3 className="line-clamp-2 text-xs leading-snug font-semibold text-white sm:text-sm">
+              {product.title}
+            </h3>
+            <div className="mt-1 flex w-full items-center justify-between sm:mt-2">
+              <div className="flex items-baseline gap-1 sm:gap-1.5">
+                {hasDiscount && (
+                  <span className="text-[10px] text-white/35 line-through sm:text-[11px]">
+                    {product.price.toLocaleString()}원
+                  </span>
+                )}
+                <span className="text-sm font-bold text-white sm:text-base">
+                  {finalPrice === 0
+                    ? "무료"
+                    : `${finalPrice.toLocaleString()}원`}
+                </span>
+              </div>
+              <span className="text-[10px] text-white/40 sm:text-[11px]">
+                좋아요 {product.likes?.length || 0}
               </span>
             </div>
-            <span className="text-[10px] text-white/40 sm:text-[11px]">
-              좋아요 {product.likes?.length || 0}
-            </span>
-          </div>
-        </div>
-      </div>
+          </CardFooter>
+        </Card>
       </article>
     </Link>
   );

--- a/src/ui/stores/use-app-store.ts
+++ b/src/ui/stores/use-app-store.ts
@@ -2,6 +2,7 @@
 
 import { useContext } from "react";
 import { useStore } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 import { AppStoreContext } from "./provider";
 import type { OrderSlice } from "./slices/order.slice";
 import type { AdminModalPropsMap, AdminModalSlice, AdminModalType } from "./slices/admin-modal.slice";
@@ -57,14 +58,17 @@ export function useGuestbookModalStore<T = GuestbookModalView>(
   ) => T,
 ): T {
   const store = useAppStoreApi();
-  return useStore(store, (s) =>
-    selector({
-      isOpen: s.guestbookModalIsOpen,
-      type: s.guestbookModalType,
-      payload: s.payload,
-      setIsOpen: s.setIsOpen,
-      closeModal: s.closeGuestbookModal,
-      clearIsOpen: s.clearIsOpen,
-    }),
+  return useStore(
+    store,
+    useShallow((s) =>
+      selector({
+        isOpen: s.guestbookModalIsOpen,
+        type: s.guestbookModalType,
+        payload: s.payload,
+        setIsOpen: s.setIsOpen,
+        closeModal: s.closeGuestbookModal,
+        clearIsOpen: s.clearIsOpen,
+      }),
+    ),
   );
 }


### PR DESCRIPTION
## Summary

- 모바일초대장 상품 카드(목록)와 상세 페이지 썸네일에 hover 오버레이를 추가해, 해당 상품의 테마로 바로 이동하는 미리보기 링크를 제공한다 (`/preview/sample/[theme]` 라우트 신설, `theme`은 `INVITATION_THEMES` 4종만 허용하고 그 외는 404)
- `useGuestbookModalStore()`를 인자 없이 호출하는 곳(`InvitationMessage.tsx`, `GuestbookModal.tsx`)에서 매 렌더 새 객체를 반환해 `useSyncExternalStore` 무한 렌더 루프(`Maximum update depth exceeded`)를 일으키던 버그를 `useShallow`로 수정한다
- 방명록 목록의 세로 스크롤바를 숨긴다(스크롤 동작 자체는 유지)
- 위 hover 오버레이 구현 과정에서 `AppImage`에 `zoomOnHover` prop을, `Card`(atoms) 서브컴포넌트(`CardHeader`/`CardAction`/`CardContent`/`CardFooter`)를 활용하도록 `ProductCard`/`ProductSummary`를 리팩터링한다

## Test plan

- `npm run tsc` — 통과
- `npm run lint` — 통과
- `npm run test:unit` — 262 passed
- `npm run test:component` — 441 passed
- Playwright로 `/preview/sample/default|blossom|botanical|midnight` 4종, 잘못된 theme 값(404), 상품 목록/상세 페이지 hover 오버레이, 방명록 스크롤바를 직접 접속해 콘솔 에러 0건 확인
