### PR TITLE
fix: 존재하지 않는 상품 수정 요청을 NOT_FOUND로 분류한다

### DIFF
--- a/src/models/product.model.ts
+++ b/src/models/product.model.ts
@@ -101,7 +101,12 @@ const productSchema = new Schema<IProduct>(
               .findOne(this.getQuery())
               .select("category")
               .lean();
-            category = existing?.category;
+            // 대상 문서가 아예 없으면 subCategory 유효성을 판단할 근거가 없다 —
+            // false로 떨어뜨려 ValidationError(INTERNAL)를 내면 findOneAndUpdate가
+            // 원래 냈어야 할 "매치 없음"(→ NOT_FOUND) 결과를 가로채게 된다. 검증을
+            // 건너뛰어 update 자체가 매치 없이 끝나도록 위임한다.
+            if (!existing) return true;
+            category = existing.category;
           }
           // 카테고리가 5종으로 늘면서 SUB_CATEGORY_MAP 인덱싱 결과가 카테고리별로 다른
           // 리터럴 튜플 타입의 union이 된다 — 명시적으로 readonly string[]로 넓혀야

--- a/test/integration/services/product.integration.test.ts
+++ b/test/integration/services/product.integration.test.ts
@@ -663,6 +663,16 @@ describe("product", () => {
       expect(result).toBeNull();
     });
 
+    it("존재하지 않는 id + category 없이 subCategory만 보내도 null을 리턴한다 (#49)", async () => {
+      const missingId = new mongoose.Types.ObjectId().toString();
+
+      const result = await updateProductService(missingId, {
+        subCategory: "first-birthday",
+      });
+
+      expect(result).toBeNull();
+    });
+
     it("id 형식이 잘못되면 null을 리턴한다", async () => {
       const result = await updateProductService("not-a-valid-id", {
         title: "x",


### PR DESCRIPTION
## Summary
- `subCategory` async validator가 update payload에 `category`가 없을 때 대상 문서를 조회해 카테고리를 알아내는데, 문서가 존재하지 않으면 이를 "subCategory 무효"로 오판해 `ValidationError`를 던져 `INTERNAL`로 응답하는 결함이 있었다.
- 문서가 없는 경우 검증을 건너뛰도록 고쳐, `findOneAndUpdate`가 매치 없음으로 처리하고 기존 `NOT_FOUND` 경로(`updateProductWorkflow`)로 정상 흐르게 했다.

## Test plan
- `npx vitest run test/integration/services/product.integration.test.ts` — 77개 통과 (재현 회귀 테스트 1건 포함)
- `npx eslint src/models/product.model.ts test/integration/services/product.integration.test.ts` — 통과

Closes #49