### PR TITLE
feat: 상품 연속 등록 흐름을 추가한다

### DIFF
--- a/src/app/(admin)/admin/products/new/_components/ProductRegistrationForm.component.test.tsx
+++ b/src/app/(admin)/admin/products/new/_components/ProductRegistrationForm.component.test.tsx
@@ -43,6 +43,7 @@ describe("ProductRegistrationForm", () => {
         pending={false}
         state={null}
         onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
       />,
     );
 
@@ -167,6 +168,7 @@ describe("ProductRegistrationForm", () => {
           },
         }}
         onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
       />,
     );
 
@@ -254,6 +256,7 @@ describe("ProductRegistrationForm", () => {
         pending={false}
         state={null}
         onCancel={onCancel}
+        onSubmitIntentChange={vi.fn()}
       />,
     );
 
@@ -270,11 +273,13 @@ describe("ProductRegistrationForm", () => {
         pending={true}
         state={null}
         onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
       />,
     );
 
-    const submitButton = screen.getByRole("button", { name: "등록 중..." });
-    expect(submitButton).toBeDisabled();
+    const submitButtons = screen.getAllByRole("button", { name: "등록 중..." });
+    expect(submitButtons).toHaveLength(2);
+    submitButtons.forEach((button) => expect(button).toBeDisabled());
   });
 
   it("카테고리를 변경하면 서브 카테고리 선택이 초기화된다", async () => {
@@ -290,5 +295,152 @@ describe("ProductRegistrationForm", () => {
     await user.click(await screen.findByRole("option", { name: "모바일초대장" }));
 
     expect(categoryTrigger!.textContent).toContain("모바일초대장");
+  });
+});
+
+describe("ProductRegistrationForm — 연속 등록(계속 작성)", () => {
+  it("상품 등록/등록 후 계속 작성 두 개의 제출 버튼을 렌더링한다", () => {
+    render(
+      <ProductRegistrationForm
+        premiumFeatures={[]}
+        action={vi.fn()}
+        pending={false}
+        state={null}
+        onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "상품 등록" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "등록 후 계속 작성" }),
+    ).toBeInTheDocument();
+  });
+
+  it("상품 등록 버튼을 클릭하면 onSubmitIntentChange(false)가 호출된다", async () => {
+    const user = userEvent.setup();
+    const onSubmitIntentChange = vi.fn();
+    render(
+      <ProductRegistrationForm
+        premiumFeatures={[]}
+        action={vi.fn()}
+        pending={false}
+        state={null}
+        onCancel={vi.fn()}
+        onSubmitIntentChange={onSubmitIntentChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "상품 등록" }));
+
+    expect(onSubmitIntentChange).toHaveBeenCalledWith(false);
+  });
+
+  it("등록 후 계속 작성 버튼을 클릭하면 onSubmitIntentChange(true)가 호출된다", async () => {
+    const user = userEvent.setup();
+    const onSubmitIntentChange = vi.fn();
+    render(
+      <ProductRegistrationForm
+        premiumFeatures={[]}
+        action={vi.fn()}
+        pending={false}
+        state={null}
+        onCancel={vi.fn()}
+        onSubmitIntentChange={onSubmitIntentChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "등록 후 계속 작성" }));
+
+    expect(onSubmitIntentChange).toHaveBeenCalledWith(true);
+  });
+
+  it("계속 작성으로 제출 성공하면 카테고리/서브카테고리/테마는 유지되고 나머지 필드는 초기화된다", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ProductRegistrationForm
+        premiumFeatures={[]}
+        action={vi.fn()}
+        pending={false}
+        state={null}
+        onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
+      />,
+    );
+
+    const subCategoryTrigger = screen
+      .getAllByRole("combobox")
+      .find((el) => el.textContent?.includes("서브 카테고리를 선택하세요"));
+    await user.click(subCategoryTrigger!);
+    await user.click(await screen.findByRole("option", { name: "청첩장" }));
+
+    const themeTrigger = screen
+      .getAllByRole("combobox")
+      .find((el) => el.textContent?.includes("기본"));
+    await user.click(themeTrigger!);
+    await user.click(await screen.findByRole("option", { name: "벚꽃" }));
+
+    await user.type(screen.getByLabelText(/상품명/), "임시 상품명");
+    await user.click(screen.getByRole("switch", { name: /추천 상품/ }));
+
+    // "계속 작성"을 클릭한 뒤, 서버 성공 응답을 흉내내 state prop을 갱신한다
+    // (실제로는 useActionState가 이 값을 컨테이너를 통해 내려준다).
+    await user.click(screen.getByRole("button", { name: "등록 후 계속 작성" }));
+
+    rerender(
+      <ProductRegistrationForm
+        premiumFeatures={[]}
+        action={vi.fn()}
+        pending={false}
+        state={{ success: true, data: { message: "등록 완료" } }}
+        onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
+      />,
+    );
+
+    const subCategoryTriggerAfter = screen
+      .getAllByRole("combobox")
+      .find((el) => el.textContent?.includes("청첩장"));
+    expect(subCategoryTriggerAfter).toBeDefined();
+
+    const themeTriggerAfter = screen
+      .getAllByRole("combobox")
+      .find((el) => el.textContent?.includes("벚꽃"));
+    expect(themeTriggerAfter).toBeDefined();
+
+    expect(screen.getByLabelText(/상품명/)).toHaveValue("");
+    expect(
+      screen.getByRole("switch", { name: /추천 상품/ }),
+    ).not.toBeChecked();
+  });
+
+  it("상품 등록 버튼으로 제출 성공해도 필드를 초기화하지 않는다(기존 흐름 회귀 없음)", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ProductRegistrationForm
+        premiumFeatures={[]}
+        action={vi.fn()}
+        pending={false}
+        state={null}
+        onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/상품명/), "임시 상품명");
+    await user.click(screen.getByRole("button", { name: "상품 등록" }));
+
+    rerender(
+      <ProductRegistrationForm
+        premiumFeatures={[]}
+        action={vi.fn()}
+        pending={false}
+        state={{ success: true, data: { message: "등록 완료" } }}
+        onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/상품명/)).toHaveValue("임시 상품명");
   });
 });

