### PR TITLE
docs(pr-template): format-fit 스킬로 PR 본문 서식을 통일한다

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,5 +11,6 @@
 - 본문은 한국어로 쓰되 섹션 제목(Summary, Test plan)과 명령·경로·식별자는 그대로 둔다.
 - Test plan에는 실제로 실행한 것만 적는다. 검증하지 않았다면 `Not run: {사유}`로 명시한다.
 - breaking change는 PR 제목에 `!`를 붙이고 Summary에 무엇이 깨지는지와 마이그레이션 방법을 적는다.
+- 본문 서식(목록/표/산문 선택)은 format-fit 스킬 기준으로 작성한다.
 - 전문: ~/.codex/docs/GIT.md, ~/.codex/docs/references/pull_request_template.md
 -->


### PR DESCRIPTION
## Summary
- `.github/pull_request_template.md`의 지침 주석에 "본문 서식은 format-fit 스킬 기준으로 작성한다" 한 줄을 추가해, 앞으로 PR 본문(목록/표/산문 선택)이 그 스킬 기준으로 작성되게 한다.

## Test plan
- Not run: 문서 한 줄 추가라 별도 검증 없음.