### PR TITLE
perf: 관리자 상품 목록 cursor 쿼리에 index를 추가한다

### DIFF
--- a/src/models/product.model.ts
+++ b/src/models/product.model.ts
@@ -182,6 +182,12 @@ productSchema.index({
   _id: -1,
 });
 
+// 관리자 상품 목록 cursor 페이징(getAdminProductsPageService) 전용 — active(deletedAt:null)
+// /trash(deletedAt:{$ne:null}) 두 view 모두 deletedAt이 leading field라 index 하나로
+// 커버된다(order.model.ts/user.model.ts와 동일하게 admin cursor 정렬을 인덱스로 전부
+// 커버하는 패턴).
+productSchema.index({ deletedAt: 1, createdAt: -1, _id: -1 });
+
 export const ProductModel =
   (mongoose.models.Product as Model<IProduct>) ||
   model<IProduct>("Product", productSchema);


### PR DESCRIPTION
## Summary
- `getAdminProductsPageService`가 `deletedAt`(active: `null`, trash: `$ne null`) 필터 + `(createdAt desc, _id desc)` 정렬로 cursor 쿼리를 날리는데, 이 모양을 커버하는 compound index가 없었다(#81에서 추가한 index 2개는 공개 목록 전용).
- `deletedAt`을 leading field로 하는 index 1개를 추가해 active/trash 두 view 모두 collection scan 대신 index를 타도록 했다 — `order.model.ts`/`user.model.ts`가 이미 쓰는 것과 동일한 패턴.

## Test plan
- `npx vitest run test/integration/services/product.integration.test.ts` — 83개 통과(회귀 없음, index 추가는 쿼리 결과를 바꾸지 않음)
- `npx eslint src/models/product.model.ts` — 통과
- `npx tsc --noEmit -p tsconfig.json` — 통과

Closes #271