--- a/src/app/(admin)/admin/products/new/_components/ProductRegistrationForm.quantityImages.component.test.tsx
+++ b/src/app/(admin)/admin/products/new/_components/ProductRegistrationForm.quantityImages.component.test.tsx
@@ -50,6 +50,7 @@ const renderForm = () =>
       pending={false}
       state={null}
       onCancel={vi.fn()}
+      onSubmitIntentChange={vi.fn()}
     />,
   );
 
@@ -124,6 +125,7 @@ describe("ProductRegistrationForm — 상세 이미지 갤러리(REQ-2/3)", () =
           },
         }}
         onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
       />,
     );
 
@@ -198,6 +200,7 @@ describe("ProductRegistrationForm — 구매 수량(REQ-2/3, §3-4 무제한 체
           },
         }}
         onCancel={vi.fn()}
+        onSubmitIntentChange={vi.fn()}
       />,
     );
 

--- a/src/app/(admin)/admin/products/new/_components/ProductRegistrationForm.tsx
+++ b/src/app/(admin)/admin/products/new/_components/ProductRegistrationForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { PremiumFeature } from "@/core/domain/premium-feature";
 import { Alert } from "@/ui/components/molecules/Alert";
 import { ImageField } from "@/ui/components/organisms/ImageField";
