### PR TITLE
ci(static): main 트리거 추가 및 lint/tsc/build 병렬화

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,7 +2,7 @@ name: Static Validation
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [dev, main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -10,7 +10,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  static:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run lint:barrels
+
+  tsc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm run tsc
+
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     services:
@@ -31,9 +58,6 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - run: npm run lint
-      - run: npm run lint:barrels
-      - run: npm run tsc
       - name: Build
         run: npm run build
         env:
@@ -46,3 +70,20 @@ jobs:
           NEXT_PUBLIC_KAKAO_MAP_API_KEY: kakao-map-ci
           BASE_URL: http://127.0.0.1:3100
           DEPLOYMENT_BASE_URL: http://127.0.0.1:3100
+
+  # lint/tsc/build를 병렬로 돌리는 대신, 브랜치 보호가 요구하는 required status check
+  # 이름("static" 하나, docs/validation/ci-gates.md)은 이 취합 job으로 고정한다 — job을
+  # 여러 개로 쪼개도 GitHub 브랜치 보호 설정을 매번 동기화할 필요가 없다.
+  static:
+    needs: [lint, tsc, build]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check parallel job results
+        run: |
+          if [ "${{ needs.lint.result }}" != "success" ] || \
+             [ "${{ needs.tsc.result }}" != "success" ] || \
+             [ "${{ needs.build.result }}" != "success" ]; then
+            echo "lint=${{ needs.lint.result }} tsc=${{ needs.tsc.result }} build=${{ needs.build.result }}"
+            exit 1
+          fi

--- a/docs/validation/ci-gates.md
+++ b/docs/validation/ci-gates.md
@@ -1,6 +1,6 @@
 # CI gates
 
-`.github/workflows/static.yml`은 `dev` 대상 pull request와 수동 실행에서 정적 검증 게이트를 제공한다. 정확한 job 이름, 명령, timeout은 workflow를 단일 소스로 삼는다.
+`.github/workflows/static.yml`은 `dev`/`main` 대상 pull request와 수동 실행에서 정적 검증 게이트를 제공한다. 정확한 job 이름, 명령, timeout은 workflow를 단일 소스로 삼는다.
 
 ## Pull request 게이트
 
@@ -10,10 +10,12 @@
 
 정적 검증은 별도 테스트 래퍼 없이 `npm run build`를 직접 실행한다. 테스트 스위트는 로컬에서 필요에 따라 실행하며 PR 필수 게이트가 아니다.
 
+lint/tsc/build는 워크플로 내부에서 별도 job으로 병렬 실행된다 — 브랜치 보호가 요구하는 required status check 이름은 그 세 job을 취합하는 `static` job 하나로 고정돼 있다(job을 쪼개거나 늘려도 이 취합 job 이름만 유지하면 브랜치 보호 설정을 다시 동기화할 필요가 없다).
+
 ## 브랜치 보호
 
 GitHub 브랜치 보호의 필수 상태 체크는 `static` 하나로 맞춘다. `dev`와 `main` 모두 최신 기준 브랜치 반영, 관리자 포함 적용, 선형 히스토리, 대화 해결을 요구하며 force-push와 삭제를 허용하지 않는다.
 
-저장소 workflow의 `pull_request.branches`는 현재 `dev`만 포함한다. 따라서 기능 브랜치는 `dev` PR에서 필수 체크를 만든 뒤 승격해야 한다. `main`으로 직접 PR하는 운영을 도입하려면 같은 체크가 `main` 대상 PR에서도 실제 생성되도록 workflow trigger를 함께 변경해야 한다.
+저장소 workflow의 `pull_request.branches`는 `dev`와 `main`을 모두 포함한다 — `main`으로 직접 PR하는 sync 등도 `static` 체크가 정상적으로 생성된다.
 
 브랜치 보호는 GitHub 저장소 설정이므로 문서만으로 강제되지 않는다. workflow job 이름을 바꾸거나 추가·삭제할 때는 `dev`와 `main`의 required status checks도 같은 변경에서 동기화하고, 새 PR에서 체크가 실제 생성되는지 확인한다.


### PR DESCRIPTION
## Summary
- `main` 브랜치 보호 규칙이 `static` 체크를 required로 요구하는데, `static.yml`은 `branches: [dev]`에만 걸려있어 `main`을 base로 하는 PR(dev→main sync 등)에서는 `pull_request` 이벤트로 정상 트리거되지 않았다. `workflow_dispatch`로 수동 실행해 success까지 확인했지만 `strict: true` required-check 재검증에서 인정되지 않아 `main`으로 가는 PR이 영구히 merge 불가 상태(`Required status check "static" is expected`)에 빠졌다(PR #275에서 실측).
- `branches: [dev, main]`로 확장해 `main` 대상 PR에서도 정상적으로 체크가 돌게 했다.
- lint/lint:barrels, tsc, build가 한 job 안에서 순차 실행돼 가장 느린 build가 항상 전체 시간에 더해졌다 — `lint`/`tsc`/`build` 3개 job으로 나눠 병렬 실행하고, 그 결과를 취합하는 `static` job을 추가했다. 브랜치 보호가 요구하는 required check 이름(`static`)은 이 취합 job으로 고정돼, job을 더 쪼개도 브랜치 보호 설정을 다시 동기화할 필요가 없다.
- `docs/validation/ci-gates.md`를 이 구조에 맞게 갱신했다.

## Test plan
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/static.yml'))"` — YAML 문법 통과
- 이 PR 자체가 `dev`를 base로 하므로, 병합 전 `static`(취합 job 포함 lint/tsc/build 병렬 실행) 체크로 새 워크플로 구조 자체가 실측 검증된다.