@@ -30,6 +30,8 @@ interface ProductRegistrationFormProps {
   pending: boolean;
   state: APIResponse<{ message: string }> | null;
   onCancel: () => void;
+  // 등록 성공 시 목록으로 이동할지(false) 폼에 남아 계속 등록할지(true) 컨테이너에 알린다.
+  onSubmitIntentChange: (continueRegistration: boolean) => void;
 }
 
 export function ProductRegistrationForm({
@@ -38,10 +40,15 @@ export function ProductRegistrationForm({
   pending,
   state,
   onCancel,
+  onSubmitIntentChange,
 }: ProductRegistrationFormProps) {
   const [isPremium, setIsPremium] = useState(false);
   const [selectedCategory, setSelectedCategory] =
     useState<ProductCategory>(MOBILE_INVITATION_CATEGORY);
+  // 연속 등록 시 유지되는 필드 — category와 마찬가지로 SelectField에 defaultValue로
+  // 넘겨 외부 상태와 동기화한다(SelectField는 defaultValue prop 변경을 감지해 재동기화한다).
+  const [selectedSubCategory, setSelectedSubCategory] = useState("");
+  const [selectedTheme, setSelectedTheme] = useState("default");
   const [isFeature, setIsFeature] = useState(false);
   const [selectedFeatureIds, setSelectedFeatureIds] = useState<string[]>([]);
   const [discountType, setDiscountType] = useState<"rate" | "amount">("rate");
@@ -55,6 +62,36 @@ export function ProductRegistrationForm({
   const [minQuantity, setMinQuantity] = useState<number>(1);
   // 등록 폼 초기값 true — mongoose default(maxQuantity: 0)와 일치.
   const [isUnlimitedMax, setIsUnlimitedMax] = useState(true);
+
+  const formRef = useRef<HTMLFormElement>(null);
+  // 마지막으로 클릭된 제출 버튼 종류. 두 버튼 모두 같은 action을 호출하므로
+  // 성공 이후 어떤 버튼이었는지는 클릭 시점에 기록해뒀다가 state 변화 시 읽는다.
+  const isContinueSubmitRef = useRef(false);
+
+  // "등록 후 계속 작성"으로 성공한 경우에만 category/subCategory/theme을 제외한
+  // 나머지 필드를 초기화한다 — uncontrolled 필드는 form.reset(), controlled 필드는
+  // 각각의 setState로 되돌린다. category/subCategory/theme은 React state이므로
+  // form.reset()의 영향을 받지 않아 그대로 유지된다.
+  useEffect(() => {
+    if (!state?.success) return;
+    if (!isContinueSubmitRef.current) return;
+
+    formRef.current?.reset();
+    setIsPremium(false);
+    setIsFeature(false);
+    setSelectedFeatureIds([]);
+    setDiscountType("rate");
+    setPriceInputError(null);
+    setDiscountInputError(null);
+    setMinQuantity(1);
+    setIsUnlimitedMax(true);
+    thumbnail.reset();
+    preview.reset();
+    images.reset();
+    // thumbnail/preview/images는 매 렌더 새로 생성되는 객체라 deps에 넣으면 매 렌더 실행된다.
+    // 제출 성공(state 변화)에만 반응하면 충분하므로 의도적으로 제외한다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
 
   const handleFeatureChange = (checked: boolean, id: string) => {
     setSelectedFeatureIds((prev) =>
@@ -81,7 +118,7 @@ export function ProductRegistrationForm({
   const maxQuantityError = getFieldError(state, "maxQuantity");
 
   return (
-    <form action={action} className="space-y-6">
+    <form ref={formRef} action={action} className="space-y-6">
       {/* featureIds — 선택된 것만 전송 */}
       {selectedFeatureIds.map((id) => (
         <input key={id} type="hidden" name="featureIds" value={id} />
@@ -136,6 +173,8 @@ export function ProductRegistrationForm({
                 <SelectField
                   id="subCategory"
                   name="subCategory"
+                  defaultValue={selectedSubCategory}
+                  onValueChange={setSelectedSubCategory}
                   placeholder="서브 카테고리를 선택하세요"
                   data={getSubCategoryOptions(selectedCategory)}
                   error={subCategoryError}
@@ -148,7 +187,8 @@ export function ProductRegistrationForm({
                   <SelectField
                     id="theme"
                     name="theme"
-                    defaultValue="default"
+                    defaultValue={selectedTheme}
+                    onValueChange={setSelectedTheme}
                     placeholder="테마를 선택하세요"
                     data={getMobileInvitationThemeOptions()}
                     error={themeError}
@@ -483,7 +523,27 @@ export function ProductRegistrationForm({
         <Button type="button" variant="outline" onClick={onCancel}>
           취소
         </Button>
-        <Button type="submit" className="min-w-30" disabled={pending}>
+        <Button
+          type="submit"
+          variant="secondary"
+          className="min-w-30"
+          disabled={pending}
+          onClick={() => {
+            isContinueSubmitRef.current = true;
+            onSubmitIntentChange(true);
+          }}
+        >
+          {pending ? "등록 중..." : "등록 후 계속 작성"}
+        </Button>
+        <Button
+          type="submit"
+          className="min-w-30"
+          disabled={pending}
+          onClick={() => {
+            isContinueSubmitRef.current = false;
+            onSubmitIntentChange(false);
+          }}
+        >
           {pending ? "등록 중..." : "상품 등록"}
         </Button>
       </div>

--- a/src/app/(admin)/admin/products/new/_containers/ProductRegistrationForm.tsx
+++ b/src/app/(admin)/admin/products/new/_containers/ProductRegistrationForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -20,11 +20,17 @@ export function ProductRegistrationForm({
     FormData
   >(createProduct, null);
 
+  // "등록 후 계속 작성" 버튼으로 제출됐는지 기록한다 — true면 성공해도 목록으로
+  // 이동하지 않고 폼에 남는다(초기화는 순수 컴포넌트가 스스로 처리한다).
+  const continueRegistrationRef = useRef(false);
+
   useEffect(() => {
     if (!state) return;
     if (state.success) {
       toast.success(state.data.message);
-      router.push(routes.admin.products.root);
+      if (!continueRegistrationRef.current) {
+        router.push(routes.admin.products.root);
+      }
     }
   }, [state, router]);
 
@@ -35,6 +41,9 @@ export function ProductRegistrationForm({
       pending={pending}
       state={state}
       onCancel={() => router.push(routes.admin.products.root)}
+      onSubmitIntentChange={(continueRegistration) => {
+        continueRegistrationRef.current = continueRegistration;
+      }}
     />
   );
 }

--- a/src/ui/hooks/useImageList.component.test.ts
+++ b/src/ui/hooks/useImageList.component.test.ts
@@ -61,4 +61,14 @@ describe("useImageList", () => {
     expect(result.current.items).toEqual([second]);
     expect(result.current.getUrls()).toEqual(["url-b"]);
   });
+
+  it("reset()은 모든 항목을 제거한다", () => {
+    const { result } = renderHook(() => useImageList());
+
+    act(() => result.current.add(["url-a", "url-b"]));
+    act(() => result.current.reset());
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.getUrls()).toEqual([]);
+  });
 });

--- a/src/ui/hooks/useImageList.ts
+++ b/src/ui/hooks/useImageList.ts
@@ -42,5 +42,7 @@ export function useImageList(defaultUrls?: string[]) {
 
   const getUrls = (): string[] => items.map((item) => item.url);
 
-  return { items, add, remove, getUrls };
+  const reset = () => setItems([]);
+
+  return { items, add, remove, getUrls, reset };
 }


### PR DESCRIPTION
## Summary

- 상품 등록 성공 시 무조건 목록으로 이동하던 흐름에 "등록 후 계속 작성" 버튼을 추가해, 여러 상품을 연속으로 등록할 때 카테고리·서브카테고리·테마를 반복 선택하지 않아도 되게 한다.
- 두 버튼("상품 등록", "등록 후 계속 작성") 모두 동일한 `createProduct` 서버 액션과 동일한 zod 검증(`productSchema`)을 거친다 — 클릭 시점에 어떤 버튼이었는지만 클라이언트에서 ref로 기록해 성공 이후 분기(라우팅 여부)에 쓴다.
- "계속 작성" 성공 시: `category`/`subCategory`/`theme`만 유지하고 나머지 필드(제목·설명·가격·할인·프리미엄·featureIds·추천·우선순위·썸네일/미리보기/상세이미지·최소/최대 구매수량)는 초기값으로 리셋한다. uncontrolled 필드는 `formRef.current.reset()`으로, controlled 필드는 각 `setState`로 되돌린다.
- `subCategory`/`theme`을 `category`처럼 `SelectField`의 `defaultValue`로 제어되는 컴포넌트 state로 승격해, reset 이후에도 값이 유지되게 했다(`category`는 기존에 이미 이 패턴이었다).
- `useImageList` 훅에 `reset()`을 추가해 썸네일/미리보기/상세이미지 목록을 연속 등록 시 비울 수 있게 했다.
- 기존 "상품 등록" 버튼 클릭 → 성공 → 목록 이동 흐름은 회귀 없이 그대로 유지된다.

## Test plan

- `npx tsc --noEmit -p tsconfig.json` — 통과
- `npx eslint` (변경 파일 전체) — 통과
- `npm run test:component` — 112 test files / 452 tests 모두 통과 (기존 회귀 없음 확인 + 신규 연속 등록 시나리오 테스트 포함)
- 실제 브라우저(dev 서버) 시각 확인: Not run — DB 접근 명령이 샌드박스 권한 분류기에 의해 차단되어 admin 세션 확보 여부를 확인하지 못했다. 대신 component 테스트로 "계속 작성" 클릭 → 성공 응답 시뮬레이션 → category/subCategory/theme 유지 + 나머지 필드 초기화 검증, "상품 등록" 클릭 시 필드 미초기화(회귀 없음) 검증을 커버했다.

Closes #48
